### PR TITLE
Add token estimates for liquidity quotes, group token resolution

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -14,6 +14,7 @@
     "tiny-invariant": "^1.2.0"
   },
   "devDependencies": {
+    "@types/bn.js": "^5.1.0",
     "@types/decimal.js": "^7.4.0",
     "@types/jest": "^26.0.24",
     "@types/mocha": "^9.0.0",

--- a/sdk/src/artifacts/whirlpool.json
+++ b/sdk/src/artifacts/whirlpool.json
@@ -1667,6 +1667,21 @@
       "code": 6037,
       "name": "AmountInAboveMaximum",
       "msg": "Amount in above maximum threshold"
+    },
+    {
+      "code": 6038,
+      "name": "TickArraySequenceInvalidIndex",
+      "msg": "Invalid index for tick array sequence"
+    },
+    {
+      "code": 6039,
+      "name": "AmountCalcOverflow",
+      "msg": "Amount calculated overflows"
+    },
+    {
+      "code": 6040,
+      "name": "AmountRemainingOverflow",
+      "msg": "Amount remaining overflows"
     }
   ]
 }

--- a/sdk/src/artifacts/whirlpool.ts
+++ b/sdk/src/artifacts/whirlpool.ts
@@ -1667,6 +1667,21 @@ export type Whirlpool = {
       "code": 6037,
       "name": "AmountInAboveMaximum",
       "msg": "Amount in above maximum threshold"
+    },
+    {
+      "code": 6038,
+      "name": "TickArraySequenceInvalidIndex",
+      "msg": "Invalid index for tick array sequence"
+    },
+    {
+      "code": 6039,
+      "name": "AmountCalcOverflow",
+      "msg": "Amount calculated overflows"
+    },
+    {
+      "code": 6040,
+      "name": "AmountRemainingOverflow",
+      "msg": "Amount remaining overflows"
     }
   ]
 };
@@ -3340,6 +3355,21 @@ export const IDL: Whirlpool = {
       "code": 6037,
       "name": "AmountInAboveMaximum",
       "msg": "Amount in above maximum threshold"
+    },
+    {
+      "code": 6038,
+      "name": "TickArraySequenceInvalidIndex",
+      "msg": "Invalid index for tick array sequence"
+    },
+    {
+      "code": 6039,
+      "name": "AmountCalcOverflow",
+      "msg": "Amount calculated overflows"
+    },
+    {
+      "code": 6040,
+      "name": "AmountRemainingOverflow",
+      "msg": "Amount remaining overflows"
     }
   ]
 };

