### PR TITLE
Adding toBaseQuoteOrder method to pool-utils

### DIFF
--- a/sdk/src/utils/public/pool-utils.ts
+++ b/sdk/src/utils/public/pool-utils.ts
@@ -189,6 +189,24 @@ export class PoolUtil {
 
     return tickArrayAddresses;
   }
+
+  /**
+   * Given an arbitrary pair of token mints, this function returns an ordering of the token mints
+   * in the format [base, quote]. USD based stable coins are prioritized as the quote currency
+   * followed by variants of SOL.
+   *
+   * @category Whirlpool Utils
+   * @param tokenMintAKey - The mint of token A in the token pair.
+   * @param tokenMintBKey - The mint of token B in the token pair.
+   * @returns A two-element array with the tokens sorted in the order of [baseToken, quoteToken].
+   */
+  public static toBaseQuoteOrder(
+    tokenMintAKey: PublicKey,
+    tokenMintBKey: PublicKey
+  ): [PublicKey, PublicKey] {
+    const pair: [PublicKey, PublicKey] = [tokenMintAKey, tokenMintBKey];
+    return pair.sort(sortByQuotePriority);
+  }
 }
 
 /**
@@ -207,19 +225,6 @@ export function toTokenAmount(a: number, b: number): TokenAmounts {
     tokenA: new u64(a.toString()),
     tokenB: new u64(b.toString()),
   };
-}
-
-/**
- * Given an arbitrary pair of token mints, this function returns an ordering of the token mints
- * in the format [base, quote]. USD based stable coins are prioritized as the quote currency
- * followed by variants of SOL.
- */
-export function toBaseQuoteOrder(
-  tokenMintAKey: PublicKey,
-  tokenMintBKey: PublicKey
-): [PublicKey, PublicKey] {
-  const pair: [PublicKey, PublicKey] = [tokenMintAKey, tokenMintBKey];
-  return pair.sort(sortByQuotePriority);
 }
 
 // These are the token mints that will be prioritized as the second token in the pair (quote).

