### PR TITLE
[v0.2.0] Refactor swapQuote functions

### DIFF
--- a/sdk/src/quotes/public/swap-quote.ts
+++ b/sdk/src/quotes/public/swap-quote.ts
@@ -22,15 +22,16 @@ import {
 } from "../../types/public";
 import { AddressUtil, MathUtil, Percentage, ZERO } from "@orca-so/common-sdk";
 import { PriceMath, TickArrayUtil, TickUtil } from "../../utils/public";
+import { Whirlpool } from "../../whirlpool-client";
+import { AccountFetcher } from "../../network/public";
 
 /**
  * @category Quotes
  */
 export type SwapQuoteParam = {
-  whirlpoolAddress: Address;
-  swapTokenMint: Address;
   whirlpoolData: WhirlpoolData;
   tokenAmount: u64;
+  aToB: boolean;
   amountSpecifiedIsInput: boolean;
   slippageTolerance: Percentage;
   tickArrayAddresses: PublicKey[];
@@ -44,6 +45,62 @@ export type SwapQuote = {
   estimatedAmountIn: u64;
   estimatedAmountOut: u64;
 } & SwapInput;
+
+export async function swapQuoteByInputToken(
+  whirlpool: Whirlpool,
+  swapTokenMint: Address,
+  tokenAmount: u64,
+  amountSpecifiedIsInput: boolean,
+  slippageTolerance: Percentage,
+  fetcher: AccountFetcher,
+  programId: Address
+): Promise<SwapQuote> {
+  const whirlpoolData = whirlpool.getData();
+  const swapMintKey = AddressUtil.toPubKey(swapTokenMint);
+  invariant(
+    whirlpoolData.tokenMintA.equals(swapMintKey) || whirlpoolData.tokenMintB.equals(swapMintKey),
+    "swapTokenMint does not match any tokens on this pool"
+  );
+
+  const aToB =
+    swapMintKey.equals(whirlpoolData.tokenMintA) === amountSpecifiedIsInput ? true : false;
+
+  const tickArrayAddresses = PoolUtil.getTickArrayPublicKeysForSwap(
+    whirlpoolData.tickCurrentIndex,
+    whirlpoolData.tickSpacing,
+    aToB,
+    AddressUtil.toPubKey(programId),
+    whirlpool.getAddress()
+  );
+  const tickArrays = await fetcher.listTickArrays(tickArrayAddresses, true);
+
+  // Check if all the tick arrays have been initialized.
+  let emptyArrayIndex = -1;
+  const arrayNeedInit = tickArrays.some((value, index) => {
+    if (!value) {
+      emptyArrayIndex = index;
+      return false;
+    }
+    return true;
+  });
+  if (!arrayNeedInit) {
+    throw new Error(
+      `TickArray index - ${emptyArrayIndex}, addr - ${tickArrayAddresses[
+        emptyArrayIndex
+      ].toBase58()} needs to be initialized.`
+    );
+  }
+
+  return swapQuoteWithParams({
+    whirlpoolData,
+    tokenAmount,
+    aToB,
+    amountSpecifiedIsInput,
+    slippageTolerance,
+    tickArrayAddresses,
+    tickArrays,
+  });
+}
 
 /**
  * TODO: Bug - The quote swap loop will ignore the first initialized tick of the next array on array traversal
@@ -59,10 +116,9 @@ export type SwapQuote = {
  * @param param a SwapQuoteParam object detailing parameters of the swap
  * @return a SwapQuote on the estimated amountIn & amountOut of the swap and a SwapInput to use on the swap instruction.
  */
-export function swapQuoteByInputToken(param: SwapQuoteParam): SwapQuote {
+export function swapQuoteWithParams(param: SwapQuoteParam): SwapQuote {
   const {
-    whirlpoolAddress,
-    swapTokenMint,
+    aToB,
     tokenAmount,
     whirlpoolData,
     amountSpecifiedIsInput,
@@ -71,15 +127,11 @@ export function swapQuoteByInputToken(param: SwapQuoteParam): SwapQuote {
     tickArrayAddresses,
   } = param;
 
-  const swapDirection =
-    AddressUtil.toPubKey(swapTokenMint).equals(whirlpoolData.tokenMintA) === amountSpecifiedIsInput
-      ? SwapDirection.AtoB
-      : SwapDirection.BtoA;
+  const swapDirection = aToB ? SwapDirection.AtoB : SwapDirection.BtoA;
   const amountSpecified = amountSpecifiedIsInput ? AmountSpecified.Input : AmountSpecified.Output;
 
   const { amountIn, amountOut, sqrtPriceLimitX64, tickArraysCrossed } = simulateSwap(
     {
-      whirlpoolAddress,
       whirlpoolData,
       amountSpecified,
       swapDirection,
@@ -124,7 +176,6 @@ export function swapQuoteByInputToken(param: SwapQuoteParam): SwapQuote {
 }
 
 type SwapSimulationBaseInput = {
-  whirlpoolAddress: Address;
   whirlpoolData: WhirlpoolData;
   amountSpecified: AmountSpecified;
   swapDirection: SwapDirection;

--- a/sdk/src/quotes/public/swap-quote.ts
+++ b/sdk/src/quotes/public/swap-quote.ts
@@ -78,10 +78,9 @@ export async function swapQuoteByInputToken(
   // Check if all the tick arrays have been initialized.
   const uninitializedIndices = TickArrayUtil.getUninitializedArrays(tickArrays);
   if (uninitializedIndices.length > 0) {
-    const uninitializedArrays = uninitializedIndices.reduce<string>(
-      (prev, unInitIndex) => prev + tickArrayAddresses[unInitIndex].toBase58() + " ",
-      ""
-    );
+    const uninitializedArrays = uninitializedIndices
+      .map((index) => tickArrayAddresses[index].toBase58())
+      .join(", ");
     throw new Error(`TickArray addresses - [${uninitializedArrays}] need to be initialized.`);
   }
 

--- a/sdk/src/utils/public/tick-utils.ts
+++ b/sdk/src/utils/public/tick-utils.ts
@@ -188,6 +188,22 @@ export class TickArrayUtil {
         .publicKey,
     ];
   }
+
+  /**
+   * Evaluate a list of tick-array data and return the array of indices which the tick-arrays are not initialized.
+   * @param tickArrays - a list of TickArrayData or null objects from AccountFetcher.listTickArrays
+   * @returns an array of array-index for the input tickArrays that requires initialization.
+   */
+  public static getUninitializedArrays(tickArrays: (TickArrayData | null)[]): number[] {
+    return tickArrays
+      .map((value, index) => {
+        if (!value) {
+          return index;
+        }
+        return -1;
+      })
+      .filter((index) => index >= 0);
+  }
 }
 
 function tickIndexToInnerIndex(

--- a/sdk/tests/integration/swap.test.ts
+++ b/sdk/tests/integration/swap.test.ts
@@ -10,13 +10,10 @@ import {
   MAX_SQRT_PRICE,
   MIN_SQRT_PRICE,
   TickArrayData,
-  WhirlpoolData,
-  PoolUtil,
   PriceMath,
   WhirlpoolIx,
   PDAUtil,
   toTx,
-  swapQuoteWithParams,
   swapQuoteByInputToken,
   buildWhirlpoolClient,
 } from "../../src";
@@ -561,7 +558,8 @@ describe("swap", () => {
       true,
       Percentage.fromFraction(1, 100),
       fetcher,
-      ctx.program.programId
+      ctx.program.programId,
+      true
     );
 
     await toTx(

--- a/sdk/tests/integration/swap.test.ts
+++ b/sdk/tests/integration/swap.test.ts
@@ -10,13 +10,15 @@ import {
   MAX_SQRT_PRICE,
   MIN_SQRT_PRICE,
   TickArrayData,
-  swapQuoteByInputToken,
   WhirlpoolData,
   PoolUtil,
   PriceMath,
   WhirlpoolIx,
   PDAUtil,
   toTx,
+  swapQuoteWithParams,
+  swapQuoteByInputToken,
+  buildWhirlpoolClient,
 } from "../../src";
 import { TickSpacing, ZERO_BN, getTokenBalance, MAX_U64 } from "../utils";
 import {
@@ -36,6 +38,7 @@ describe("swap", () => {
   const program = anchor.workspace.Whirlpool;
   const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = new AccountFetcher(ctx.connection);
+  const client = buildWhirlpoolClient(ctx, fetcher);
 
   it("fail on token vault mint a does not match whirlpool token a", async () => {
     const { poolInitInfo, whirlpoolPda, tokenAccountA, tokenAccountB } =
@@ -520,7 +523,7 @@ describe("swap", () => {
     const { poolInitInfo, whirlpoolPda, tokenAccountA, tokenAccountB } =
       await initTestPoolWithTokens(ctx, TickSpacing.Standard);
     const aToB = false;
-    const tickArrays = await initTickArrayRange(
+    await initTickArrayRange(
       ctx,
       whirlpoolPda.publicKey,
       22528, // to 33792
@@ -549,26 +552,17 @@ describe("swap", () => {
     const oraclePda = PDAUtil.getOracle(ctx.program.programId, whirlpoolPda.publicKey);
 
     const whirlpoolKey = poolInitInfo.whirlpoolPda.publicKey;
-    const whirlpoolData = (await fetcher.getPool(whirlpoolKey, true)) as WhirlpoolData;
-    const tickArrayAddresses = PoolUtil.getTickArrayPublicKeysForSwap(
-      whirlpoolData.tickCurrentIndex,
-      whirlpoolData.tickSpacing,
-      aToB,
-      ctx.program.programId,
-      whirlpoolPda.publicKey
+    const whirlpool = await client.getPool(whirlpoolKey, true);
+    const whirlpoolData = whirlpool.getData();
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      new u64(100000),
+      true,
+      Percentage.fromFraction(1, 100),
+      fetcher,
+      ctx.program.programId
     );
-    const tickArraySequenceData = await fetcher.listTickArrays(tickArrayAddresses, true);
-
-    const quote = swapQuoteByInputToken({
-      whirlpoolAddress: whirlpoolKey,
-      swapTokenMint: whirlpoolData.tokenMintB,
-      whirlpoolData,
-      tokenAmount: new u64(100000),
-      amountSpecifiedIsInput: true,
-      slippageTolerance: Percentage.fromFraction(1, 100),
-      tickArrayAddresses: tickArrayAddresses,
-      tickArrays: tickArraySequenceData,
-    });
 
     await toTx(
       ctx,


### PR DESCRIPTION
Previous swapQuote function is pretty difficult to use. Making some modifications to help users call swap quotes. This is a breaking change to the swapQuote's parameters. When we release, we have to bump to v0.2.0

- `swapQuoteByInputToken` as a convenience method to help users fetch the necessary information to perform the swap quote
- `swapQuoteWithParams` for the more advanced users who have previously fetched the data they need to perform the swap quote