--- a/sdk/src/impl/whirlpool-impl.ts
+++ b/sdk/src/impl/whirlpool-impl.ts
@@ -168,7 +168,13 @@ export class WhirlpoolImpl implements Whirlpool {
     invariant(TickUtil.checkTickInBounds(tickLower), "tickLower is out of bounds.");
     invariant(TickUtil.checkTickInBounds(tickUpper), "tickUpper is out of bounds.");
 
-    const { liquidityAmount: liquidity, tokenMaxA, tokenMaxB, tokenEstA, tokenEstB } = liquidityInput;
+    const {
+      liquidityAmount: liquidity,
+      tokenMaxA,
+      tokenMaxB,
+      tokenEstA,
+      tokenEstB,
+    } = liquidityInput;
 
     invariant(liquidity.gt(new u64(0)), "liquidity must be greater than zero");
 
@@ -215,17 +221,17 @@ export class WhirlpoolImpl implements Whirlpool {
     );
     txBuilder.addInstruction(positionIx).addSigner(positionMintKeypair);
 
-    const[ataA, ataB] = await resolveOrCreateATAs(
+    const [ataA, ataB] = await resolveOrCreateATAs(
       this.ctx.connection,
       sourceWallet,
       [
         { tokenMint: whirlpool.tokenMintA, wrappedSolAmountIn: tokenMaxA },
         { tokenMint: whirlpool.tokenMintB, wrappedSolAmountIn: tokenMaxB },
       ],
-      () => this.fetcher.getAccountRentExempt(),
-    )
-    const { address: tokenOwnerAccountA, ... tokenOwnerAccountAIx } = ataA;
-    const { address: tokenOwnerAccountB, ... tokenOwnerAccountBIx } = ataB;
+      () => this.fetcher.getAccountRentExempt()
+    );
+    const { address: tokenOwnerAccountA, ...tokenOwnerAccountAIx } = ataA;
+    const { address: tokenOwnerAccountB, ...tokenOwnerAccountBIx } = ataB;
 
     txBuilder.addInstruction(tokenOwnerAccountAIx);
     txBuilder.addInstruction(tokenOwnerAccountBIx);
@@ -315,11 +321,11 @@ export class WhirlpoolImpl implements Whirlpool {
       this.ctx.connection,
       destinationWallet,
       [{ tokenMint: whirlpool.tokenMintA }, { tokenMint: whirlpool.tokenMintB }],
-      () => this.fetcher.getAccountRentExempt(),
+      () => this.fetcher.getAccountRentExempt()
     );
 
-    const { address: tokenOwnerAccountA, ... createTokenOwnerAccountAIx } = ataA;
-    const { address: tokenOwnerAccountB, ... createTokenOwnerAccountBIx } = ataB;
+    const { address: tokenOwnerAccountA, ...createTokenOwnerAccountAIx } = ataA;
+    const { address: tokenOwnerAccountB, ...createTokenOwnerAccountBIx } = ataB;
 
     txBuilder.addInstruction(createTokenOwnerAccountAIx).addInstruction(createTokenOwnerAccountBIx);
     resolvedAssociatedTokenAddresses[whirlpool.tokenMintA.toBase58()] = tokenOwnerAccountA;
@@ -389,19 +395,19 @@ export class WhirlpoolImpl implements Whirlpool {
     } = quote;
     const whirlpool = this.data;
     const txBuilder = new TransactionBuilder(this.ctx.provider);
-    
+
     const [ataA, ataB] = await resolveOrCreateATAs(
       this.ctx.connection,
       wallet,
       [
-        { tokenMint: whirlpool.tokenMintA, wrappedSolAmountIn: aToB ? estimatedAmountIn: ZERO },
-        { tokenMint: whirlpool.tokenMintB, wrappedSolAmountIn: !aToB ? estimatedAmountIn: ZERO },
+        { tokenMint: whirlpool.tokenMintA, wrappedSolAmountIn: aToB ? estimatedAmountIn : ZERO },
+        { tokenMint: whirlpool.tokenMintB, wrappedSolAmountIn: !aToB ? estimatedAmountIn : ZERO },
       ],
-      () => this.fetcher.getAccountRentExempt(),
+      () => this.fetcher.getAccountRentExempt()
     );
 
-    const { address: tokenOwnerAccountA, ... tokenOwnerAccountAIx } = ataA;
-    const { address: tokenOwnerAccountB, ... tokenOwnerAccountBIx } = ataB;
+    const { address: tokenOwnerAccountA, ...tokenOwnerAccountAIx } = ataA;
+    const { address: tokenOwnerAccountB, ...tokenOwnerAccountBIx } = ataB;
 
     txBuilder.addInstruction(tokenOwnerAccountAIx);
     txBuilder.addInstruction(tokenOwnerAccountBIx);

--- a/sdk/src/instructions/decrease-liquidity-ix.ts
+++ b/sdk/src/instructions/decrease-liquidity-ix.ts
@@ -42,6 +42,8 @@ export type DecreaseLiquidityParams = {
 export type DecreaseLiquidityInput = {
   tokenMinA: BN;
   tokenMinB: BN;
+  tokenEstA: BN;
+  tokenEstB: BN;
   liquidityAmount: BN;
 };
 

--- a/sdk/src/instructions/increase-liquidity-ix.ts
+++ b/sdk/src/instructions/increase-liquidity-ix.ts
@@ -50,6 +50,8 @@ export type IncreaseLiquidityParams = {
 export type IncreaseLiquidityInput = {
   tokenMaxA: u64;
   tokenMaxB: u64;
+  tokenEstA: u64;
+  tokenEstB: u64;
   liquidityAmount: u64;
 };
 

--- a/sdk/src/quotes/public/decrease-liquidity-quote.ts
+++ b/sdk/src/quotes/public/decrease-liquidity-quote.ts
@@ -127,7 +127,7 @@ function quotePositionInRange(param: DecreaseLiquidityQuoteParam): DecreaseLiqui
 
   const tokenEstA = getTokenAFromLiquidity(liquidity, sqrtPriceX64, sqrtPriceUpperX64, false);
   const tokenMinA = adjustForSlippage(tokenEstA, slippageTolerance, false);
-  const tokenEstB = getTokenBFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceX64, false)
+  const tokenEstB = getTokenBFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceX64, false);
   const tokenMinB = adjustForSlippage(tokenEstB, slippageTolerance, false);
 
   return {

--- a/sdk/src/quotes/public/decrease-liquidity-quote.ts
+++ b/sdk/src/quotes/public/decrease-liquidity-quote.ts
@@ -1,5 +1,4 @@
-import { Percentage } from "@orca-so/common-sdk";
-import { ZERO } from "@orca-so/sdk";
+import { Percentage, ZERO } from "@orca-so/common-sdk";
 import { BN } from "@project-serum/anchor";
 import { u64 } from "@solana/spl-token";
 import invariant from "tiny-invariant";
@@ -107,15 +106,14 @@ function quotePositionBelowRange(param: DecreaseLiquidityQuoteParam): DecreaseLi
   const sqrtPriceLowerX64 = PriceMath.tickIndexToSqrtPriceX64(tickLowerIndex);
   const sqrtPriceUpperX64 = PriceMath.tickIndexToSqrtPriceX64(tickUpperIndex);
 
-  const minTokenA = adjustForSlippage(
-    getTokenAFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceUpperX64, false),
-    slippageTolerance,
-    false
-  );
+  const tokenEstA = getTokenAFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceUpperX64, false);
+  const tokenMinA = adjustForSlippage(tokenEstA, slippageTolerance, false);
 
   return {
-    tokenMinA: minTokenA,
+    tokenMinA,
     tokenMinB: ZERO,
+    tokenEstA,
+    tokenEstB: ZERO,
     liquidityAmount: liquidity,
   };
 }