--- a/sdk/tests/utils/pool-utils.test.ts
+++ b/sdk/tests/utils/pool-utils.test.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from "@solana/web3.js";
-import { toBaseQuoteOrder } from "../../src/utils/public/pool-utils";
+import { PoolUtil } from "../../src/utils/public/pool-utils";
 import * as assert from "assert";
 
 const MINTS: { [symbol: string]: PublicKey } = {
@@ -18,41 +18,41 @@ const MINTS: { [symbol: string]: PublicKey } = {
 describe("determine base quote token ordering", () => {
   it("USD stables", async () => {
     // USDC/FTM => FTM/USDC
-    let pair = toBaseQuoteOrder(MINTS.USDC, MINTS.FTM);
+    let pair = PoolUtil.toBaseQuoteOrder(MINTS.USDC, MINTS.FTM);
     assert.equal(MINTS.FTM, pair[0]);
     assert.equal(MINTS.USDC, pair[1]);
 
     // USDT/USDC => USDC/USDT
-    pair = toBaseQuoteOrder(MINTS.USDT, MINTS.USDC);
+    pair = PoolUtil.toBaseQuoteOrder(MINTS.USDT, MINTS.USDC);
     assert.equal(MINTS.USDC, pair[0]);
     assert.equal(MINTS.USDT, pair[1]);
 
     // USDH/stSOL => stSOL/USDH
-    pair = toBaseQuoteOrder(MINTS.USDH, MINTS.stSOL);
+    pair = PoolUtil.toBaseQuoteOrder(MINTS.USDH, MINTS.stSOL);
     assert.equal(MINTS.stSOL, pair[0]);
     assert.equal(MINTS.USDH, pair[1]);
   });
 
   it("SOL variants", async () => {
     // SOL/mSOL => mSOL/SOL
-    let pair = toBaseQuoteOrder(MINTS.SOL, MINTS.mSOL);
+    let pair = PoolUtil.toBaseQuoteOrder(MINTS.SOL, MINTS.mSOL);
     assert.equal(MINTS.mSOL, pair[0]);
     assert.equal(MINTS.SOL, pair[1]);
 
     // mSOL/BTC => BTC/mSOL
-    pair = toBaseQuoteOrder(MINTS.mSOL, MINTS.BTC);
+    pair = PoolUtil.toBaseQuoteOrder(MINTS.mSOL, MINTS.BTC);
     assert.equal(MINTS.BTC, pair[0]);
     assert.equal(MINTS.mSOL, pair[1]);
 
     // mSOL/whETH => whETH/mSOL
-    pair = toBaseQuoteOrder(MINTS.mSOL, MINTS.whETH);
+    pair = PoolUtil.toBaseQuoteOrder(MINTS.mSOL, MINTS.whETH);
     assert.equal(MINTS.whETH, pair[0]);
     assert.equal(MINTS.mSOL, pair[1]);
   });
 
   it("Order remains unchanged for exotic pairs", async () => {
     // FTM/ORCA => FTM/ORCA (unchanged)
-    const pair = toBaseQuoteOrder(MINTS.FTM, MINTS.ORCA);
+    const pair = PoolUtil.toBaseQuoteOrder(MINTS.FTM, MINTS.ORCA);
     assert.equal(MINTS.FTM, pair[0]);
     assert.equal(MINTS.ORCA, pair[1]);
   });

--- a/sdk/tests/utils/pool-utils.test.ts
+++ b/sdk/tests/utils/pool-utils.test.ts
@@ -1,0 +1,59 @@
+import { PublicKey } from "@solana/web3.js";
+import { toBaseQuoteOrder } from "../../src/utils/public/pool-utils";
+import * as assert from "assert";
+
+const MINTS: { [symbol: string]: PublicKey } = {
+  FTM: new PublicKey("EsPKhGTMf3bGoy4Qm7pCv3UCcWqAmbC1UGHBTDxRjjD4"),
+  SOL: new PublicKey("So11111111111111111111111111111111111111112"),
+  mSOL: new PublicKey("mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So"),
+  USDH: new PublicKey("USDH1SM1ojwWUga67PGrgFWUHibbjqMvuMaDkRJTgkX"),
+  stSOL: new PublicKey("7dHbWXmci3dT8UFYWYZweBLXgycu7Y3iL6trKn1Y7ARj"),
+  BTC: new PublicKey("9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E"),
+  whETH: new PublicKey("7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs"),
+  USDC: new PublicKey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"),
+  USDT: new PublicKey("Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"),
+  ORCA: new PublicKey("orcaEKTdK7LKz57vaAYr9QeNsVEPfiu6QeMU1kektZE"),
+};
+
+describe("determine base quote token ordering", () => {
+  it("USD stables", async () => {
+    // USDC/FTM => FTM/USDC
+    let pair = toBaseQuoteOrder(MINTS.USDC, MINTS.FTM);
+    assert.equal(MINTS.FTM, pair[0]);
+    assert.equal(MINTS.USDC, pair[1]);
+
+    // USDT/USDC => USDC/USDT
+    pair = toBaseQuoteOrder(MINTS.USDT, MINTS.USDC);
+    assert.equal(MINTS.USDC, pair[0]);
+    assert.equal(MINTS.USDT, pair[1]);
+
+    // USDH/stSOL => stSOL/USDH
+    pair = toBaseQuoteOrder(MINTS.USDH, MINTS.stSOL);
+    assert.equal(MINTS.stSOL, pair[0]);
+    assert.equal(MINTS.USDH, pair[1]);
+  });
+
+  it("SOL variants", async () => {
+    // SOL/mSOL => mSOL/SOL
+    let pair = toBaseQuoteOrder(MINTS.SOL, MINTS.mSOL);
+    assert.equal(MINTS.mSOL, pair[0]);
+    assert.equal(MINTS.SOL, pair[1]);
+
+    // mSOL/BTC => BTC/mSOL
+    pair = toBaseQuoteOrder(MINTS.mSOL, MINTS.BTC);
+    assert.equal(MINTS.BTC, pair[0]);
+    assert.equal(MINTS.mSOL, pair[1]);
+
+    // mSOL/whETH => whETH/mSOL
+    pair = toBaseQuoteOrder(MINTS.mSOL, MINTS.whETH);
+    assert.equal(MINTS.whETH, pair[0]);
+    assert.equal(MINTS.mSOL, pair[1]);
+  });
+
+  it("Order remains unchanged for exotic pairs", async () => {
+    // FTM/ORCA => FTM/ORCA (unchanged)
+    const pair = toBaseQuoteOrder(MINTS.FTM, MINTS.ORCA);
+    assert.equal(MINTS.FTM, pair[0]);
+    assert.equal(MINTS.ORCA, pair[1]);
+  });
+});


### PR DESCRIPTION
**Background**
The Whirlpools smart contract enforces a strict ordering of pool token mints for `token_a` and `token_b` to guarantee unique pools. This ordering does not represent a `base / quote` currency pair.

**Changes**
This PR adds a helper method to determine a `base / quote` currency ordering that prioritizes USD stable coins followed by SOL and its variants.