### PR TITLE
Swap argument name consistency between lib.rs and swap.rs

### DIFF
--- a/programs/whirlpool/src/lib.rs
+++ b/programs/whirlpool/src/lib.rs
@@ -321,7 +321,7 @@ pub mod whirlpool {
         amount: u64,
         other_amount_threshold: u64,
         sqrt_price_limit: u128,
-        exact_input: bool,
+        amount_specified_is_input: bool,
         a_to_b: bool,
     ) -> ProgramResult {
         return instructions::swap::handler(
@@ -329,7 +329,7 @@ pub mod whirlpool {
             amount,
             other_amount_threshold,
             sqrt_price_limit,
-            exact_input,
+            amount_specified_is_input,
             a_to_b,
         );
     }

--- a/sdk/src/artifacts/whirlpool.json
+++ b/sdk/src/artifacts/whirlpool.json
@@ -815,7 +815,7 @@
           "type": "u128"
         },
         {
-          "name": "exactInput",
+          "name": "amountSpecifiedIsInput",
           "type": "bool"
         },
         {

--- a/sdk/src/artifacts/whirlpool.ts
+++ b/sdk/src/artifacts/whirlpool.ts
@@ -815,7 +815,7 @@ export type Whirlpool = {
           "type": "u128"
         },
         {
-          "name": "exactInput",
+          "name": "amountSpecifiedIsInput",
           "type": "bool"
         },
         {
@@ -2503,7 +2503,7 @@ export const IDL: Whirlpool = {
           "type": "u128"
         },
         {
-          "name": "exactInput",
+          "name": "amountSpecifiedIsInput",
           "type": "bool"
         },
         {


### PR DESCRIPTION
Noticed inconsistent variable naming when working with the IDL. This makes the argument names consistent between `swap.rs` and `lib.rs` and regenerates the IDL.