@@ -127,20 +125,16 @@ function quotePositionInRange(param: DecreaseLiquidityQuoteParam): DecreaseLiqui
   const sqrtPriceLowerX64 = PriceMath.tickIndexToSqrtPriceX64(tickLowerIndex);
   const sqrtPriceUpperX64 = PriceMath.tickIndexToSqrtPriceX64(tickUpperIndex);
 
-  const minTokenA = adjustForSlippage(
-    getTokenAFromLiquidity(liquidity, sqrtPriceX64, sqrtPriceUpperX64, false),
-    slippageTolerance,
-    false
-  );
-  const minTokenB = adjustForSlippage(
-    getTokenBFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceX64, false),
-    slippageTolerance,
-    false
-  );
+  const tokenEstA = getTokenAFromLiquidity(liquidity, sqrtPriceX64, sqrtPriceUpperX64, false);
+  const tokenMinA = adjustForSlippage(tokenEstA, slippageTolerance, false);
+  const tokenEstB = getTokenBFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceX64, false)
+  const tokenMinB = adjustForSlippage(tokenEstB, slippageTolerance, false);
 
   return {
-    tokenMinA: minTokenA,
-    tokenMinB: minTokenB,
+    tokenMinA,
+    tokenMinB,
+    tokenEstA,
+    tokenEstB,
     liquidityAmount: liquidity,
   };
 }
@@ -151,15 +145,14 @@ function quotePositionAboveRange(param: DecreaseLiquidityQuoteParam): DecreaseLi
   const sqrtPriceLowerX64 = PriceMath.tickIndexToSqrtPriceX64(tickLowerIndex);
   const sqrtPriceUpperX64 = PriceMath.tickIndexToSqrtPriceX64(tickUpperIndex);
 
