### PR TITLE
[v0.2.0] Refactor swapQuote functions (#20)

### DIFF
--- a/sdk/src/utils/public/tick-utils.ts
+++ b/sdk/src/utils/public/tick-utils.ts
@@ -188,6 +188,22 @@ export class TickArrayUtil {
         .publicKey,
     ];
   }
+
+  /**
+   * Evaluate a list of tick-array data and return the array of indices which the tick-arrays are not initialized.
+   * @param tickArrays - a list of TickArrayData or null objects from AccountFetcher.listTickArrays
+   * @returns an array of array-index for the input tickArrays that requires initialization.
+   */
+  public static getUninitializedArrays(tickArrays: (TickArrayData | null)[]): number[] {
+    return tickArrays
+      .map((value, index) => {
+        if (!value) {
+          return index;
+        }
+        return -1;
+      })
+      .filter((index) => index >= 0);
+  }
 }
 
 function tickIndexToInnerIndex(


### PR DESCRIPTION
- Refactor swapQuoteByInputToken as a convenience method to help users fetch the necessary information to perform the swap quote
- Add swapQuoteWithParams for the more advanced users who have previously fetched the data they need to perform the swap quote