-  const minTokenB = adjustForSlippage(
-    getTokenBFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceUpperX64, false),
-    slippageTolerance,
-    false
-  );
+  const tokenEstB = getTokenBFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceUpperX64, false);
+  const tokenMinB = adjustForSlippage(tokenEstB, slippageTolerance, false);
 
   return {
     tokenMinA: ZERO,
-    tokenMinB: minTokenB,
+    tokenMinB,
+    tokenEstA: ZERO,
+    tokenEstB,
     liquidityAmount: liquidity,
   };
 }

--- a/sdk/src/quotes/public/increase-liquidity-quote.ts
+++ b/sdk/src/quotes/public/increase-liquidity-quote.ts
@@ -129,6 +129,8 @@ function quotePositionBelowRange(param: IncreaseLiquidityQuoteParam): IncreaseLi
     return {
       tokenMaxA: ZERO,
       tokenMaxB: ZERO,
+      tokenEstA: ZERO,
+      tokenEstB: ZERO,
       liquidityAmount: ZERO,
     };
   }
@@ -143,16 +145,14 @@ function quotePositionBelowRange(param: IncreaseLiquidityQuoteParam): IncreaseLi
     false
   );
 
-  const maxTokenA = adjustForSlippage(
-    getTokenAFromLiquidity(liquidityAmount, sqrtPriceLowerX64, sqrtPriceUpperX64, true),
-    slippageTolerance,
-    true
-  );
-  const maxTokenB = ZERO;
+  const tokenEstA = getTokenAFromLiquidity(liquidityAmount, sqrtPriceLowerX64, sqrtPriceUpperX64, true);
+  const tokenMaxA = adjustForSlippage(tokenEstA, slippageTolerance, true);
 
   return {
-    tokenMaxA: maxTokenA,
-    tokenMaxB: maxTokenB,
+    tokenMaxA,
+    tokenMaxB: ZERO,
+    tokenEstA,
+    tokenEstB: ZERO,
     liquidityAmount,
   };
 }
@@ -172,30 +172,32 @@ function quotePositionInRange(param: IncreaseLiquidityQuoteParam): IncreaseLiqui
   const sqrtPriceLowerX64 = PriceMath.tickIndexToSqrtPriceX64(tickLowerIndex);
   const sqrtPriceUpperX64 = PriceMath.tickIndexToSqrtPriceX64(tickUpperIndex);
 
-  let [tokenAmountA, tokenAmountB] = tokenMintA.equals(inputTokenMint)
+  let [tokenEstA, tokenEstB] = tokenMintA.equals(inputTokenMint)
     ? [inputTokenAmount, undefined]
     : [undefined, inputTokenAmount];
 
   let liquidityAmount: BN;
 
-  if (tokenAmountA) {
-    liquidityAmount = getLiquidityFromTokenA(tokenAmountA, sqrtPriceX64, sqrtPriceUpperX64, false);
-    tokenAmountA = getTokenAFromLiquidity(liquidityAmount, sqrtPriceX64, sqrtPriceUpperX64, true);
-    tokenAmountB = getTokenBFromLiquidity(liquidityAmount, sqrtPriceLowerX64, sqrtPriceX64, true);
-  } else if (tokenAmountB) {
-    liquidityAmount = getLiquidityFromTokenB(tokenAmountB, sqrtPriceLowerX64, sqrtPriceX64, false);
-    tokenAmountA = getTokenAFromLiquidity(liquidityAmount, sqrtPriceX64, sqrtPriceUpperX64, true);
-    tokenAmountB = getTokenBFromLiquidity(liquidityAmount, sqrtPriceLowerX64, sqrtPriceX64, true);
+  if (tokenEstA) {
+    liquidityAmount = getLiquidityFromTokenA(tokenEstA, sqrtPriceX64, sqrtPriceUpperX64, false);
+    tokenEstA = getTokenAFromLiquidity(liquidityAmount, sqrtPriceX64, sqrtPriceUpperX64, true);
+    tokenEstB = getTokenBFromLiquidity(liquidityAmount, sqrtPriceLowerX64, sqrtPriceX64, true);
+  } else if (tokenEstB) {
+    liquidityAmount = getLiquidityFromTokenB(tokenEstB, sqrtPriceLowerX64, sqrtPriceX64, false);
+    tokenEstA = getTokenAFromLiquidity(liquidityAmount, sqrtPriceX64, sqrtPriceUpperX64, true);
+    tokenEstB = getTokenBFromLiquidity(liquidityAmount, sqrtPriceLowerX64, sqrtPriceX64, true);
   } else {
     throw new Error("invariant violation");
   }
 
-  const maxTokenA = adjustForSlippage(tokenAmountA, slippageTolerance, true);
-  const maxTokenB = adjustForSlippage(tokenAmountB, slippageTolerance, true);
+  const tokenMaxA = adjustForSlippage(tokenEstA, slippageTolerance, true);
+  const tokenMaxB = adjustForSlippage(tokenEstB, slippageTolerance, true);
 
   return {
-    tokenMaxA: maxTokenA,
-    tokenMaxB: maxTokenB,
+    tokenMaxA,
+    tokenMaxB,
+    tokenEstA: tokenEstA!,
+    tokenEstB: tokenEstB!,
     liquidityAmount,
   };
 }
@@ -214,6 +216,8 @@ function quotePositionAboveRange(param: IncreaseLiquidityQuoteParam): IncreaseLi
     return {
       tokenMaxA: ZERO,
       tokenMaxB: ZERO,
+      tokenEstA: ZERO,
+      tokenEstB: ZERO,
       liquidityAmount: ZERO,
     };
   }
@@ -227,16 +231,14 @@ function quotePositionAboveRange(param: IncreaseLiquidityQuoteParam): IncreaseLi
     false
   );
 
-  const maxTokenA = ZERO;
-  const maxTokenB = adjustForSlippage(
-    getTokenBFromLiquidity(liquidityAmount, sqrtPriceLowerX64, sqrtPriceUpperX64, true),
-    slippageTolerance,
-    true
-  );
+  const tokenEstB = getTokenBFromLiquidity(liquidityAmount, sqrtPriceLowerX64, sqrtPriceUpperX64, true)
+  const tokenMaxB = adjustForSlippage(tokenEstB, slippageTolerance, true);
 
   return {
-    tokenMaxA: maxTokenA,
-    tokenMaxB: maxTokenB,
+    tokenMaxA: ZERO,
+    tokenMaxB,
+    tokenEstA: ZERO,
+    tokenEstB,
     liquidityAmount,
   };
 }

--- a/sdk/src/quotes/public/increase-liquidity-quote.ts
+++ b/sdk/src/quotes/public/increase-liquidity-quote.ts
@@ -145,7 +145,12 @@ function quotePositionBelowRange(param: IncreaseLiquidityQuoteParam): IncreaseLi
     false
   );
 
-  const tokenEstA = getTokenAFromLiquidity(liquidityAmount, sqrtPriceLowerX64, sqrtPriceUpperX64, true);
+  const tokenEstA = getTokenAFromLiquidity(
+    liquidityAmount,
+    sqrtPriceLowerX64,
+    sqrtPriceUpperX64,
+    true
+  );
   const tokenMaxA = adjustForSlippage(tokenEstA, slippageTolerance, true);
 
   return {
@@ -231,7 +236,12 @@ function quotePositionAboveRange(param: IncreaseLiquidityQuoteParam): IncreaseLi
     false
   );
 
-  const tokenEstB = getTokenBFromLiquidity(liquidityAmount, sqrtPriceLowerX64, sqrtPriceUpperX64, true)
+  const tokenEstB = getTokenBFromLiquidity(
+    liquidityAmount,
+    sqrtPriceLowerX64,
+    sqrtPriceUpperX64,
+    true
+  );
   const tokenMaxB = adjustForSlippage(tokenEstB, slippageTolerance, true);
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -703,6 +703,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/bn.js@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-5.1.0.tgz#32c5d271503a12653c62cf4d2b45e6eab8cebc68"
+  integrity sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/connect@^3.4.33":
   version "3.4.35"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"


### PR DESCRIPTION
- Add tokenEst(imates) to the increase/decrease liquidity quotes
- Add group token resolution to minimize RPC calls when resolving ATAs

Token estimates - What we can expect the resulting token to be at this given time / on-chain data
Token min - The minimum expected amount of token received / sent given the estimate and slippage