### PR TITLE
[SDK] Refactoring swap-quote 

### DIFF
--- a/sdk/src/errors/errors.ts
+++ b/sdk/src/errors/errors.ts
@@ -1,24 +1,24 @@
 export enum MathErrorCode {
-  MultiplicationOverflow,
-  MulDivOverflow,
-  MultiplicationShiftRightOverflow,
-  DivideByZero,
+  MultiplicationOverflow = `MultiplicationOverflow`,
+  MulDivOverflow = `MulDivOverflow`,
+  MultiplicationShiftRightOverflow = `MultiplicationShiftRightOverflow`,
+  DivideByZero = `DivideByZero`,
 }
 
 export enum TokenErrorCode {
-  TokenMaxExceeded,
-  TokenMinSubceeded,
+  TokenMaxExceeded = `TokenMaxExceeded`,
+  TokenMinSubceeded = `TokenMinSubceeded`,
 }
 
 export enum SwapErrorCode {
-  InvalidSqrtPriceLimitDirection,
-  SqrtPriceOutOfBounds,
-  ZeroTradableAmount,
-  AmountOutBelowMinimum,
-  AmountInAboveMaximum,
-  TickArrayCrossingAboveMax,
-  TickArrayIndexNotInitialized,
-  TickArraySequenceInvalid,
+  InvalidSqrtPriceLimitDirection = `InvalidSqrtPriceLimitDirection`,
+  SqrtPriceOutOfBounds = `SqrtPriceOutOfBounds`,
+  ZeroTradableAmount = `ZeroTradableAmount`,
+  AmountOutBelowMinimum = `AmountOutBelowMinimum`,
+  AmountInAboveMaximum = `AmountInAboveMaximum`,
+  TickArrayCrossingAboveMax = `TickArrayCrossingAboveMax`,
+  TickArrayIndexNotInitialized = `TickArrayIndexNotInitialized`,
+  TickArraySequenceInvalid = `TickArraySequenceInvalid`,
 }
 
 export type WhirlpoolsErrorCode = TokenErrorCode | SwapErrorCode | MathErrorCode;

--- a/sdk/src/errors/errors.ts
+++ b/sdk/src/errors/errors.ts
@@ -1,0 +1,38 @@
+export enum MathErrorCode {
+  MultiplicationOverflow,
+  MulDivOverflow,
+  MultiplicationShiftRightOverflow,
+  DivideByZero,
+}
+
+export enum TokenErrorCode {
+  TokenMaxExceeded,
+  TokenMinSubceeded,
+}
+
+export enum SwapErrorCode {
+  InvalidSqrtPriceLimitDirection,
+  SqrtPriceOutOfBounds,
+  ZeroTradableAmount,
+  AmountOutBelowMinimum,
+  AmountInAboveMaximum,
+  TickArrayCrossingAboveMax,
+  TickArrayIndexNotInitialized,
+  TickArraySequenceInvalid,
+}
+
+export type WhirlpoolsErrorCode = TokenErrorCode | SwapErrorCode | MathErrorCode;
+
+export class WhirlpoolsError extends Error {
+  message: string;
+  errorCode?: WhirlpoolsErrorCode;
+  constructor(message: string, errorCode?: WhirlpoolsErrorCode) {
+    super(message);
+    this.message = message;
+    this.errorCode = errorCode;
+  }
+
+  public static isWhirlpoolsErrorCode(e: any, code: WhirlpoolsErrorCode): boolean {
+    return e instanceof WhirlpoolsError && e.errorCode === code;
+  }
+}

--- a/sdk/src/impl/whirlpool-impl.ts
+++ b/sdk/src/impl/whirlpool-impl.ts
@@ -6,7 +6,7 @@ import {
   TransactionBuilder,
   ZERO,
 } from "@orca-so/common-sdk";
-import { Address, BN, translateAddress } from "@project-serum/anchor";
+import { Address, translateAddress } from "@project-serum/anchor";
 import { WhirlpoolContext } from "../context";
 import {
   IncreaseLiquidityInput,
@@ -19,7 +19,7 @@ import {
   swapIx,
   SwapInput,
 } from "../instructions";
-import { MAX_SQRT_PRICE, MIN_SQRT_PRICE, TokenInfo, WhirlpoolData } from "../types/public";
+import { TokenInfo, WhirlpoolData } from "../types/public";
 import { Whirlpool } from "../whirlpool-client";
 import { PublicKey, Keypair } from "@solana/web3.js";
 import { u64 } from "@solana/spl-token";
@@ -370,7 +370,7 @@ export class WhirlpoolImpl implements Whirlpool {
   }
 
   private async getSwapTx(input: SwapInput, wallet: PublicKey): Promise<TransactionBuilder> {
-    const { sqrtPriceLimit, otherAmountThreshold, amount, aToB, amountSpecifiedIsInput } = input;
+    const { amount, aToB } = input;
     const whirlpool = this.data;
     const txBuilder = new TransactionBuilder(this.ctx.provider);
 
@@ -390,104 +390,22 @@ export class WhirlpoolImpl implements Whirlpool {
     txBuilder.addInstruction(tokenOwnerAccountAIx);
     txBuilder.addInstruction(tokenOwnerAccountBIx);
 
-    const targetSqrtPriceLimitX64 = sqrtPriceLimit || this.getDefaultSqrtPriceLimit(aToB);
-
-    const tickArrayAddresses = await this.getTickArrayPublicKeysForSwap(
-      whirlpool.tickCurrentIndex,
-      targetSqrtPriceLimitX64,
-      whirlpool.tickSpacing,
-      this.address,
-      this.ctx.program.programId,
-      aToB
-    );
-
     const oraclePda = PDAUtil.getOracle(this.ctx.program.programId, this.address);
 
     txBuilder.addInstruction(
       swapIx(this.ctx.program, {
-        amount,
-        otherAmountThreshold,
-        sqrtPriceLimit: targetSqrtPriceLimitX64,
-        amountSpecifiedIsInput,
-        aToB,
+        ...input,
         whirlpool: this.address,
         tokenAuthority: wallet,
         tokenOwnerAccountA,
         tokenVaultA: whirlpool.tokenVaultA,
         tokenOwnerAccountB,
         tokenVaultB: whirlpool.tokenVaultB,
-        tickArray0: tickArrayAddresses[0],
-        tickArray1: tickArrayAddresses[1],
-        tickArray2: tickArrayAddresses[2],
         oracle: oraclePda.publicKey,
       })
     );
 
     return txBuilder;
-  }
-
-  private async getTickArrayPublicKeysForSwap(
-    tickCurrentIndex: number,
-    targetSqrtPriceX64: BN,
-    tickSpacing: number,
-    poolAddress: PublicKey,
-    programId: PublicKey,
-    aToB: boolean
-  ): Promise<[PublicKey, PublicKey, PublicKey]> {
-    // TODO: fix directionality
-    const nextInitializableTickIndex = (
-      aToB ? TickUtil.getPrevInitializableTickIndex : TickUtil.getNextInitializableTickIndex
-    )(tickCurrentIndex, tickSpacing);
-    const targetTickIndex = PriceMath.sqrtPriceX64ToTickIndex(targetSqrtPriceX64);
-
-    let currentStartTickIndex = TickUtil.getStartTickIndex(nextInitializableTickIndex, tickSpacing);
-    const targetStartTickIndex = TickUtil.getStartTickIndex(targetTickIndex, tickSpacing);
-
-    const offset = nextInitializableTickIndex < targetTickIndex ? 1 : -1;
-
-    let count = 1;
-    const tickArrayAddresses: [PublicKey, PublicKey, PublicKey] = [
-      PDAUtil.getTickArray(programId, poolAddress, currentStartTickIndex).publicKey,
-      PublicKey.default,
-      PublicKey.default,
-    ];
-
-    while (currentStartTickIndex !== targetStartTickIndex && count < 3) {
-      const nextStartTickIndex = TickUtil.getStartTickIndex(
-        nextInitializableTickIndex,
-        tickSpacing,
-        offset * count
-      );
-      const nextTickArrayAddress = PDAUtil.getTickArray(
-        programId,
-        poolAddress,
-        nextStartTickIndex
-      ).publicKey;
-
-      const nextTickArray = await this.fetcher.getTickArray(nextTickArrayAddress, false);
-      if (!nextTickArray) {
-        break;
-      }
-
-      tickArrayAddresses[count] = nextTickArrayAddress;
-      count++;
-      currentStartTickIndex = nextStartTickIndex;
-    }
-
-    while (count < 3) {
-      tickArrayAddresses[count] = PDAUtil.getTickArray(
-        programId,
-        poolAddress,
-        currentStartTickIndex
-      ).publicKey;
-      count++;
-    }
-
-    return tickArrayAddresses;
-  }
-
-  private getDefaultSqrtPriceLimit(aToB: boolean): BN {
-    return new BN(aToB ? MIN_SQRT_PRICE : MAX_SQRT_PRICE);
   }
 
   private async refresh() {

--- a/sdk/src/quotes/public/swap-quote.ts
+++ b/sdk/src/quotes/public/swap-quote.ts
@@ -3,27 +3,13 @@ import { PublicKey } from "@solana/web3.js";
 import { u64 } from "@solana/spl-token";
 import invariant from "tiny-invariant";
 import { PoolUtil } from "../../utils/public/pool-utils";
-import {
-  SwapDirection,
-  AmountSpecified,
-  adjustAmountForSlippage,
-  getAmountFixedDelta,
-  getNextSqrtPrice,
-  getAmountUnfixedDelta,
-} from "../../utils/position-util";
 import { SwapInput } from "../../instructions";
-import {
-  WhirlpoolData,
-  TickArrayData,
-  MAX_TICK_ARRAY_CROSSINGS,
-  MIN_SQRT_PRICE,
-  MAX_SQRT_PRICE,
-  TICK_ARRAY_SIZE,
-} from "../../types/public";
-import { AddressUtil, MathUtil, Percentage, ZERO } from "@orca-so/common-sdk";
-import { PriceMath, TickArrayUtil, TickUtil } from "../../utils/public";
+import { WhirlpoolData, TickArrayData, MIN_SQRT_PRICE, MAX_SQRT_PRICE } from "../../types/public";
+import { AddressUtil, Percentage, ZERO } from "@orca-so/common-sdk";
+import { TickArrayUtil } from "../../utils/public";
 import { Whirlpool } from "../../whirlpool-client";
 import { AccountFetcher } from "../../network/public";
+import { swapQuoteWithParamsImpl } from "../swap/swap-quote-impl";
 
 /**
  * @category Quotes
@@ -31,11 +17,17 @@ import { AccountFetcher } from "../../network/public";
 export type SwapQuoteParam = {
   whirlpoolData: WhirlpoolData;
   tokenAmount: u64;
+  otherAmountThreshold: u64;
+  sqrtPriceLimit: u64;
   aToB: boolean;
   amountSpecifiedIsInput: boolean;
   slippageTolerance: Percentage;
-  tickArrayAddresses: PublicKey[];
-  tickArrays: (TickArrayData | null)[];
+  tickArrays: TickArray[];
+};
+
+export type TickArray = {
+  address: PublicKey;
+  data: TickArrayData | null;
 };
 
 /**
@@ -44,6 +36,9 @@ export type SwapQuoteParam = {
 export type SwapQuote = {
   estimatedAmountIn: u64;
   estimatedAmountOut: u64;
+  estimatedEndTickIndex: number;
+  estimatedEndSqrtPrice: u64;
+  estimatedFeeAmount: u64;
 } & SwapInput;
 
 /**
@@ -67,418 +62,39 @@ export async function swapQuoteByInputToken(
   const aToB =
     swapMintKey.equals(whirlpoolData.tokenMintA) === amountSpecifiedIsInput ? true : false;
 
-  const tickArrayAddresses = PoolUtil.getTickArrayPublicKeysForSwap(
+  const tickArrays = await PoolUtil.getTickArraysForSwap(
     whirlpoolData.tickCurrentIndex,
     whirlpoolData.tickSpacing,
     aToB,
     AddressUtil.toPubKey(programId),
-    whirlpool.getAddress()
+    whirlpool.getAddress(),
+    fetcher,
+    refresh
   );
-  const tickArrays = await fetcher.listTickArrays(tickArrayAddresses, refresh);
 
   // Check if all the tick arrays have been initialized.
-  const uninitializedIndices = TickArrayUtil.getUninitializedArrays(tickArrays);
+  const uninitializedIndices = TickArrayUtil.getUninitializedArrays(
+    tickArrays.map((array) => array.data)
+  );
   if (uninitializedIndices.length > 0) {
     const uninitializedArrays = uninitializedIndices
-      .map((index) => tickArrayAddresses[index].toBase58())
+      .map((index) => tickArrays[index].address.toBase58())
       .join(", ");
     throw new Error(`TickArray addresses - [${uninitializedArrays}] need to be initialized.`);
   }
 
-  return swapQuoteWithParams({
+  return swapQuoteWithParamsImpl({
     whirlpoolData,
     tokenAmount,
     aToB,
     amountSpecifiedIsInput,
+    sqrtPriceLimit: getDefaultSqrtPriceLimit(aToB),
+    otherAmountThreshold: ZERO,
     slippageTolerance,
-    tickArrayAddresses,
     tickArrays,
   });
 }
 
-/**
- * TODO: Bug - The quote swap loop will ignore the first initialized tick of the next array on array traversal
- * if the tick is on offset 0.
- * TODO: Build out a comprhensive integ test-suite for all tick traversal. The test suite would confirm
- * edge cases for both smart-contract and quote (they must equal). The original test-cases in SDK can be ported
- * over in this effort.
- * TODO: Think about other types of quote that we want to write (ex. limit by price to get trade amount etc)
- *
- * Get an estimated quote of a swap
- *
- * @category Quotes
- * @param param a SwapQuoteParam object detailing parameters of the swap
- * @return a SwapQuote on the estimated amountIn & amountOut of the swap and a SwapInput to use on the swap instruction.
- */
-export function swapQuoteWithParams(param: SwapQuoteParam): SwapQuote {
-  const {
-    aToB,
-    tokenAmount,
-    whirlpoolData,
-    amountSpecifiedIsInput,
-    slippageTolerance,
-    tickArrays,
-    tickArrayAddresses,
-  } = param;
-
-  const swapDirection = aToB ? SwapDirection.AtoB : SwapDirection.BtoA;
-  const amountSpecified = amountSpecifiedIsInput ? AmountSpecified.Input : AmountSpecified.Output;
-
-  const { amountIn, amountOut, sqrtPriceLimitX64, tickArraysCrossed } = simulateSwap(
-    {
-      whirlpoolData,
-      amountSpecified,
-      swapDirection,
-      tickArrays,
-    },
-    {
-      amount: tokenAmount,
-      currentSqrtPriceX64: whirlpoolData.sqrtPrice,
-      currentTickIndex: whirlpoolData.tickCurrentIndex,
-      currentLiquidity: whirlpoolData.liquidity,
-    }
-  );
-
-  const otherAmountThreshold = adjustAmountForSlippage(
-    amountIn,
-    amountOut,
-    slippageTolerance,
-    amountSpecified
-  );
-
-  // Compute the traversed set of tick-arrays. Set the remaining slots to
-  //the last traversed array.
-  const traversedTickArrays = tickArrayAddresses.map((addr, index) => {
-    if (index < tickArraysCrossed) {
-      return addr;
-    }
-    return tickArrayAddresses[Math.max(tickArraysCrossed - 1, 0)];
-  });
-
-  return {
-    amount: tokenAmount,
-    otherAmountThreshold,
-    sqrtPriceLimit: sqrtPriceLimitX64,
-    estimatedAmountIn: amountIn,
-    estimatedAmountOut: amountOut,
-    aToB: swapDirection === SwapDirection.AtoB,
-    amountSpecifiedIsInput,
-    tickArray0: traversedTickArrays[0],
-    tickArray1: traversedTickArrays[1],
-    tickArray2: traversedTickArrays[2],
-  };
-}
-
-type SwapSimulationBaseInput = {
-  whirlpoolData: WhirlpoolData;
-  amountSpecified: AmountSpecified;
-  swapDirection: SwapDirection;
-  tickArrays: (TickArrayData | null)[];
-};
-
-type SwapSimulationInput = {
-  amount: BN;
-  currentSqrtPriceX64: BN;
-  currentTickIndex: number;
-  currentLiquidity: BN;
-};
-
-type SwapSimulationOutput = {
-  amountIn: BN;
-  amountOut: BN;
-  sqrtPriceLimitX64: BN;
-  tickArraysCrossed: number;
-};
-
-type SwapStepSimulationInput = {
-  sqrtPriceX64: BN;
-  tickIndex: number;
-  liquidity: BN;
-  amountRemaining: u64;
-  tickArraysCrossed: number;
-};
-
-type SwapStepSimulationOutput = {
-  nextSqrtPriceX64: BN;
-  nextTickIndex: number;
-  input: BN;
-  output: BN;
-  tickArraysCrossed: number;
-  hasReachedNextTick: boolean;
-};
-
-function simulateSwap(
-  baseInput: SwapSimulationBaseInput,
-  input: SwapSimulationInput
-): SwapSimulationOutput {
-  const { amountSpecified, swapDirection } = baseInput;
-
-  let {
-    currentTickIndex,
-    currentLiquidity,
-    amount: specifiedAmountLeft,
-    currentSqrtPriceX64,
-  } = input;
-
-  invariant(!specifiedAmountLeft.eq(ZERO), "amount must be nonzero");
-
-  let otherAmountCalculated = ZERO;
-
-  let tickArraysCrossed = 0;
-  let sqrtPriceLimitX64;
-
-  while (specifiedAmountLeft.gt(ZERO)) {
-    if (tickArraysCrossed > MAX_TICK_ARRAY_CROSSINGS) {
-      throw Error("Crossed the maximum number of tick arrays");
-    }
-
-    const swapStepSimulationOutput: SwapStepSimulationOutput = simulateSwapStep(baseInput, {
-      sqrtPriceX64: currentSqrtPriceX64,
-      amountRemaining: specifiedAmountLeft,
-      tickIndex: currentTickIndex,
-      liquidity: currentLiquidity,
-      tickArraysCrossed,
-    });
-
-    const { input, output, nextSqrtPriceX64, nextTickIndex, hasReachedNextTick } =
-      swapStepSimulationOutput;
-
-    const [specifiedAmountUsed, otherAmount] = resolveTokenAmounts(input, output, amountSpecified);
-
-    specifiedAmountLeft = specifiedAmountLeft.sub(specifiedAmountUsed);
-    otherAmountCalculated = otherAmountCalculated.add(otherAmount);
-
-    if (hasReachedNextTick) {
-      const nextTick = fetchTick(baseInput, nextTickIndex);
-
-      currentLiquidity = calculateNewLiquidity(
-        currentLiquidity,
-        nextTick.liquidityNet,
-        swapDirection
-      );
-
-      currentTickIndex = swapDirection == SwapDirection.AtoB ? nextTickIndex - 1 : nextTickIndex;
-    }
-
-    currentSqrtPriceX64 = nextSqrtPriceX64;
-    tickArraysCrossed = swapStepSimulationOutput.tickArraysCrossed;
-
-    if (tickArraysCrossed > MAX_TICK_ARRAY_CROSSINGS) {
-      sqrtPriceLimitX64 = PriceMath.tickIndexToSqrtPriceX64(nextTickIndex);
-    }
-  }
-
-  const [inputAmount, outputAmount] = resolveTokenAmounts(
-    input.amount.sub(specifiedAmountLeft),
-    otherAmountCalculated,
-    amountSpecified
-  );
-
-  if (!sqrtPriceLimitX64) {
-    if (swapDirection === SwapDirection.AtoB) {
-      sqrtPriceLimitX64 = new BN(MIN_SQRT_PRICE);
-    } else {
-      sqrtPriceLimitX64 = new BN(MAX_SQRT_PRICE);
-    }
-  }
-
-  // Return sqrtPriceLimit if 3 tick arrays crossed
-  return {
-    amountIn: inputAmount,
-    amountOut: outputAmount,
-    sqrtPriceLimitX64,
-    tickArraysCrossed,
-  };
-}
-
-function simulateSwapStep(
-  baseInput: SwapSimulationBaseInput,
-  input: SwapStepSimulationInput
-): SwapStepSimulationOutput {
-  const { whirlpoolData, amountSpecified, swapDirection } = baseInput;
-
-  const { feeRate } = whirlpoolData;
-
-  const feeRatePercentage = PoolUtil.getFeeRate(feeRate);
-
-  const { amountRemaining, liquidity, sqrtPriceX64, tickIndex, tickArraysCrossed } = input;
-
-  const { tickIndex: nextTickIndex, tickArraysCrossed: tickArraysCrossedUpdate } =
-    // Return last tick in tick array if max tick arrays crossed
-    // Error out of this gets called for another iteration
-    getNextInitializedTickIndex(baseInput, tickIndex, tickArraysCrossed);
-
-  const targetSqrtPriceX64 = PriceMath.tickIndexToSqrtPriceX64(nextTickIndex);
-
-  let fixedDelta = getAmountFixedDelta(
-    sqrtPriceX64,
-    targetSqrtPriceX64,
-    liquidity,
-    amountSpecified,
-    swapDirection
-  );
-
-  let amountCalculated = amountRemaining;
-  if (amountSpecified == AmountSpecified.Input) {
-    amountCalculated = calculateAmountAfterFees(amountRemaining, feeRatePercentage);
-  }
-
-  const nextSqrtPriceX64 = amountCalculated.gte(fixedDelta)
-    ? targetSqrtPriceX64 // Fully utilize liquidity till upcoming (next/prev depending on swap type) initialized tick
-    : getNextSqrtPrice(sqrtPriceX64, liquidity, amountCalculated, amountSpecified, swapDirection);
-
-  const hasReachedNextTick = nextSqrtPriceX64.eq(targetSqrtPriceX64);
-
-  const unfixedDelta = getAmountUnfixedDelta(
-    sqrtPriceX64,
-    nextSqrtPriceX64,
-    liquidity,
-    amountSpecified,
-    swapDirection
-  );
-
-  if (!hasReachedNextTick) {
-    fixedDelta = getAmountFixedDelta(
-      sqrtPriceX64,
-      nextSqrtPriceX64,
-      liquidity,
-      amountSpecified,
-      swapDirection
-    );
-  }
-
-  let [inputDelta, outputDelta] = resolveTokenAmounts(fixedDelta, unfixedDelta, amountSpecified);
-
-  // Cap output if output specified
-  if (amountSpecified == AmountSpecified.Output && outputDelta.gt(amountRemaining)) {
-    outputDelta = amountRemaining;
-  }
-
-  if (amountSpecified == AmountSpecified.Input && !hasReachedNextTick) {
-    inputDelta = amountRemaining;
-  } else {
-    inputDelta = inputDelta.add(calculateFeesFromAmount(inputDelta, feeRatePercentage));
-  }
-
-  return {
-    nextTickIndex,
-    nextSqrtPriceX64,
-    input: inputDelta,
-    output: outputDelta,
-    tickArraysCrossed: tickArraysCrossedUpdate,
-    hasReachedNextTick,
-  };
-}
-
-function calculateAmountAfterFees(amount: u64, feeRate: Percentage): BN {
-  return amount.mul(feeRate.denominator.sub(feeRate.numerator)).div(feeRate.denominator);
-}
-
-function calculateFeesFromAmount(amount: u64, feeRate: Percentage): BN {
-  return MathUtil.divRoundUp(
-    amount.mul(feeRate.numerator),
-    feeRate.denominator.sub(feeRate.numerator)
-  );
-}
-
-function calculateNewLiquidity(liquidity: BN, nextLiquidityNet: BN, swapDirection: SwapDirection) {
-  if (swapDirection == SwapDirection.AtoB) {
-    nextLiquidityNet = nextLiquidityNet.neg();
-  }
-
-  return liquidity.add(nextLiquidityNet);
-}
-
-function resolveTokenAmounts(
-  specifiedTokenAmount: BN,
-  otherTokenAmount: BN,
-  amountSpecified: AmountSpecified
-): [BN, BN] {
-  if (amountSpecified == AmountSpecified.Input) {
-    return [specifiedTokenAmount, otherTokenAmount];
-  } else {
-    return [otherTokenAmount, specifiedTokenAmount];
-  }
-}
-
-function fetchTickArray(baseInput: SwapSimulationBaseInput, tickIndex: number) {
-  const {
-    tickArrays,
-    whirlpoolData: { tickSpacing },
-  } = baseInput;
-
-  const startTickArray = tickArrays[0];
-  invariant(!!startTickArray, `tickArray is null at index 0`);
-  const sequenceStartIndex = startTickArray.startTickIndex;
-  const expectedArrayIndex = Math.abs(
-    Math.floor((tickIndex - sequenceStartIndex) / tickSpacing / TICK_ARRAY_SIZE)
-  );
-
-  invariant(
-    expectedArrayIndex > 0 || expectedArrayIndex < tickArrays.length,
-    `tickIndex ${tickIndex} assumes array-index of ${expectedArrayIndex} and is out of bounds for sequence`
-  );
-
-  const tickArray = tickArrays[expectedArrayIndex];
-  invariant(!!tickArray, `tickArray is null at array-index ${expectedArrayIndex}`);
-
-  return tickArray;
-}
-
-function fetchTick(baseInput: SwapSimulationBaseInput, tickIndex: number) {
-  const tickArray = fetchTickArray(baseInput, tickIndex);
-  const {
-    whirlpoolData: { tickSpacing },
-  } = baseInput;
-  return TickArrayUtil.getTickFromArray(tickArray, tickIndex, tickSpacing);
-}
-
-function getNextInitializedTickIndex(
-  baseInput: SwapSimulationBaseInput,
-  currentTickIndex: number,
-  tickArraysCrossed: number
-) {
-  const {
-    whirlpoolData: { tickSpacing },
-    swapDirection,
-  } = baseInput;
-  let nextInitializedTickIndex: number | undefined = undefined;
-
-  while (nextInitializedTickIndex === undefined) {
-    const currentTickArray = fetchTickArray(baseInput, currentTickIndex);
-
-    let temp;
-    if (swapDirection == SwapDirection.AtoB) {
-      temp = TickUtil.findPreviousInitializedTickIndex(
-        currentTickArray,
-        currentTickIndex,
-        tickSpacing
-      );
-    } else {
-      temp = TickUtil.findNextInitializedTickIndex(currentTickArray, currentTickIndex, tickSpacing);
-    }
-
-    if (temp) {
-      nextInitializedTickIndex = temp;
-    } else if (tickArraysCrossed === MAX_TICK_ARRAY_CROSSINGS) {
-      if (swapDirection === SwapDirection.AtoB) {
-        nextInitializedTickIndex = currentTickArray.startTickIndex;
-      } else {
-        nextInitializedTickIndex = currentTickArray.startTickIndex + TICK_ARRAY_SIZE * tickSpacing;
-      }
-      tickArraysCrossed++;
-    } else {
-      if (swapDirection === SwapDirection.AtoB) {
-        currentTickIndex = currentTickArray.startTickIndex - 1;
-      } else {
-        currentTickIndex = currentTickArray.startTickIndex + TICK_ARRAY_SIZE * tickSpacing - 1;
-      }
-      tickArraysCrossed++;
-    }
-  }
-
-  return {
-    tickIndex: nextInitializedTickIndex,
-    tickArraysCrossed,
-  };
+export function getDefaultSqrtPriceLimit(aToB: boolean) {
+  return aToB ? new u64(MIN_SQRT_PRICE) : new u64(MAX_SQRT_PRICE);
 }

--- a/sdk/src/quotes/public/swap-quote.ts
+++ b/sdk/src/quotes/public/swap-quote.ts
@@ -1,18 +1,27 @@
-import { Address, BN } from "@project-serum/anchor";
-import { PublicKey } from "@solana/web3.js";
+import { Address } from "@project-serum/anchor";
 import { u64 } from "@solana/spl-token";
 import invariant from "tiny-invariant";
 import { PoolUtil } from "../../utils/public/pool-utils";
 import { SwapInput } from "../../instructions";
-import { WhirlpoolData, TickArrayData, MIN_SQRT_PRICE, MAX_SQRT_PRICE } from "../../types/public";
-import { AddressUtil, Percentage, ZERO } from "@orca-so/common-sdk";
-import { TickArrayUtil } from "../../utils/public";
+import { WhirlpoolData, TickArray } from "../../types/public";
+import { AddressUtil, Percentage } from "@orca-so/common-sdk";
+import { TickArrayUtil, TokenType } from "../../utils/public";
 import { Whirlpool } from "../../whirlpool-client";
 import { AccountFetcher } from "../../network/public";
-import { swapQuoteWithParamsImpl } from "../swap/swap-quote-impl";
+import { simulateSwap } from "../swap/swap-quote-impl";
+import { SwapUtils } from "../../utils/public/swap-utils";
 
 /**
  * @category Quotes
+ *
+ * @param tokenAmount - The amount of input or output token to swap from (depending on amountSpecifiedIsInput).
+ * @param otherAmountThreshold - The maximum/minimum of input/output token to swap into (depending on amountSpecifiedIsInput).
+ * @param sqrtPriceLimit - The maximum/minimum price the swap will swap to.
+ * @param aToB - The direction of the swap. True if swapping from A to B. False if swapping from B to A.
+ * @param amountSpecifiedIsInput - Specifies the token the parameter `amount`represents. If true, the amount represents
+ *                                 the input token of the swap.
+ * @param slippageTolerance - The amount of slippage to account for in this quote
+ * @param tickArrays - An sequential array of tick-array objects in the direction of the trade to swap on
  */
 export type SwapQuoteParam = {
   whirlpoolData: WhirlpoolData;
@@ -25,13 +34,14 @@ export type SwapQuoteParam = {
   tickArrays: TickArray[];
 };
 
-export type TickArray = {
-  address: PublicKey;
-  data: TickArrayData | null;
-};
-
 /**
+ * A collection of estimated values from quoting a swap.
  * @category Quotes
+ * @param estimatedAmountIn - Approximate number of input token swapped in the swap
+ * @param estimatedAmountOut - Approximate number of output token swapped in the swap
+ * @param estimatedEndTickIndex - Approximate tick-index the Whirlpool will land on after this swap
+ * @param estimatedEndSqrtPrice - Approximate sqrtPrice the Whirlpool will land on after this swap
+ * @param estimatedFeeAmount - Approximate feeAmount (all fees) charged on this swap
  */
 export type SwapQuote = {
   estimatedAmountIn: u64;
@@ -42,27 +52,36 @@ export type SwapQuote = {
 } & SwapInput;
 
 /**
+ * Get an estimated swap quote using input token amount.
+ *
  * @category Quotes
+ * @param whirlpool - Whirlpool to perform the swap on
+ * @param inputTokenMint - PublicKey for the input token mint to swap with
+ * @param tokenAmount - The amount of input token to swap from
+ * @param slippageTolerance - The amount of slippage to account for in this quote
+ * @param programId - PublicKey for the Whirlpool ProgramId
+ * @param fetcher - AccountFetcher object to fetch solana accounts
+ * @param refresh - If true, fetcher would default to fetching the latest accounts
+ * @returns a SwapQuote object with estimates on token amounts, fee & end whirlpool states.
  */
 export async function swapQuoteByInputToken(
   whirlpool: Whirlpool,
-  swapTokenMint: Address,
+  inputTokenMint: Address,
   tokenAmount: u64,
-  amountSpecifiedIsInput: boolean,
   slippageTolerance: Percentage,
-  fetcher: AccountFetcher,
   programId: Address,
+  fetcher: AccountFetcher,
   refresh: boolean
 ): Promise<SwapQuote> {
   const whirlpoolData = whirlpool.getData();
-  const swapMintKey = AddressUtil.toPubKey(swapTokenMint);
+  const swapMintKey = AddressUtil.toPubKey(inputTokenMint);
   const swapTokenType = PoolUtil.getTokenType(whirlpoolData, swapMintKey);
   invariant(!!swapTokenType, "swapTokenMint does not match any tokens on this pool");
 
-  const aToB =
-    swapMintKey.equals(whirlpoolData.tokenMintA) === amountSpecifiedIsInput ? true : false;
+  const aToB = swapTokenType === TokenType.TokenA;
+  const amountSpecifiedIsInput = true;
 
-  const tickArrays = await PoolUtil.getTickArraysForSwap(
+  const tickArrays = await SwapUtils.getTickArrays(
     whirlpoolData.tickCurrentIndex,
     whirlpoolData.tickSpacing,
     aToB,
@@ -72,6 +91,87 @@ export async function swapQuoteByInputToken(
     refresh
   );
 
+  checkIfAllTickArraysInitialized(tickArrays);
+
+  return simulateSwap({
+    whirlpoolData,
+    tokenAmount,
+    aToB,
+    amountSpecifiedIsInput,
+    sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
+    otherAmountThreshold: SwapUtils.getDefaultOtherAmountThreshold(amountSpecifiedIsInput),
+    slippageTolerance,
+    tickArrays,
+  });
+}
+
+/**
+ * Get an estimated swap quote using an output token amount.
+ *
+ * Use this quote to get an estimated amount of input token needed to receive
+ * the defined output token amount.
+ *
+ * @category Quotes
+ * @param whirlpool - Whirlpool to perform the swap on
+ * @param outputTokenMint - PublicKey for the output token mint to swap into
+ * @param tokenAmount - The maximum amount of output token to receive in this swap.
+ * @param slippageTolerance - The amount of slippage to account for in this quote
+ * @param programId - PublicKey for the Whirlpool ProgramId
+ * @param fetcher - AccountFetcher object to fetch solana accounts
+ * @param refresh - If true, fetcher would default to fetching the latest accounts
+ * @returns a SwapQuote object with estimates on token amounts, fee & end whirlpool states.
+ */
+export async function swapQuoteByOutputToken(
+  whirlpool: Whirlpool,
+  outputTokenMint: Address,
+  tokenAmount: u64,
+  slippageTolerance: Percentage,
+  programId: Address,
+  fetcher: AccountFetcher,
+  refresh: boolean
+): Promise<SwapQuote> {
+  const whirlpoolData = whirlpool.getData();
+  const swapMintKey = AddressUtil.toPubKey(outputTokenMint);
+  const swapTokenType = PoolUtil.getTokenType(whirlpoolData, swapMintKey);
+  invariant(!!swapTokenType, "swapTokenMint does not match any tokens on this pool");
+
+  const aToB = swapTokenType === TokenType.TokenB;
+  const amountSpecifiedIsInput = false;
+
+  const tickArrays = await SwapUtils.getTickArrays(
+    whirlpoolData.tickCurrentIndex,
+    whirlpoolData.tickSpacing,
+    aToB,
+    AddressUtil.toPubKey(programId),
+    whirlpool.getAddress(),
+    fetcher,
+    refresh
+  );
+
+  checkIfAllTickArraysInitialized(tickArrays);
+
+  return simulateSwap({
+    whirlpoolData,
+    tokenAmount,
+    aToB,
+    amountSpecifiedIsInput,
+    sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
+    otherAmountThreshold: SwapUtils.getDefaultOtherAmountThreshold(amountSpecifiedIsInput),
+    slippageTolerance,
+    tickArrays,
+  });
+}
+
+/**
+ * Perform a sync swap quote based on the basic swap instruction parameters.
+ * @param params - SwapQuote parameters
+ * @returns a SwapQuote object with estimates on token amounts, fee & end whirlpool states.
+ */
+export function swapQuoteWithParams(params: SwapQuoteParam) {
+  return simulateSwap(params);
+}
+
+function checkIfAllTickArraysInitialized(tickArrays: TickArray[]) {
   // Check if all the tick arrays have been initialized.
   const uninitializedIndices = TickArrayUtil.getUninitializedArrays(
     tickArrays.map((array) => array.data)
@@ -82,19 +182,4 @@ export async function swapQuoteByInputToken(
       .join(", ");
     throw new Error(`TickArray addresses - [${uninitializedArrays}] need to be initialized.`);
   }
-
-  return swapQuoteWithParamsImpl({
-    whirlpoolData,
-    tokenAmount,
-    aToB,
-    amountSpecifiedIsInput,
-    sqrtPriceLimit: getDefaultSqrtPriceLimit(aToB),
-    otherAmountThreshold: ZERO,
-    slippageTolerance,
-    tickArrays,
-  });
-}
-
-export function getDefaultSqrtPriceLimit(aToB: boolean) {
-  return aToB ? new u64(MIN_SQRT_PRICE) : new u64(MAX_SQRT_PRICE);
 }

--- a/sdk/src/quotes/swap/swap-manager.ts
+++ b/sdk/src/quotes/swap/swap-manager.ts
@@ -14,7 +14,7 @@ export type SwapResult = {
   totalFeeAmount: BN;
 };
 
-export function simulateSwap(
+export function computeSwap(
   whirlpoolData: WhirlpoolData,
   tickSequence: TickArraySequence,
   tokenAmount: u64,
@@ -62,7 +62,7 @@ export function simulateSwap(
       amountCalculated = amountCalculated.add(swapComputation.amountOut);
     } else {
       amountRemaining = amountRemaining.sub(swapComputation.amountOut);
-      amountRemaining = amountRemaining.add(swapComputation.amountIn);
+      amountCalculated = amountCalculated.add(swapComputation.amountIn);
       amountCalculated = amountCalculated.add(swapComputation.feeAmount);
     }
 

--- a/sdk/src/quotes/swap/swap-manager.ts
+++ b/sdk/src/quotes/swap/swap-manager.ts
@@ -1,0 +1,169 @@
+import { ZERO } from "@orca-so/common-sdk";
+import { u64 } from "@solana/spl-token";
+import BN from "bn.js";
+import { PROTOCOL_FEE_RATE_MUL_VALUE, WhirlpoolData } from "../../types/public";
+import { PriceMath } from "../../utils/public";
+import { TickArraySequence } from "./tick-array-sequence";
+import { computeSwapStep } from "../../utils/math/swap-math";
+
+export type SwapResult = {
+  amountA: BN;
+  amountB: BN;
+  nextTickIndex: number;
+  nextSqrtPrice: BN;
+  totalFeeAmount: BN;
+};
+
+export function simulateSwap(
+  whirlpoolData: WhirlpoolData,
+  tickSequence: TickArraySequence,
+  tokenAmount: u64,
+  sqrtPriceLimit: u64,
+  amountSpecifiedIsInput: boolean,
+  aToB: boolean
+): SwapResult {
+  let amountRemaining = tokenAmount;
+  let amountCalculated = ZERO;
+  let currSqrtPrice = whirlpoolData.sqrtPrice;
+  let currLiquidity = whirlpoolData.liquidity;
+  let currTickIndex = whirlpoolData.tickCurrentIndex;
+  let totalFeeAmount = ZERO;
+  const feeRate = whirlpoolData.feeRate;
+  const protocolFeeRate = whirlpoolData.protocolFeeRate;
+  let currProtocolFee = new u64(0);
+  let currFeeGrowthGlobalInput = aToB
+    ? whirlpoolData.feeGrowthGlobalA
+    : whirlpoolData.feeGrowthGlobalB;
+
+  while (amountRemaining.gt(ZERO) && !sqrtPriceLimit.eq(currSqrtPrice)) {
+    let { nextIndex: nextTickIndex } = tickSequence.findNextInitializedTickIndex(currTickIndex);
+
+    let { nextTickPrice, nextSqrtPriceLimit: targetSqrtPrice } = getNextSqrtPrices(
+      nextTickIndex,
+      sqrtPriceLimit,
+      aToB
+    );
+
+    const swapComputation = computeSwapStep(
+      amountRemaining,
+      feeRate,
+      currLiquidity,
+      currSqrtPrice,
+      targetSqrtPrice,
+      amountSpecifiedIsInput,
+      aToB
+    );
+
+    totalFeeAmount = totalFeeAmount.add(swapComputation.feeAmount);
+
+    if (amountSpecifiedIsInput) {
+      amountRemaining = amountRemaining.sub(swapComputation.amountIn);
+      amountRemaining = amountRemaining.sub(swapComputation.feeAmount);
+      amountCalculated = amountCalculated.add(swapComputation.amountOut);
+    } else {
+      amountRemaining = amountRemaining.sub(swapComputation.amountOut);
+      amountRemaining = amountRemaining.add(swapComputation.amountIn);
+      amountCalculated = amountCalculated.add(swapComputation.feeAmount);
+    }
+
+    let { nextProtocolFee, nextFeeGrowthGlobalInput } = calculateFees(
+      swapComputation.feeAmount,
+      protocolFeeRate,
+      currLiquidity,
+      currProtocolFee,
+      currFeeGrowthGlobalInput
+    );
+    currProtocolFee = nextProtocolFee;
+    currFeeGrowthGlobalInput = nextFeeGrowthGlobalInput;
+
+    if (swapComputation.nextPrice.eq(nextTickPrice)) {
+      const nextTick = tickSequence.getTick(nextTickIndex);
+      if (nextTick.initialized) {
+        currLiquidity = calculateNextLiquidity(nextTick.liquidityNet, currLiquidity, aToB);
+      }
+      currTickIndex = aToB ? nextTickIndex - 1 : nextTickIndex;
+    } else {
+      currTickIndex = PriceMath.sqrtPriceX64ToTickIndex(swapComputation.nextPrice);
+    }
+
+    currSqrtPrice = swapComputation.nextPrice;
+  }
+
+  let { amountA, amountB } = calculateEstTokens(
+    tokenAmount,
+    amountRemaining,
+    amountCalculated,
+    aToB,
+    amountSpecifiedIsInput
+  );
+
+  return {
+    amountA,
+    amountB,
+    nextTickIndex: currTickIndex,
+    nextSqrtPrice: currSqrtPrice,
+    totalFeeAmount,
+  };
+}
+
+function getNextSqrtPrices(nextTick: number, sqrtPriceLimit: BN, aToB: boolean) {
+  const nextTickPrice = PriceMath.tickIndexToSqrtPriceX64(nextTick);
+  const nextSqrtPriceLimit = aToB
+    ? BN.max(sqrtPriceLimit, nextTickPrice)
+    : BN.min(sqrtPriceLimit, nextTickPrice);
+  return { nextTickPrice, nextSqrtPriceLimit };
+}
+
+function calculateFees(
+  feeAmount: BN,
+  protocolFeeRate: number,
+  currLiquidity: BN,
+  currProtocolFee: BN,
+  currFeeGrowthGlobalInput: BN
+) {
+  let nextProtocolFee = currProtocolFee;
+  let nextFeeGrowthGlobalInput = currFeeGrowthGlobalInput;
+  let globalFee = feeAmount;
+
+  if (protocolFeeRate > 0) {
+    let delta = calculateProtocolFee(globalFee, protocolFeeRate);
+    globalFee = globalFee.sub(delta);
+    nextProtocolFee = nextProtocolFee.add(currProtocolFee);
+  }
+
+  if (currLiquidity.gt(ZERO)) {
+    const globalFeeIncrement = globalFee.shln(64).div(currLiquidity);
+    nextFeeGrowthGlobalInput = nextFeeGrowthGlobalInput.add(globalFeeIncrement);
+  }
+
+  return {
+    nextProtocolFee,
+    nextFeeGrowthGlobalInput,
+  };
+}
+
+function calculateProtocolFee(globalFee: BN, protocolFeeRate: number) {
+  return globalFee.mul(new u64(protocolFeeRate).div(PROTOCOL_FEE_RATE_MUL_VALUE));
+}
+
+function calculateEstTokens(
+  amount: BN,
+  amountRemaining: BN,
+  amountCalculated: BN,
+  aToB: boolean,
+  amountSpecifiedIsInput: boolean
+) {
+  return aToB === amountSpecifiedIsInput
+    ? {
+        amountA: amount.sub(amountRemaining),
+        amountB: amountCalculated,
+      }
+    : {
+        amountA: amountCalculated,
+        amountB: amount.sub(amountRemaining),
+      };
+}
+
+function calculateNextLiquidity(tickNetLiquidity: BN, currLiquidity: BN, aToB: boolean) {
+  return aToB ? currLiquidity.sub(tickNetLiquidity) : currLiquidity.add(tickNetLiquidity);
+}

--- a/sdk/src/quotes/swap/swap-quote-impl.ts
+++ b/sdk/src/quotes/swap/swap-quote-impl.ts
@@ -1,4 +1,4 @@
-import { Percentage, ZERO } from "@orca-so/common-sdk";
+import { ZERO } from "@orca-so/common-sdk";
 import { SwapQuoteParam, SwapQuote } from "../public";
 import { BN } from "@project-serum/anchor";
 import { u64 } from "@solana/spl-token";
@@ -22,7 +22,6 @@ export function simulateSwap(params: SwapQuoteParam): SwapQuote {
     sqrtPriceLimit,
     otherAmountThreshold,
     amountSpecifiedIsInput,
-    slippageTolerance,
   } = params;
 
   if (sqrtPriceLimit.gt(new u64(MAX_SQRT_PRICE) || sqrtPriceLimit.lt(new u64(MIN_SQRT_PRICE)))) {
@@ -90,8 +89,7 @@ export function simulateSwap(params: SwapQuoteParam): SwapQuote {
   const { estimatedAmountIn, estimatedAmountOut } = remapAndAdjustTokens(
     swapResults.amountA,
     swapResults.amountB,
-    aToB,
-    slippageTolerance
+    aToB
   );
 
   const numOfTickCrossings = tickSequence.getNumOfTouchedArrays();
@@ -121,15 +119,7 @@ export function simulateSwap(params: SwapQuoteParam): SwapQuote {
   };
 }
 
-/**
- *  TODO: Handle the slippage.
- *  */
-function remapAndAdjustTokens(
-  amountA: BN,
-  amountB: BN,
-  aToB: boolean,
-  slippageTolerance: Percentage
-) {
+function remapAndAdjustTokens(amountA: BN, amountB: BN, aToB: boolean) {
   const estimatedAmountIn = aToB ? amountA : amountB;
   const estimatedAmountOut = aToB ? amountB : amountA;
   return {

--- a/sdk/src/quotes/swap/swap-quote-impl.ts
+++ b/sdk/src/quotes/swap/swap-quote-impl.ts
@@ -4,7 +4,7 @@ import { BN } from "@project-serum/anchor";
 import { u64 } from "@solana/spl-token";
 import { TickArraySequence } from "./tick-array-sequence";
 import { computeSwap } from "./swap-manager";
-import { MAX_SQRT_PRICE, MAX_TICK_ARRAY_CROSSINGS, MIN_SQRT_PRICE } from "../../types/public";
+import { MAX_SQRT_PRICE, MAX_SWAP_TICK_ARRAYS, MIN_SQRT_PRICE } from "../../types/public";
 import { SwapErrorCode, WhirlpoolsError } from "../../errors/errors";
 
 /**
@@ -94,15 +94,15 @@ export function simulateSwap(params: SwapQuoteParam): SwapQuote {
     slippageTolerance
   );
 
-  const numOfTickCrossings = tickSequence.getNumOfTouchedArrays() - 1;
-  if (numOfTickCrossings > MAX_TICK_ARRAY_CROSSINGS) {
+  const numOfTickCrossings = tickSequence.getNumOfTouchedArrays();
+  if (numOfTickCrossings > MAX_SWAP_TICK_ARRAYS) {
     throw new WhirlpoolsError(
       `Input amount causes the quote to traverse more than the allowable amount of tick-arrays ${numOfTickCrossings}`,
       SwapErrorCode.TickArrayCrossingAboveMax
     );
   }
 
-  const touchedArrays = tickSequence.getTouchedArrays(MAX_TICK_ARRAY_CROSSINGS);
+  const touchedArrays = tickSequence.getTouchedArrays(MAX_SWAP_TICK_ARRAYS);
 
   return {
     estimatedAmountIn,

--- a/sdk/src/quotes/swap/swap-quote-impl.ts
+++ b/sdk/src/quotes/swap/swap-quote-impl.ts
@@ -3,7 +3,7 @@ import { SwapQuoteParam, SwapQuote } from "../public";
 import { BN } from "@project-serum/anchor";
 import { u64 } from "@solana/spl-token";
 import { TickArraySequence } from "./tick-array-sequence";
-import { simulateSwap } from "./swap-manager";
+import { computeSwap } from "./swap-manager";
 import { MAX_SQRT_PRICE, MAX_TICK_ARRAY_CROSSINGS, MIN_SQRT_PRICE } from "../../types/public";
 import { SwapErrorCode, WhirlpoolsError } from "../../errors/errors";
 
@@ -13,7 +13,7 @@ import { SwapErrorCode, WhirlpoolsError } from "../../errors/errors";
  * @returns
  * @exceptions
  */
-export function swapQuoteWithParamsImpl(params: SwapQuoteParam): SwapQuote {
+export function simulateSwap(params: SwapQuoteParam): SwapQuote {
   const {
     aToB,
     whirlpoolData,
@@ -56,7 +56,7 @@ export function swapQuoteWithParamsImpl(params: SwapQuoteParam): SwapQuote {
     );
   }
 
-  const swapResults = simulateSwap(
+  const swapResults = computeSwap(
     whirlpoolData,
     tickSequence,
     tokenAmount,
@@ -78,7 +78,7 @@ export function swapQuoteWithParamsImpl(params: SwapQuoteParam): SwapQuote {
   } else {
     if (
       (aToB && otherAmountThreshold.lt(swapResults.amountA)) ||
-      (!aToB && otherAmountThreshold.lt(swapResults.amountA))
+      (!aToB && otherAmountThreshold.lt(swapResults.amountB))
     ) {
       throw new WhirlpoolsError(
         "Quoted amount for the other token is above the otherAmountThreshold.",

--- a/sdk/src/quotes/swap/swap-quote-impl.ts
+++ b/sdk/src/quotes/swap/swap-quote-impl.ts
@@ -1,0 +1,139 @@
+import { Percentage, ZERO } from "@orca-so/common-sdk";
+import { SwapQuoteParam, SwapQuote } from "../public";
+import { BN } from "@project-serum/anchor";
+import { u64 } from "@solana/spl-token";
+import { TickArraySequence } from "./tick-array-sequence";
+import { simulateSwap } from "./swap-manager";
+import { MAX_SQRT_PRICE, MAX_TICK_ARRAY_CROSSINGS, MIN_SQRT_PRICE } from "../../types/public";
+import { SwapErrorCode, WhirlpoolsError } from "../../errors/errors";
+
+/**
+ * Figure out the quote parameters needed to successfully complete this trade on chain
+ * @param param
+ * @returns
+ * @exceptions
+ */
+export function swapQuoteWithParamsImpl(params: SwapQuoteParam): SwapQuote {
+  const {
+    aToB,
+    whirlpoolData,
+    tickArrays,
+    tokenAmount,
+    sqrtPriceLimit,
+    otherAmountThreshold,
+    amountSpecifiedIsInput,
+    slippageTolerance,
+  } = params;
+
+  if (sqrtPriceLimit.gt(new u64(MAX_SQRT_PRICE) || sqrtPriceLimit.lt(new u64(MIN_SQRT_PRICE)))) {
+    throw new WhirlpoolsError(
+      "Provided SqrtPriceLimit is out of bounds.",
+      SwapErrorCode.SqrtPriceOutOfBounds
+    );
+  }
+
+  if (
+    (aToB && sqrtPriceLimit.gt(whirlpoolData.sqrtPrice)) ||
+    (!aToB && sqrtPriceLimit.lt(whirlpoolData.sqrtPrice))
+  ) {
+    throw new WhirlpoolsError(
+      "Provided SqrtPriceLimit is in the opposite direction of the trade.",
+      SwapErrorCode.InvalidSqrtPriceLimitDirection
+    );
+  }
+
+  if (tokenAmount.eq(ZERO)) {
+    throw new WhirlpoolsError("Provided tokenAmount is zero.", SwapErrorCode.ZeroTradableAmount);
+  }
+
+  const tickSequence = new TickArraySequence(tickArrays, whirlpoolData.tickSpacing, aToB);
+
+  // Ensure 1st search-index resides on the 1st array in the sequence to match smart contract expectation.
+  if (!tickSequence.checkArrayContainsTickIndex(0, whirlpoolData.tickCurrentIndex)) {
+    throw new WhirlpoolsError(
+      "TickArray at index 0 does not contain the Whirlpool current tick index.",
+      SwapErrorCode.TickArraySequenceInvalid
+    );
+  }
+
+  const swapResults = simulateSwap(
+    whirlpoolData,
+    tickSequence,
+    tokenAmount,
+    sqrtPriceLimit,
+    amountSpecifiedIsInput,
+    aToB
+  );
+
+  if (amountSpecifiedIsInput) {
+    if (
+      (aToB && otherAmountThreshold.gt(swapResults.amountB)) ||
+      (!aToB && otherAmountThreshold.gt(swapResults.amountA))
+    ) {
+      throw new WhirlpoolsError(
+        "Quoted amount for the other token is below the otherAmountThreshold.",
+        SwapErrorCode.AmountOutBelowMinimum
+      );
+    }
+  } else {
+    if (
+      (aToB && otherAmountThreshold.lt(swapResults.amountA)) ||
+      (!aToB && otherAmountThreshold.lt(swapResults.amountA))
+    ) {
+      throw new WhirlpoolsError(
+        "Quoted amount for the other token is above the otherAmountThreshold.",
+        SwapErrorCode.AmountInAboveMaximum
+      );
+    }
+  }
+
+  const { estimatedAmountIn, estimatedAmountOut } = remapAndAdjustTokens(
+    swapResults.amountA,
+    swapResults.amountB,
+    aToB,
+    slippageTolerance
+  );
+
+  const numOfTickCrossings = tickSequence.getNumOfTouchedArrays() - 1;
+  if (numOfTickCrossings > MAX_TICK_ARRAY_CROSSINGS) {
+    throw new WhirlpoolsError(
+      `Input amount causes the quote to traverse more than the allowable amount of tick-arrays ${numOfTickCrossings}`,
+      SwapErrorCode.TickArrayCrossingAboveMax
+    );
+  }
+
+  const touchedArrays = tickSequence.getTouchedArrays(MAX_TICK_ARRAY_CROSSINGS);
+
+  return {
+    estimatedAmountIn,
+    estimatedAmountOut,
+    estimatedEndTickIndex: swapResults.nextTickIndex,
+    estimatedEndSqrtPrice: swapResults.nextSqrtPrice,
+    estimatedFeeAmount: swapResults.totalFeeAmount,
+    amount: tokenAmount,
+    amountSpecifiedIsInput,
+    aToB,
+    otherAmountThreshold,
+    sqrtPriceLimit,
+    tickArray0: touchedArrays[0],
+    tickArray1: touchedArrays[1],
+    tickArray2: touchedArrays[2],
+  };
+}
+
+/**
+ *  TODO: Handle the slippage.
+ *  */
+function remapAndAdjustTokens(
+  amountA: BN,
+  amountB: BN,
+  aToB: boolean,
+  slippageTolerance: Percentage
+) {
+  const estimatedAmountIn = aToB ? amountA : amountB;
+  const estimatedAmountOut = aToB ? amountB : amountA;
+  return {
+    estimatedAmountIn,
+    estimatedAmountOut,
+  };
+}

--- a/sdk/src/quotes/swap/tick-array-index.ts
+++ b/sdk/src/quotes/swap/tick-array-index.ts
@@ -1,0 +1,43 @@
+import { TICK_ARRAY_SIZE } from "../../types/public";
+
+export class TickArrayIndex {
+  static fromTickIndex(index: number, tickSpacing: number) {
+    const arrayIndex = Math.floor(Math.floor(index / tickSpacing) / TICK_ARRAY_SIZE);
+    let offsetIndex = Math.floor((index % (tickSpacing * TICK_ARRAY_SIZE)) / tickSpacing);
+    if (offsetIndex < 0) {
+      offsetIndex = TICK_ARRAY_SIZE + offsetIndex;
+    }
+    return new TickArrayIndex(arrayIndex, offsetIndex, tickSpacing);
+  }
+
+  constructor(
+    readonly arrayIndex: number,
+    readonly offsetIndex: number,
+    readonly tickSpacing: number
+  ) {
+    if (offsetIndex >= TICK_ARRAY_SIZE) {
+      throw new Error("Invalid offsetIndex - value has to be smaller than TICK_ARRAY_SIZE");
+    }
+    if (offsetIndex < 0) {
+      throw new Error("Invalid offsetIndex - value is smaller than 0");
+    }
+
+    if (tickSpacing < 0) {
+      throw new Error("Invalid tickSpacing - value is less than 0");
+    }
+  }
+
+  toTickIndex() {
+    return (
+      this.arrayIndex * TICK_ARRAY_SIZE * this.tickSpacing + this.offsetIndex * this.tickSpacing
+    );
+  }
+
+  toNextInitializableTickIndex() {
+    return TickArrayIndex.fromTickIndex(this.toTickIndex() + this.tickSpacing, this.tickSpacing);
+  }
+
+  toPrevInitializableTickIndex() {
+    return TickArrayIndex.fromTickIndex(this.toTickIndex() - this.tickSpacing, this.tickSpacing);
+  }
+}

--- a/sdk/src/quotes/swap/tick-array-sequence.ts
+++ b/sdk/src/quotes/swap/tick-array-sequence.ts
@@ -1,0 +1,152 @@
+import { SwapErrorCode, WhirlpoolsError } from "../../errors/errors";
+import { MAX_TICK_INDEX, MIN_TICK_INDEX, TickData, TICK_ARRAY_SIZE } from "../../types/public";
+import { TickArray } from "../public";
+import { TickArrayIndex } from "./tick-array-index";
+import { PublicKey } from "@solana/web3.js";
+
+/**
+ * NOTE: differs from contract method of having the swap manager keep track of array index.
+ * This is due to the initial requirement to lazy load tick-arrays. This requirement is no longer necessary.
+ */
+export class TickArraySequence {
+  private touchedArrays: number[];
+  private startArrayIndex: number;
+
+  constructor(
+    readonly tickArrays: TickArray[],
+    readonly tickSpacing: number,
+    readonly aToB: boolean
+  ) {
+    if (!tickArrays[0] || !tickArrays[0].data) {
+      throw new Error("TickArray index 0 must be initialized");
+    }
+
+    this.touchedArrays = [...Array<number>(tickArrays.length).fill(0)];
+    this.startArrayIndex = TickArrayIndex.fromTickIndex(
+      tickArrays[0].data.startTickIndex,
+      this.tickSpacing
+    ).arrayIndex;
+  }
+
+  checkArrayContainsTickIndex(sequenceIndex: number, tickIndex: number) {
+    const tickArray = this.tickArrays[sequenceIndex]?.data;
+    if (!tickArray) {
+      return false;
+    }
+    return this.checkIfIndexIsInTickArrayRange(tickArray.startTickIndex, tickIndex);
+  }
+
+  getNumOfTouchedArrays() {
+    return this.touchedArrays.filter((val) => val > 0).length;
+  }
+
+  getTouchedArrays(minArraySize: number): PublicKey[] {
+    let result = this.touchedArrays.reduce<PublicKey[]>((prev, curr, index) => {
+      if (curr) {
+        prev.push(this.tickArrays[index].address);
+      }
+      return prev;
+    }, []);
+
+    // Edge case: nothing was ever touched.
+    if (result.length === 0) {
+      return [];
+    }
+
+    // If the result does not fit minArraySize, pad the rest with the last touched array
+    const sizeDiff = minArraySize - result.length;
+    if (sizeDiff > 0) {
+      result = result.concat(Array(sizeDiff).fill(result[result.length - 1]));
+    }
+
+    return result;
+  }
+
+  getTick(index: number): TickData {
+    const targetTaIndex = TickArrayIndex.fromTickIndex(index, this.tickSpacing);
+
+    if (!this.isArrayIndexInBounds(targetTaIndex, this.aToB)) {
+      throw new Error("Provided tick index is out of bounds for this sequence.");
+    }
+
+    const localArrayIndex = this.getLocalArrayIndex(targetTaIndex.arrayIndex, this.aToB);
+    const tickArray = this.tickArrays[localArrayIndex].data;
+
+    this.touchedArrays[localArrayIndex] = 1;
+
+    if (!tickArray) {
+      throw new WhirlpoolsError(
+        `TickArray at index ${localArrayIndex} is not initialized.`,
+        SwapErrorCode.TickArrayIndexNotInitialized
+      );
+    }
+
+    if (!this.checkIfIndexIsInTickArrayRange(tickArray.startTickIndex, index)) {
+      throw new WhirlpoolsError(
+        `TickArray at index ${localArrayIndex} is unexpected for this sequence.`,
+        SwapErrorCode.TickArraySequenceInvalid
+      );
+    }
+
+    return tickArray.ticks[targetTaIndex.offsetIndex];
+  }
+  /**
+   * if a->b, currIndex is included in the search
+   * if b->a, currIndex is always ignored
+   * @param currIndex
+   * @returns
+   */
+  findNextInitializedTickIndex(currIndex: number) {
+    const searchIndex = this.aToB ? currIndex : currIndex + this.tickSpacing;
+    let currTaIndex = TickArrayIndex.fromTickIndex(searchIndex, this.tickSpacing);
+
+    // Throw error if the search attempted to search for an index out of bounds
+    if (!this.isArrayIndexInBounds(currTaIndex, this.aToB)) {
+      throw new WhirlpoolsError(
+        `Swap input value traversed too many arrays. Out of bounds at attempt to traverse tick index - ${currTaIndex.toTickIndex()}.`,
+        SwapErrorCode.TickArraySequenceInvalid
+      );
+    }
+
+    while (this.isArrayIndexInBounds(currTaIndex, this.aToB)) {
+      const currTickData = this.getTick(currTaIndex.toTickIndex());
+      if (currTickData.initialized) {
+        return { nextIndex: currTaIndex.toTickIndex(), nextTickData: currTickData };
+      }
+      currTaIndex = this.aToB
+        ? currTaIndex.toPrevInitializableTickIndex()
+        : currTaIndex.toNextInitializableTickIndex();
+    }
+
+    const lastIndexInArray = Math.max(
+      Math.min(
+        this.aToB ? currTaIndex.toTickIndex() + this.tickSpacing : currTaIndex.toTickIndex() - 1,
+        MAX_TICK_INDEX
+      ),
+      MIN_TICK_INDEX
+    );
+
+    return { nextIndex: lastIndexInArray, nextTickData: null };
+  }
+
+  private getLocalArrayIndex(arrayIndex: number, aToB: boolean) {
+    return aToB ? this.startArrayIndex - arrayIndex : arrayIndex - this.startArrayIndex;
+  }
+
+  /**
+   * Check whether the array index potentially exists in this sequence.
+   * Note: assumes the sequence of tick-arrays are sequential
+   * @param index
+   */
+  private isArrayIndexInBounds(index: TickArrayIndex, aToB: boolean) {
+    // a+0...a+n-1 array index is ok
+    const localArrayIndex = this.getLocalArrayIndex(index.arrayIndex, aToB);
+    const seqLength = this.tickArrays.length;
+    return localArrayIndex >= 0 && localArrayIndex < seqLength;
+  }
+
+  private checkIfIndexIsInTickArrayRange(startTick: number, tickIndex: number) {
+    const upperBound = startTick + this.tickSpacing * TICK_ARRAY_SIZE;
+    return !(tickIndex < startTick || tickIndex > upperBound);
+  }
+}

--- a/sdk/src/quotes/swap/tick-array-sequence.ts
+++ b/sdk/src/quotes/swap/tick-array-sequence.ts
@@ -1,6 +1,11 @@
 import { SwapErrorCode, WhirlpoolsError } from "../../errors/errors";
-import { MAX_TICK_INDEX, MIN_TICK_INDEX, TickData, TICK_ARRAY_SIZE } from "../../types/public";
-import { TickArray } from "../public";
+import {
+  MAX_TICK_INDEX,
+  MIN_TICK_INDEX,
+  TickArray,
+  TickData,
+  TICK_ARRAY_SIZE,
+} from "../../types/public";
 import { TickArrayIndex } from "./tick-array-index";
 import { PublicKey } from "@solana/web3.js";
 

--- a/sdk/src/quotes/swap/tick-array-sequence.ts
+++ b/sdk/src/quotes/swap/tick-array-sequence.ts
@@ -14,7 +14,7 @@ import { PublicKey } from "@solana/web3.js";
  * This is due to the initial requirement to lazy load tick-arrays. This requirement is no longer necessary.
  */
 export class TickArraySequence {
-  private touchedArrays: number[];
+  private touchedArrays: boolean[];
   private startArrayIndex: number;
 
   constructor(
@@ -26,7 +26,7 @@ export class TickArraySequence {
       throw new Error("TickArray index 0 must be initialized");
     }
 
-    this.touchedArrays = [...Array<number>(tickArrays.length).fill(0)];
+    this.touchedArrays = [...Array<boolean>(tickArrays.length).fill(false)];
     this.startArrayIndex = TickArrayIndex.fromTickIndex(
       tickArrays[0].data.startTickIndex,
       this.tickSpacing
@@ -42,7 +42,7 @@ export class TickArraySequence {
   }
 
   getNumOfTouchedArrays() {
-    return this.touchedArrays.filter((val) => val > 0).length;
+    return this.touchedArrays.filter((val) => !!val).length;
   }
 
   getTouchedArrays(minArraySize: number): PublicKey[] {
@@ -77,7 +77,7 @@ export class TickArraySequence {
     const localArrayIndex = this.getLocalArrayIndex(targetTaIndex.arrayIndex, this.aToB);
     const tickArray = this.tickArrays[localArrayIndex].data;
 
-    this.touchedArrays[localArrayIndex] = 1;
+    this.touchedArrays[localArrayIndex] = true;
 
     if (!tickArray) {
       throw new WhirlpoolsError(

--- a/sdk/src/types/public/client-types.ts
+++ b/sdk/src/types/public/client-types.ts
@@ -1,8 +1,18 @@
 import { PublicKey } from "@solana/web3.js";
 import { MintInfo } from "@solana/spl-token";
+import { TickArrayData } from "./anchor-types";
 
 /**
  * Extended MintInfo class to host token info.
  * @category WhirlpoolClient
  */
 export type TokenInfo = MintInfo & { mint: PublicKey };
+
+/**
+ * A wrapper class of a TickArray on a Whirlpool
+ * @category WhirlpoolClient
+ */
+export type TickArray = {
+  address: PublicKey;
+  data: TickArrayData | null;
+};

--- a/sdk/src/types/public/constants.ts
+++ b/sdk/src/types/public/constants.ts
@@ -59,10 +59,10 @@ export const METADATA_PROGRAM_ADDRESS = new PublicKey(
 );
 
 /**
- * The maximum number of tick-array crossing that can occur in a swap.
+ * The maximum number of tick-arrays that can traversed across in a swap.
  * @category Constants
  */
-export const MAX_TICK_ARRAY_CROSSINGS = 2;
+export const MAX_SWAP_TICK_ARRAYS = 3;
 
 /**
  * The denominator which the protocol fee rate is divided on.

--- a/sdk/src/types/public/constants.ts
+++ b/sdk/src/types/public/constants.ts
@@ -1,3 +1,4 @@
+import { BN } from "@project-serum/anchor";
 import { PublicKey } from "@solana/web3.js";
 
 /**
@@ -62,3 +63,15 @@ export const METADATA_PROGRAM_ADDRESS = new PublicKey(
  * @category Constants
  */
 export const MAX_TICK_ARRAY_CROSSINGS = 2;
+
+/**
+ * The denominator which the protocol fee rate is divided on.
+ * @category Constants
+ */
+export const PROTOCOL_FEE_RATE_MUL_VALUE = new BN(10000);
+
+/**
+ * The denominator which the fee rate is divided on.
+ * @category Constants
+ */
+export const FEE_RATE_MUL_VALUE = new BN(1000000);

--- a/sdk/src/utils/math/bit-math.ts
+++ b/sdk/src/utils/math/bit-math.ts
@@ -1,0 +1,82 @@
+import { ZERO, ONE, MathUtil, TWO, U64_MAX } from "@orca-so/common-sdk";
+import { BN } from "@project-serum/anchor";
+import { MathErrorCode, WhirlpoolsError } from "../../errors/errors";
+
+export class BitMath {
+  static mul(n0: BN, n1: BN, limit: number): BN {
+    const result = n0.mul(n1);
+    if (this.isOverLimit(result, limit)) {
+      throw new WhirlpoolsError(
+        `Mul result higher than u${limit}`,
+        MathErrorCode.MultiplicationOverflow
+      );
+    }
+    return result;
+  }
+
+  static mulDiv(n0: BN, n1: BN, d: BN, limit: number): BN {
+    return this.mulDivRoundUpIf(n0, n1, d, false, limit);
+  }
+
+  static mulDivRoundUp(n0: BN, n1: BN, d: BN, limit: number): BN {
+    return this.mulDivRoundUpIf(n0, n1, d, true, limit);
+  }
+
+  static mulDivRoundUpIf(n0: BN, n1: BN, d: BN, roundUp: boolean, limit: number): BN {
+    if (d.eq(ZERO)) {
+      throw new WhirlpoolsError("checkedMulDiv denominator is zero", MathErrorCode.DivideByZero);
+    }
+
+    const p = this.mul(n0, n1, limit);
+    const n = p.div(d);
+
+    return roundUp && p.mod(d).gt(ZERO) ? n.add(ONE) : n;
+  }
+
+  static checked_mul_shift_right(n0: BN, n1: BN, limit: number) {
+    return this.checked_mul_shift_right_round_up_if(n0, n1, false, limit);
+  }
+
+  static checked_mul_shift_right_round_up_if(n0: BN, n1: BN, roundUp: boolean, limit: number) {
+    if (n0.eq(ZERO) || n1.eq(ZERO)) {
+      return ZERO;
+    }
+
+    const p = this.mul(n0, n1, limit);
+    if (this.isOverLimit(p, limit)) {
+      throw new WhirlpoolsError(
+        `MulDivShiftRight overflowed u${limit}.`,
+        MathErrorCode.MultiplicationShiftRightOverflow
+      );
+    }
+    const result = MathUtil.fromX64_BN(p);
+    const shouldRound = roundUp && result.and(U64_MAX).gt(ZERO);
+    if (shouldRound && result.eq(U64_MAX)) {
+      throw new WhirlpoolsError(
+        `MulDivShiftRight overflowed u${limit}.`,
+        MathErrorCode.MultiplicationOverflow
+      );
+    }
+
+    return shouldRound ? result.add(ONE) : result;
+  }
+
+  static isOverLimit(n0: BN, limit: number) {
+    const limitBN = TWO.pow(new BN(limit)).sub(ONE);
+    return n0.gt(limitBN);
+  }
+
+  static divRoundUp(n: BN, d: BN) {
+    return this.divRoundUpIf(n, d, true);
+  }
+
+  static divRoundUpIf(n: BN, d: BN, roundUp: boolean) {
+    if (d.eq(ZERO)) {
+      throw new WhirlpoolsError("divRoundUpIf - divide by zero", MathErrorCode.DivideByZero);
+    }
+
+    let q = n.div(d);
+
+    return roundUp && n.mod(d).gt(ZERO) ? q.add(ONE) : q;
+  }
+}

--- a/sdk/src/utils/math/bit-math.ts
+++ b/sdk/src/utils/math/bit-math.ts
@@ -24,7 +24,7 @@ export class BitMath {
 
   static mulDivRoundUpIf(n0: BN, n1: BN, d: BN, roundUp: boolean, limit: number): BN {
     if (d.eq(ZERO)) {
-      throw new WhirlpoolsError("checkedMulDiv denominator is zero", MathErrorCode.DivideByZero);
+      throw new WhirlpoolsError("mulDiv denominator is zero", MathErrorCode.DivideByZero);
     }
 
     const p = this.mul(n0, n1, limit);
@@ -45,7 +45,7 @@ export class BitMath {
     const p = this.mul(n0, n1, limit);
     if (this.isOverLimit(p, limit)) {
       throw new WhirlpoolsError(
-        `MulDivShiftRight overflowed u${limit}.`,
+        `MulShiftRight overflowed u${limit}.`,
         MathErrorCode.MultiplicationShiftRightOverflow
       );
     }
@@ -53,7 +53,7 @@ export class BitMath {
     const shouldRound = roundUp && result.and(U64_MAX).gt(ZERO);
     if (shouldRound && result.eq(U64_MAX)) {
       throw new WhirlpoolsError(
-        `MulDivShiftRight overflowed u${limit}.`,
+        `MulShiftRight overflowed u${limit}.`,
         MathErrorCode.MultiplicationOverflow
       );
     }

--- a/sdk/src/utils/math/swap-math.ts
+++ b/sdk/src/utils/math/swap-math.ts
@@ -1,0 +1,115 @@
+import { u64 } from "@solana/spl-token";
+import { BN } from "@project-serum/anchor";
+import { getAmountDeltaA, getAmountDeltaB, getNextSqrtPrice } from "./token-math";
+import { BitMath } from "./bit-math";
+import { FEE_RATE_MUL_VALUE } from "../../types/public";
+
+export type SwapStep = {
+  amountIn: BN;
+  amountOut: BN;
+  nextPrice: BN;
+  feeAmount: BN;
+};
+
+export function computeSwapStep(
+  amountRemaining: u64,
+  feeRate: number,
+  currLiquidity: BN,
+  currSqrtPrice: BN,
+  targetSqrtPrice: BN,
+  amountSpecifiedIsInput: boolean,
+  aToB: boolean
+): SwapStep {
+  let amountFixedDelta = getAmountFixedDelta(
+    currSqrtPrice,
+    targetSqrtPrice,
+    currLiquidity,
+    amountSpecifiedIsInput,
+    aToB
+  );
+
+  let amountCalc = amountRemaining;
+  if (amountSpecifiedIsInput) {
+    const result = BitMath.mulDiv(
+      amountRemaining,
+      FEE_RATE_MUL_VALUE.sub(new BN(feeRate)),
+      FEE_RATE_MUL_VALUE,
+      128
+    );
+    amountCalc = result;
+  }
+
+  let nextSqrtPrice = amountCalc.gte(amountFixedDelta)
+    ? targetSqrtPrice
+    : getNextSqrtPrice(currSqrtPrice, currLiquidity, amountCalc, amountSpecifiedIsInput, aToB);
+
+  let isMaxSwap = nextSqrtPrice.eq(targetSqrtPrice);
+
+  let amountUnfixedDelta = getAmountUnfixedDelta(
+    currSqrtPrice,
+    nextSqrtPrice,
+    currLiquidity,
+    amountSpecifiedIsInput,
+    aToB
+  );
+
+  if (!isMaxSwap) {
+    amountFixedDelta = getAmountFixedDelta(
+      currSqrtPrice,
+      nextSqrtPrice,
+      currLiquidity,
+      amountSpecifiedIsInput,
+      aToB
+    );
+  }
+
+  let amountIn = amountSpecifiedIsInput ? amountFixedDelta : amountUnfixedDelta;
+  let amountOut = amountSpecifiedIsInput ? amountUnfixedDelta : amountFixedDelta;
+
+  if (!amountSpecifiedIsInput && amountOut.gt(amountRemaining)) {
+    amountOut = amountRemaining;
+  }
+
+  let feeAmount: BN;
+  if (amountSpecifiedIsInput && !isMaxSwap) {
+    feeAmount = amountRemaining.sub(amountIn);
+  } else {
+    const feeRateBN = new BN(feeRate);
+    feeAmount = BitMath.mulDivRoundUp(amountIn, feeRateBN, FEE_RATE_MUL_VALUE.sub(feeRateBN), 128);
+  }
+
+  return {
+    amountIn,
+    amountOut,
+    nextPrice: nextSqrtPrice,
+    feeAmount,
+  };
+}
+
+function getAmountFixedDelta(
+  currSqrtPrice: BN,
+  targetSqrtPrice: BN,
+  currLiquidity: BN,
+  amountSpecifiedIsInput: boolean,
+  aToB: boolean
+) {
+  if (aToB === amountSpecifiedIsInput) {
+    return getAmountDeltaA(currSqrtPrice, targetSqrtPrice, currLiquidity, amountSpecifiedIsInput);
+  } else {
+    return getAmountDeltaB(currSqrtPrice, targetSqrtPrice, currLiquidity, amountSpecifiedIsInput);
+  }
+}
+
+function getAmountUnfixedDelta(
+  currSqrtPrice: BN,
+  targetSqrtPrice: BN,
+  currLiquidity: BN,
+  amountSpecifiedIsInput: boolean,
+  aToB: boolean
+) {
+  if (aToB === amountSpecifiedIsInput) {
+    return getAmountDeltaB(currSqrtPrice, targetSqrtPrice, currLiquidity, !amountSpecifiedIsInput);
+  } else {
+    return getAmountDeltaA(currSqrtPrice, targetSqrtPrice, currLiquidity, !amountSpecifiedIsInput);
+  }
+}

--- a/sdk/src/utils/math/token-math.ts
+++ b/sdk/src/utils/math/token-math.ts
@@ -1,0 +1,138 @@
+import { Percentage, U64_MAX, ZERO } from "@orca-so/common-sdk";
+import { BN } from "@project-serum/anchor";
+import { u64 } from "@solana/spl-token";
+import { MathErrorCode, TokenErrorCode, WhirlpoolsError } from "../../errors/errors";
+import { MAX_SQRT_PRICE, MIN_SQRT_PRICE } from "../../types/public";
+import { BitMath } from "./bit-math";
+
+export function getAmountDeltaA(
+  currSqrtPrice: BN,
+  targetSqrtPrice: BN,
+  currLiquidity: BN,
+  roundUp: boolean
+): BN {
+  let [sqrtPriceLower, sqrtPriceUpper] = toIncreasingPriceOrder(currSqrtPrice, targetSqrtPrice);
+  let sqrtPriceDiff = sqrtPriceUpper.sub(sqrtPriceLower);
+
+  let numerator = currLiquidity.mul(sqrtPriceDiff).shln(64);
+  let denominator = sqrtPriceLower.mul(sqrtPriceUpper);
+
+  let quotient = numerator.div(denominator);
+  let remainder = numerator.mod(denominator);
+
+  let result = roundUp && !remainder.eq(ZERO) ? quotient.add(new BN(1)) : quotient;
+
+  if (result.gt(U64_MAX)) {
+    throw new WhirlpoolsError("Results larger than U64", TokenErrorCode.TokenMaxExceeded);
+  }
+
+  return result;
+}
+
+export function getAmountDeltaB(
+  currSqrtPrice: BN,
+  targetSqrtPrice: BN,
+  currLiquidity: BN,
+  roundUp: boolean
+): BN {
+  let [sqrtPriceLower, sqrtPriceUpper] = toIncreasingPriceOrder(currSqrtPrice, targetSqrtPrice);
+  let sqrtPriceDiff = sqrtPriceUpper.sub(sqrtPriceLower);
+  return BitMath.checked_mul_shift_right_round_up_if(currLiquidity, sqrtPriceDiff, roundUp, 128);
+}
+
+export function getNextSqrtPrice(
+  sqrtPrice: BN,
+  currLiquidity: BN,
+  amount: u64,
+  amountSpecifiedIsInput: boolean,
+  aToB: boolean
+) {
+  if (amountSpecifiedIsInput === aToB) {
+    return getNextSqrtPriceFromARoundUp(sqrtPrice, currLiquidity, amount, amountSpecifiedIsInput);
+  } else {
+    return getNextSqrtPriceFromBRoundDown(sqrtPrice, currLiquidity, amount, amountSpecifiedIsInput);
+  }
+}
+
+function toIncreasingPriceOrder(sqrtPrice0: BN, sqrtPrice1: BN) {
+  if (sqrtPrice0.gt(sqrtPrice1)) {
+    return [sqrtPrice1, sqrtPrice0];
+  } else {
+    return [sqrtPrice0, sqrtPrice1];
+  }
+}
+
+function getNextSqrtPriceFromARoundUp(
+  sqrtPrice: BN,
+  currLiquidity: BN,
+  amount: u64,
+  amountSpecifiedIsInput: boolean
+) {
+  if (amount.eq(ZERO)) {
+    return sqrtPrice;
+  }
+
+  let p = BitMath.mul(sqrtPrice, amount, 256);
+  let numerator = BitMath.mul(currLiquidity, sqrtPrice, 256).shln(64);
+  if (BitMath.isOverLimit(numerator, 256)) {
+    throw new WhirlpoolsError(
+      "getNextSqrtPriceFromARoundUp - numerator overflow u256",
+      MathErrorCode.MultiplicationOverflow
+    );
+  }
+
+  let currLiquidityShiftLeft = currLiquidity.shln(64);
+  if (!amountSpecifiedIsInput && currLiquidityShiftLeft.lte(p)) {
+    throw new WhirlpoolsError(
+      "getNextSqrtPriceFromARoundUp - Unable to divide currLiquidityX64 by product",
+      MathErrorCode.DivideByZero
+    );
+  }
+
+  let denominator = amountSpecifiedIsInput
+    ? currLiquidityShiftLeft.add(p)
+    : currLiquidityShiftLeft.sub(p);
+
+  let price = BitMath.divRoundUp(numerator, denominator);
+
+  if (price.lt(new BN(MIN_SQRT_PRICE))) {
+    throw new WhirlpoolsError(
+      "getNextSqrtPriceFromARoundUp - price less than min sqrt price",
+      TokenErrorCode.TokenMinSubceeded
+    );
+  } else if (price.gt(new BN(MAX_SQRT_PRICE))) {
+    throw new WhirlpoolsError(
+      "getNextSqrtPriceFromARoundUp - price less than max sqrt price",
+      TokenErrorCode.TokenMaxExceeded
+    );
+  }
+
+  return price;
+}
+
+function getNextSqrtPriceFromBRoundDown(
+  sqrtPrice: BN,
+  currLiquidity: BN,
+  amount: u64,
+  amountSpecifiedIsInput: boolean
+) {
+  let amountX64 = amount.shln(64);
+
+  let delta = BitMath.divRoundUpIf(amountX64, currLiquidity, !amountSpecifiedIsInput);
+
+  if (amountSpecifiedIsInput) {
+    sqrtPrice = sqrtPrice.add(delta);
+  } else {
+    sqrtPrice = sqrtPrice.sub(delta);
+  }
+
+  return sqrtPrice;
+}
+
+function adjustForSlippage(n: BN, { numerator, denominator }: Percentage, adjustUp: boolean): BN {
+  if (adjustUp) {
+    return n.mul(denominator.add(numerator)).div(denominator);
+  } else {
+    return n.mul(denominator).div(denominator.add(numerator));
+  }
+}

--- a/sdk/src/utils/math/token-math.ts
+++ b/sdk/src/utils/math/token-math.ts
@@ -2,7 +2,7 @@ import { Percentage, U64_MAX, ZERO } from "@orca-so/common-sdk";
 import { BN } from "@project-serum/anchor";
 import { u64 } from "@solana/spl-token";
 import { MathErrorCode, TokenErrorCode, WhirlpoolsError } from "../../errors/errors";
-import { MAX_SQRT_PRICE, MIN_SQRT_PRICE } from "../../types/public";
+import { MAX_SQRT_PRICE, MIN_SQRT_PRICE, SwapInput } from "../../types/public";
 import { BitMath } from "./bit-math";
 
 export function getAmountDeltaA(
@@ -51,6 +51,18 @@ export function getNextSqrtPrice(
     return getNextSqrtPriceFromARoundUp(sqrtPrice, currLiquidity, amount, amountSpecifiedIsInput);
   } else {
     return getNextSqrtPriceFromBRoundDown(sqrtPrice, currLiquidity, amount, amountSpecifiedIsInput);
+  }
+}
+
+export function adjustForSlippage(
+  n: BN,
+  { numerator, denominator }: Percentage,
+  adjustUp: boolean
+): BN {
+  if (adjustUp) {
+    return n.mul(denominator.add(numerator)).div(denominator);
+  } else {
+    return n.mul(denominator).div(denominator.add(numerator));
   }
 }
 
@@ -127,12 +139,4 @@ function getNextSqrtPriceFromBRoundDown(
   }
 
   return sqrtPrice;
-}
-
-function adjustForSlippage(n: BN, { numerator, denominator }: Percentage, adjustUp: boolean): BN {
-  if (adjustUp) {
-    return n.mul(denominator.add(numerator)).div(denominator);
-  } else {
-    return n.mul(denominator).div(denominator.add(numerator));
-  }
 }

--- a/sdk/src/utils/position-util.ts
+++ b/sdk/src/utils/position-util.ts
@@ -98,47 +98,6 @@ export function getLiquidityFromTokenB(
   }
 }
 
-function orderSqrtPrice(sqrtPrice0X64: BN, sqrtPrice1X64: BN): [BN, BN] {
-  if (sqrtPrice0X64.lt(sqrtPrice1X64)) {
-    return [sqrtPrice0X64, sqrtPrice1X64];
-  } else {
-    return [sqrtPrice1X64, sqrtPrice0X64];
-  }
-}
-
-export function getTokenAFromLiquidity(
-  liquidity: BN,
-  sqrtPrice0X64: BN,
-  sqrtPrice1X64: BN,
-  roundUp: boolean
-) {
-  const [sqrtPriceLowerX64, sqrtPriceUpperX64] = orderSqrtPrice(sqrtPrice0X64, sqrtPrice1X64);
-
-  const numerator = liquidity.mul(sqrtPriceUpperX64.sub(sqrtPriceLowerX64)).shln(64);
-  const denominator = sqrtPriceUpperX64.mul(sqrtPriceLowerX64);
-  if (roundUp) {
-    return MathUtil.divRoundUp(numerator, denominator);
-  } else {
-    return numerator.div(denominator);
-  }
-}
-
-export function getTokenBFromLiquidity(
-  liquidity: BN,
-  sqrtPrice0X64: BN,
-  sqrtPrice1X64: BN,
-  roundUp: boolean
-) {
-  const [sqrtPriceLowerX64, sqrtPriceUpperX64] = orderSqrtPrice(sqrtPrice0X64, sqrtPrice1X64);
-
-  const result = liquidity.mul(sqrtPriceUpperX64.sub(sqrtPriceLowerX64));
-  if (roundUp) {
-    return MathUtil.shiftRightRoundUp(result);
-  } else {
-    return result.shrn(64);
-  }
-}
-
 export function getAmountFixedDelta(
   currentSqrtPriceX64: BN,
   targetSqrtPriceX64: BN,
@@ -202,5 +161,48 @@ export function getNextSqrtPrice(
     return getUpperSqrtPriceFromTokenB(amount, liquidity, sqrtPriceX64);
   } else {
     return getLowerSqrtPriceFromTokenB(amount, liquidity, sqrtPriceX64);
+  }
+}
+
+export function getTokenAFromLiquidity(
+  liquidity: BN,
+  sqrtPrice0X64: BN,
+  sqrtPrice1X64: BN,
+  roundUp: boolean
+) {
+  const [sqrtPriceLowerX64, sqrtPriceUpperX64] = orderSqrtPrice(sqrtPrice0X64, sqrtPrice1X64);
+
+  const numerator = liquidity.mul(sqrtPriceUpperX64.sub(sqrtPriceLowerX64)).shln(64);
+  const denominator = sqrtPriceUpperX64.mul(sqrtPriceLowerX64);
+  if (roundUp) {
+    return MathUtil.divRoundUp(numerator, denominator);
+  } else {
+    return numerator.div(denominator);
+  }
+}
+
+export function getTokenBFromLiquidity(
+  liquidity: BN,
+  sqrtPrice0X64: BN,
+  sqrtPrice1X64: BN,
+  roundUp: boolean
+) {
+  const [sqrtPriceLowerX64, sqrtPriceUpperX64] = orderSqrtPrice(sqrtPrice0X64, sqrtPrice1X64);
+
+  const result = liquidity.mul(sqrtPriceUpperX64.sub(sqrtPriceLowerX64));
+  if (roundUp) {
+    return MathUtil.shiftRightRoundUp(result);
+  } else {
+    return result.shrn(64);
+  }
+}
+
+/** Private */
+
+function orderSqrtPrice(sqrtPrice0X64: BN, sqrtPrice1X64: BN): [BN, BN] {
+  if (sqrtPrice0X64.lt(sqrtPrice1X64)) {
+    return [sqrtPrice0X64, sqrtPrice1X64];
+  } else {
+    return [sqrtPrice1X64, sqrtPrice0X64];
   }
 }

--- a/sdk/src/utils/public/index.ts
+++ b/sdk/src/utils/public/index.ts
@@ -4,3 +4,4 @@ export * from "./tick-utils";
 export * from "./pool-utils";
 export * from "./ix-utils";
 export * from "./types";
+export * from "./swap-utils";

--- a/sdk/src/utils/public/pool-utils.ts
+++ b/sdk/src/utils/public/pool-utils.ts
@@ -1,19 +1,11 @@
 import { AddressUtil, MathUtil, Percentage } from "@orca-so/common-sdk";
 import { Address, BN } from "@project-serum/anchor";
-import { Token, u64 } from "@solana/spl-token";
+import { u64 } from "@solana/spl-token";
 import { PublicKey } from "@solana/web3.js";
 import Decimal from "decimal.js";
-import { AccountFetcher } from "../../network/public";
-import { TickArray } from "../../quotes/public";
-import {
-  MAX_TICK_ARRAY_CROSSINGS,
-  WhirlpoolData,
-  WhirlpoolRewardInfoData,
-} from "../../types/public";
-import { PDAUtil } from "./pda-utils";
+import { WhirlpoolData, WhirlpoolRewardInfoData } from "../../types/public";
 import { PriceMath } from "./price-math";
-import { TickUtil } from "./tick-utils";
-import { SwapDirection, TokenType } from "./types";
+import { TokenType } from "./types";
 
 /**
  * @category Whirlpool Utils
@@ -41,28 +33,6 @@ export class PoolUtil {
       return TokenType.TokenB;
     }
     return undefined;
-  }
-
-  /**
-   * Given the intended token mint to swap, return the swap direction of a swap for a Whirlpool
-   * @param pool The Whirlpool to evaluate the mint against
-   * @param swapTokenMint The token mint PublicKey the user bases their swap against
-   * @param swapTokenIsInput Whether the swap token is the input token. (similar to amountSpecifiedIsInput from swap Ix)
-   * @returns The direction of the swap given the swapTokenMint. undefined if the token mint is not part of the trade pair of the pool.
-   */
-  public static getSwapDirection(
-    pool: WhirlpoolData,
-    swapTokenMint: PublicKey,
-    swapTokenIsInput: boolean
-  ): SwapDirection | undefined {
-    const tokenType = PoolUtil.getTokenType(pool, swapTokenMint);
-    if (!tokenType) {
-      return undefined;
-    }
-
-    return (tokenType === TokenType.TokenA) === swapTokenIsInput
-      ? SwapDirection.AtoB
-      : SwapDirection.BtoA;
   }
 
   public static getFeeRate(feeRate: number): Percentage {
@@ -199,71 +169,6 @@ export class PoolUtil {
       );
       return BN.min(estLiquidityAmountA, estLiquidityAmountB);
     }
-  }
-
-  /**
-   * Given the current tick-index, returns the dervied PDA and fetched data
-   * for the tick-arrays that this swap may traverse across.
-   *
-   * TODO: Handle the edge case where the first tick-array may be the previous array of
-   * expected start-index due to slippage.
-   *
-   * @category Whirlpool Utils
-   * @param tickCurrentIndex - The current tickIndex for the Whirlpool to swap on.
-   * @param tickSpacing - The tickSpacing for the Whirlpool.
-   * @param aToB - The direction of the trade.
-   * @param programId - The Whirlpool programId which the Whirlpool lives on.
-   * @param whirlpoolAddress - PublicKey of the whirlpool to swap on.
-   * @returns An array of PublicKey[] for the tickArray accounts that this swap may traverse across.
-   */
-  public static getTickArrayPublicKeysForSwap(
-    tickCurrentIndex: number,
-    tickSpacing: number,
-    aToB: boolean,
-    programId: PublicKey,
-    whirlpoolAddress: PublicKey
-  ) {
-    let offset = 0;
-    let tickArrayAddresses: PublicKey[] = [];
-    for (let i = 0; i <= MAX_TICK_ARRAY_CROSSINGS; i++) {
-      let startIndex: number;
-      try {
-        startIndex = TickUtil.getStartTickIndex(tickCurrentIndex, tickSpacing, offset);
-      } catch {
-        return tickArrayAddresses;
-      }
-
-      const pda = PDAUtil.getTickArray(programId, whirlpoolAddress, startIndex);
-      tickArrayAddresses.push(pda.publicKey);
-      offset = aToB ? offset - 1 : offset + 1;
-    }
-
-    return tickArrayAddresses;
-  }
-
-  public static async getTickArraysForSwap(
-    tickCurrentIndex: number,
-    tickSpacing: number,
-    aToB: boolean,
-    programId: PublicKey,
-    whirlpoolAddress: PublicKey,
-    fetcher: AccountFetcher,
-    refresh: boolean
-  ): Promise<TickArray[]> {
-    const addresses = PoolUtil.getTickArrayPublicKeysForSwap(
-      tickCurrentIndex,
-      tickSpacing,
-      aToB,
-      programId,
-      whirlpoolAddress
-    );
-    const data = await fetcher.listTickArrays(addresses, refresh);
-    return addresses.map((addr, index) => {
-      return {
-        address: addr,
-        data: data[index],
-      };
-    });
   }
 
   /**

--- a/sdk/src/utils/public/price-math.ts
+++ b/sdk/src/utils/public/price-math.ts
@@ -1,7 +1,7 @@
 import { MathUtil } from "@orca-so/common-sdk";
 import { BN } from "@project-serum/anchor";
 import Decimal from "decimal.js";
-import { MAX_TICK_INDEX, MIN_TICK_INDEX, MAX_SQRT_PRICE, MIN_SQRT_PRICE } from "../../types/public";
+import { MAX_SQRT_PRICE, MIN_SQRT_PRICE } from "../../types/public";
 import { TickUtil } from "./tick-utils";
 
 const BIT_PRECISION = 14;
@@ -34,10 +34,6 @@ export class PriceMath {
    * @returns
    */
   public static tickIndexToSqrtPriceX64(tickIndex: number): BN {
-    if (tickIndex > MAX_TICK_INDEX || tickIndex < MIN_TICK_INDEX) {
-      throw new Error("Provided tick index does not fit within supported tick index range.");
-    }
-
     if (tickIndex > 0) {
       return new BN(tickIndexToSqrtPricePositive(tickIndex));
     } else {

--- a/sdk/src/utils/public/swap-utils.ts
+++ b/sdk/src/utils/public/swap-utils.ts
@@ -1,0 +1,135 @@
+import { ZERO, U64_MAX } from "@orca-so/common-sdk";
+import { PublicKey } from "@solana/web3.js";
+import BN from "bn.js";
+import { AccountFetcher } from "../../network/public";
+import {
+  MIN_SQRT_PRICE,
+  MAX_SQRT_PRICE,
+  WhirlpoolData,
+  MAX_TICK_ARRAY_CROSSINGS,
+  TickArray,
+} from "../../types/public";
+import { PDAUtil } from "./pda-utils";
+import { PoolUtil } from "./pool-utils";
+import { TickUtil } from "./tick-utils";
+import { SwapDirection, TokenType } from "./types";
+
+/**
+ * @category Whirlpool Utils
+ */
+export class SwapUtils {
+  /**
+   * Get the default values for the sqrtPriceLimit parameter in a swap.
+   * @param aToB - The direction of a swap
+   * @returns The default values for the sqrtPriceLimit parameter in a swap.
+   */
+  public static getDefaultSqrtPriceLimit(aToB: boolean) {
+    return new BN(aToB ? MIN_SQRT_PRICE : MAX_SQRT_PRICE);
+  }
+
+  /**
+   * Get the default values for the otherAmountThreshold parameter in a swap.
+   * @param amountSpecifiedIsInput - The direction of a swap
+   * @returns The default values for the otherAmountThreshold parameter in a swap.
+   */
+  public static getDefaultOtherAmountThreshold(amountSpecifiedIsInput: boolean) {
+    return amountSpecifiedIsInput ? ZERO : U64_MAX;
+  }
+
+  /**
+   * Given the intended token mint to swap, return the swap direction of a swap for a Whirlpool
+   * @param pool The Whirlpool to evaluate the mint against
+   * @param swapTokenMint The token mint PublicKey the user bases their swap against
+   * @param swapTokenIsInput Whether the swap token is the input token. (similar to amountSpecifiedIsInput from swap Ix)
+   * @returns The direction of the swap given the swapTokenMint. undefined if the token mint is not part of the trade pair of the pool.
+   */
+  public static getSwapDirection(
+    pool: WhirlpoolData,
+    swapTokenMint: PublicKey,
+    swapTokenIsInput: boolean
+  ): SwapDirection | undefined {
+    const tokenType = PoolUtil.getTokenType(pool, swapTokenMint);
+    if (!tokenType) {
+      return undefined;
+    }
+
+    return (tokenType === TokenType.TokenA) === swapTokenIsInput
+      ? SwapDirection.AtoB
+      : SwapDirection.BtoA;
+  }
+
+  /**
+   * Given the current tick-index, returns the dervied PDA and fetched data
+   * for the tick-arrays that this swap may traverse across.
+   *
+   * @category Whirlpool Utils
+   * @param tickCurrentIndex - The current tickIndex for the Whirlpool to swap on.
+   * @param tickSpacing - The tickSpacing for the Whirlpool.
+   * @param aToB - The direction of the trade.
+   * @param programId - The Whirlpool programId which the Whirlpool lives on.
+   * @param whirlpoolAddress - PublicKey of the whirlpool to swap on.
+   * @returns An array of PublicKey[] for the tickArray accounts that this swap may traverse across.
+   */
+  public static getTickArrayPublicKeys(
+    tickCurrentIndex: number,
+    tickSpacing: number,
+    aToB: boolean,
+    programId: PublicKey,
+    whirlpoolAddress: PublicKey
+  ) {
+    let offset = 0;
+    let tickArrayAddresses: PublicKey[] = [];
+    for (let i = 0; i <= MAX_TICK_ARRAY_CROSSINGS; i++) {
+      let startIndex: number;
+      try {
+        startIndex = TickUtil.getStartTickIndex(tickCurrentIndex, tickSpacing, offset);
+      } catch {
+        return tickArrayAddresses;
+      }
+
+      const pda = PDAUtil.getTickArray(programId, whirlpoolAddress, startIndex);
+      tickArrayAddresses.push(pda.publicKey);
+      offset = aToB ? offset - 1 : offset + 1;
+    }
+
+    return tickArrayAddresses;
+  }
+
+  /**
+   * Given the current tick-index, returns TickArray objects that this swap may traverse across.
+   *
+   * @category Whirlpool Utils
+   * @param tickCurrentIndex - The current tickIndex for the Whirlpool to swap on.
+   * @param tickSpacing - The tickSpacing for the Whirlpool.
+   * @param aToB - The direction of the trade.
+   * @param programId - The Whirlpool programId which the Whirlpool lives on.
+   * @param whirlpoolAddress - PublicKey of the whirlpool to swap on.
+   * @param fetcher - AccountFetcher object to fetch solana accounts
+   * @param refresh - If true, fetcher would default to fetching the latest accounts
+   * @returns An array of PublicKey[] for the tickArray accounts that this swap may traverse across.
+   */
+  public static async getTickArrays(
+    tickCurrentIndex: number,
+    tickSpacing: number,
+    aToB: boolean,
+    programId: PublicKey,
+    whirlpoolAddress: PublicKey,
+    fetcher: AccountFetcher,
+    refresh: boolean
+  ): Promise<TickArray[]> {
+    const addresses = SwapUtils.getTickArrayPublicKeys(
+      tickCurrentIndex,
+      tickSpacing,
+      aToB,
+      programId,
+      whirlpoolAddress
+    );
+    const data = await fetcher.listTickArrays(addresses, refresh);
+    return addresses.map((addr, index) => {
+      return {
+        address: addr,
+        data: data[index],
+      };
+    });
+  }
+}

--- a/sdk/src/utils/public/swap-utils.ts
+++ b/sdk/src/utils/public/swap-utils.ts
@@ -6,7 +6,7 @@ import {
   MIN_SQRT_PRICE,
   MAX_SQRT_PRICE,
   WhirlpoolData,
-  MAX_TICK_ARRAY_CROSSINGS,
+  MAX_SWAP_TICK_ARRAYS,
   TickArray,
 } from "../../types/public";
 import { PDAUtil } from "./pda-utils";
@@ -79,7 +79,7 @@ export class SwapUtils {
   ) {
     let offset = 0;
     let tickArrayAddresses: PublicKey[] = [];
-    for (let i = 0; i <= MAX_TICK_ARRAY_CROSSINGS; i++) {
+    for (let i = 0; i < MAX_SWAP_TICK_ARRAYS; i++) {
       let startIndex: number;
       try {
         startIndex = TickUtil.getStartTickIndex(tickCurrentIndex, tickSpacing, offset);

--- a/sdk/src/utils/public/tick-utils.ts
+++ b/sdk/src/utils/public/tick-utils.ts
@@ -37,8 +37,8 @@ export class TickUtil {
 
     const ticksInArray = TICK_ARRAY_SIZE * tickSpacing;
     const minTickIndex = MIN_TICK_INDEX - ((MIN_TICK_INDEX % ticksInArray) + ticksInArray);
-    invariant(startTickIndex >= minTickIndex, "startTickIndex is too small");
-    invariant(startTickIndex <= MAX_TICK_INDEX, "startTickIndex is too large");
+    invariant(startTickIndex >= minTickIndex, `startTickIndex is too small - - ${startTickIndex}`);
+    invariant(startTickIndex <= MAX_TICK_INDEX, `startTickIndex is too large - ${startTickIndex}`);
     return startTickIndex;
   }
 
@@ -167,27 +167,30 @@ export class TickArrayUtil {
   }
 
   /**
-   *
-   * @param tickLowerIndex
-   * @param tickUpperIndex
-   * @param tickSpacing
-   * @param whirlpool
-   * @param programId
-   * @returns
+   * Return a sequence of tick array pdas based on the sequence start index.
+   * @param tick - A tick in the first tick-array of your sequence
+   * @param tickSpacing - Tick spacing for the whirlpool
+   * @param numOfTickArrays - The number of TickArray PDAs to generate
+   * @param programId - Program Id of the whirlpool for these tick-arrays
+   * @param whirlpoolAddress - Address for the Whirlpool for these tick-arrays
+   * @returns TickArray PDAs for the sequence`
    */
-  public static getAdjacentTickArrays(
-    tickLowerIndex: number,
-    tickUpperIndex: number,
+  public static async getTickArrayPDAs(
+    tick: number,
     tickSpacing: number,
-    whirlpool: PublicKey,
-    programId: PublicKey
-  ): [PublicKey, PublicKey] {
-    return [
-      PDAUtil.getTickArrayFromTickIndex(tickLowerIndex, tickSpacing, whirlpool, programId)
-        .publicKey,
-      PDAUtil.getTickArrayFromTickIndex(tickUpperIndex, tickSpacing, whirlpool, programId)
-        .publicKey,
-    ];
+    numOfTickArrays: number,
+    programId: PublicKey,
+    whirlpoolAddress: PublicKey,
+    aToB: boolean
+  ) {
+    let arrayIndexList = [...Array(numOfTickArrays).keys()];
+    if (aToB) {
+      arrayIndexList = arrayIndexList.map((value) => -value);
+    }
+    return arrayIndexList.map((value) => {
+      const startTick = TickUtil.getStartTickIndex(tick, tickSpacing, value);
+      return PDAUtil.getTickArray(programId, whirlpoolAddress, startTick);
+    });
   }
 
   public static async getUninitializedArraysPDAs(

--- a/sdk/tests/integration/swap.test.ts
+++ b/sdk/tests/integration/swap.test.ts
@@ -555,10 +555,9 @@ describe("swap", () => {
       whirlpool,
       whirlpoolData.tokenMintB,
       new u64(100000),
-      true,
       Percentage.fromFraction(1, 100),
-      fetcher,
       ctx.program.programId,
+      fetcher,
       true
     );
 

--- a/sdk/tests/sdk/whirlpools/swap/swap-array.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/swap-array.test.ts
@@ -1,0 +1,521 @@
+import BN from "bn.js";
+import * as anchor from "@project-serum/anchor";
+import * as assert from "assert";
+import {
+  PriceMath,
+  AccountFetcher,
+  buildWhirlpoolClient,
+  WhirlpoolContext,
+  TICK_ARRAY_SIZE,
+  swapQuoteByInputToken,
+  PDAUtil,
+  getDefaultSqrtPriceLimit,
+  PoolUtil,
+} from "../../../../src";
+import {
+  arrayTickIndexToTickIndex,
+  setupSwapTest,
+  buildPosition,
+} from "../../../utils/swap-test-utils";
+import { AddressUtil, Percentage, ZERO } from "@orca-so/common-sdk";
+import { TickSpacing } from "../../../utils";
+import { u64 } from "@solana/spl-token";
+import { swapQuoteWithParamsImpl } from "../../../../src/quotes/swap/swap-quote-impl";
+import { SwapErrorCode, WhirlpoolsError } from "../../../../src/errors/errors";
+import { adjustForSlippage } from "../../../../src/utils/position-util";
+import { getTickArrays } from "../../../utils/testDataTypes";
+
+describe("swap arrays test", async () => {
+  const provider = anchor.Provider.local();
+  anchor.setProvider(anchor.Provider.env());
+  const program = anchor.workspace.Whirlpool;
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
+  const fetcher = new AccountFetcher(ctx.connection);
+  const client = buildWhirlpoolClient(ctx, fetcher);
+  const tickSpacing = TickSpacing.SixtyFour;
+  const slippageTolerance = Percentage.fromFraction(1, 100);
+
+  /**
+   * |-------------c2-----|xxxxxxxxxxxxxxxxx|------c1-----------|
+   */
+  it("3 sequential arrays, 2nd array not initialized, a->b", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 44 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const missingTickArray = PDAUtil.getTickArray(ctx.program.programId, whirlpool.getAddress(), 0);
+    const expectedError = `[${missingTickArray.publicKey.toBase58()}] need to be initialized`;
+    await assert.rejects(
+      swapQuoteByInputToken(
+        whirlpool,
+        whirlpoolData.tokenMintA,
+        new u64(10000),
+        true,
+        slippageTolerance,
+        fetcher,
+        ctx.program.programId,
+        true
+      ),
+      (err: Error) => err.message.indexOf(expectedError) != -1
+    );
+  });
+
+  /**
+   * |-------------c1-----|xxxxxxxxxxxxxxxxx|------c2-----------|
+   */
+  it("3 sequential arrays, 2nd array not initialized, b->a", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -1, offsetIndex: 44 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const missingTickArray = PDAUtil.getTickArray(ctx.program.programId, whirlpool.getAddress(), 0);
+    const expectedError = `[${missingTickArray.publicKey.toBase58()}] need to be initialized`;
+    await assert.rejects(
+      swapQuoteByInputToken(
+        whirlpool,
+        whirlpoolData.tokenMintB,
+        new u64(10000),
+        true,
+        slippageTolerance,
+        fetcher,
+        ctx.program.programId,
+        true
+      ),
+      (err: Error) => err.message.indexOf(expectedError) != -1
+    );
+  });
+
+  /**
+   * c1|------------------|-----------------|-------------------|
+   */
+  it("3 sequential arrays does not contain curr_tick_index, a->b", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -2, offsetIndex: 44 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const aToB = true;
+    const tickArrays = await PoolUtil.getTickArraysForSwap(
+      arrayTickIndexToTickIndex({ arrayIndex: 0, offsetIndex: 10 }, tickSpacing),
+      tickSpacing,
+      aToB,
+      ctx.program.programId,
+      whirlpool.getAddress(),
+      fetcher,
+      true
+    );
+    assert.throws(
+      () =>
+        swapQuoteWithParamsImpl({
+          aToB,
+          amountSpecifiedIsInput: true,
+          slippageTolerance,
+          tokenAmount: new u64("10000"),
+          whirlpoolData,
+          tickArrays,
+          sqrtPriceLimit: getDefaultSqrtPriceLimit(aToB),
+          otherAmountThreshold: ZERO,
+        }),
+      (err) => (err as WhirlpoolsError).errorCode === SwapErrorCode.TickArraySequenceInvalid
+    );
+  });
+
+  /**
+   * |--------------------|-----------------|-------------------|c1
+   */
+  it("3 sequential arrays does not contain curr_tick_index, b->a", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 2, offsetIndex: 44 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.getData();
+    const aToB = false;
+    const tickArrays = await PoolUtil.getTickArraysForSwap(
+      arrayTickIndexToTickIndex({ arrayIndex: 0, offsetIndex: 10 }, tickSpacing),
+      tickSpacing,
+      aToB,
+      ctx.program.programId,
+      whirlpool.getAddress(),
+      fetcher,
+      true
+    );
+    assert.throws(
+      () =>
+        swapQuoteWithParamsImpl({
+          aToB,
+          amountSpecifiedIsInput: true,
+          slippageTolerance,
+          tokenAmount: new u64("10000"),
+          whirlpoolData,
+          tickArrays,
+          sqrtPriceLimit: getDefaultSqrtPriceLimit(aToB),
+          otherAmountThreshold: ZERO,
+        }),
+      (err) => (err as WhirlpoolsError).errorCode === SwapErrorCode.TickArraySequenceInvalid
+    );
+  });
+
+  /**
+   * |--------------------|------c1---------|-------------------|
+   */
+  it("3 sequential arrays, 2nd array contains curr_tick_index, a->b", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 0, offsetIndex: 44 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const aToB = true;
+    const tickArrays = await PoolUtil.getTickArraysForSwap(
+      arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 10 }, tickSpacing),
+      tickSpacing,
+      aToB,
+      ctx.program.programId,
+      whirlpool.getAddress(),
+      fetcher,
+      true
+    );
+    assert.throws(
+      () =>
+        swapQuoteWithParamsImpl({
+          aToB,
+          amountSpecifiedIsInput: true,
+          slippageTolerance,
+          tokenAmount: new u64("10000"),
+          whirlpoolData,
+          tickArrays,
+          sqrtPriceLimit: getDefaultSqrtPriceLimit(aToB),
+          otherAmountThreshold: ZERO,
+        }),
+      (err) => (err as WhirlpoolsError).errorCode === SwapErrorCode.TickArraySequenceInvalid
+    );
+  });
+
+  /**
+   * |--------------------|------c1---------|-------------------|
+   */
+  it("3 sequential arrays, 2nd array contains curr_tick_index, b->a", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 0, offsetIndex: 44 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264, 16896],
+      fundedPositions: [
+        buildPosition(
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const aToB = false;
+    const tickArrays = await PoolUtil.getTickArraysForSwap(
+      arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 10 }, tickSpacing),
+      tickSpacing,
+      aToB,
+      ctx.program.programId,
+      whirlpool.getAddress(),
+      fetcher,
+      true
+    );
+
+    assert.throws(
+      () =>
+        swapQuoteWithParamsImpl({
+          aToB,
+          amountSpecifiedIsInput: true,
+          slippageTolerance,
+          tokenAmount: new u64("10000"),
+          whirlpoolData,
+          tickArrays,
+          sqrtPriceLimit: getDefaultSqrtPriceLimit(aToB),
+          otherAmountThreshold: ZERO,
+        }),
+      (err) => (err as WhirlpoolsError).errorCode === SwapErrorCode.TickArraySequenceInvalid
+    );
+  });
+
+  /**
+   * |---a-c2--(5632)-----|------(0)--------|---c1--(11264)--a-|
+   */
+  it("on first array, 2nd array is not sequential, a->b", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 2, offsetIndex: 44 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          { arrayIndex: 1, offsetIndex: 10 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const aToB = true;
+    const tickArrays = await getTickArrays(
+      [11264, 0, 5632],
+      ctx,
+      AddressUtil.toPubKey(whirlpool.getAddress()),
+      fetcher
+    );
+    assert.throws(
+      () =>
+        swapQuoteWithParamsImpl({
+          aToB,
+          amountSpecifiedIsInput: true,
+          slippageTolerance,
+          tokenAmount: new u64("10000"),
+          whirlpoolData,
+          tickArrays,
+          sqrtPriceLimit: getDefaultSqrtPriceLimit(aToB),
+          otherAmountThreshold: ZERO,
+        }),
+      (err) => {
+        const whirlErr = err as WhirlpoolsError;
+        const errorCodeMatch = whirlErr.errorCode === SwapErrorCode.TickArraySequenceInvalid;
+        const messageMatch = whirlErr.message.indexOf("TickArray at index 1 is unexpected") >= 0;
+        return errorCodeMatch && messageMatch;
+      }
+    );
+  });
+
+  /**
+   * |-a--(-11264)---c1---|--------(0)------|----(-5632)---c2--a-|
+   */
+  it("on first array, 2nd array is not sequential, b->a", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -2, offsetIndex: 44 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          { arrayIndex: -2, offsetIndex: 10 },
+          { arrayIndex: -1, offsetIndex: TICK_ARRAY_SIZE - 2 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const aToB = false;
+    const tickArrays = await getTickArrays(
+      [-11264, 0, -5632],
+      ctx,
+      AddressUtil.toPubKey(whirlpool.getAddress()),
+      fetcher
+    );
+    assert.throws(
+      () =>
+        swapQuoteWithParamsImpl({
+          aToB,
+          amountSpecifiedIsInput: true,
+          slippageTolerance,
+          tokenAmount: new u64("10000"),
+          whirlpoolData,
+          tickArrays,
+          sqrtPriceLimit: getDefaultSqrtPriceLimit(aToB),
+          otherAmountThreshold: ZERO,
+        }),
+      (err) => {
+        const whirlErr = err as WhirlpoolsError;
+        const errorCodeMatch = whirlErr.errorCode === SwapErrorCode.TickArraySequenceInvalid;
+        const messageMatch = whirlErr.message.indexOf("TickArray at index 1 is unexpected") >= 0;
+        return errorCodeMatch && messageMatch;
+      }
+    );
+  });
+
+  /**
+   * |-------(5632)------|-------(5632)------|---c2--(5632)-c1---|
+   */
+  it("3 identical arrays, 1st contains curr_tick_index, a->b", async () => {
+    const currIndex = arrayTickIndexToTickIndex(
+      { arrayIndex: 1, offsetIndex: TICK_ARRAY_SIZE - 4 },
+      tickSpacing
+    );
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [5632],
+      fundedPositions: [
+        buildPosition(
+          { arrayIndex: 1, offsetIndex: 0 },
+          { arrayIndex: 1, offsetIndex: TICK_ARRAY_SIZE - 1 },
+          tickSpacing,
+          new BN(250_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const aToB = true;
+    const tickArrays = await getTickArrays(
+      [5632, 5632, 5632],
+      ctx,
+      AddressUtil.toPubKey(whirlpool.getAddress()),
+      fetcher
+    );
+    const tradeAmount = new u64("33588");
+    const quote = swapQuoteWithParamsImpl({
+      aToB,
+      amountSpecifiedIsInput: true,
+      slippageTolerance,
+      tokenAmount: tradeAmount,
+      whirlpoolData,
+      tickArrays,
+      sqrtPriceLimit: getDefaultSqrtPriceLimit(aToB),
+      otherAmountThreshold: ZERO,
+    });
+
+    // Verify with an actual swap.
+    assert.equal(quote.aToB, aToB);
+    assert.equal(quote.amountSpecifiedIsInput, true);
+    assert.equal(quote.sqrtPriceLimit.toString(), getDefaultSqrtPriceLimit(aToB).toString());
+    assert.equal(quote.otherAmountThreshold, ZERO);
+    assert.equal(
+      quote.estimatedAmountIn.toString(),
+      adjustForSlippage(tradeAmount, slippageTolerance, true).toString()
+    );
+    assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+  });
+
+  /**
+   * |---c1--(5632)-c2---|-------(5632)------|-------(5632)------|
+   */
+  it("3 identical arrays, 1st contains curr_tick_index, b->a", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 4 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [5632],
+      fundedPositions: [
+        buildPosition(
+          { arrayIndex: 1, offsetIndex: 0 },
+          { arrayIndex: 1, offsetIndex: TICK_ARRAY_SIZE - 1 },
+          tickSpacing,
+          new BN(250_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const aToB = false;
+    const tickArrays = await getTickArrays(
+      [5632, 5632, 5632],
+      ctx,
+      AddressUtil.toPubKey(whirlpool.getAddress()),
+      fetcher
+    );
+    const tradeAmount = new u64("33588");
+    const quote = swapQuoteWithParamsImpl({
+      aToB,
+      amountSpecifiedIsInput: true,
+      slippageTolerance,
+      tokenAmount: tradeAmount,
+      whirlpoolData,
+      tickArrays,
+      sqrtPriceLimit: getDefaultSqrtPriceLimit(aToB),
+      otherAmountThreshold: ZERO,
+    });
+
+    // Verify with an actual swap.
+    assert.equal(quote.aToB, aToB);
+    assert.equal(quote.amountSpecifiedIsInput, true);
+    assert.equal(quote.sqrtPriceLimit.toString(), getDefaultSqrtPriceLimit(aToB).toString());
+    assert.equal(quote.otherAmountThreshold, ZERO);
+    assert.equal(
+      quote.estimatedAmountIn.toString(),
+      adjustForSlippage(tradeAmount, slippageTolerance, true).toString()
+    );
+    assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+  });
+});

--- a/sdk/tests/sdk/whirlpools/swap/swap-array.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/swap-array.test.ts
@@ -9,8 +9,8 @@ import {
   TICK_ARRAY_SIZE,
   swapQuoteByInputToken,
   PDAUtil,
-  getDefaultSqrtPriceLimit,
-  PoolUtil,
+  SwapUtils,
+  swapQuoteWithParams,
 } from "../../../../src";
 import {
   arrayTickIndexToTickIndex,
@@ -20,7 +20,6 @@ import {
 import { AddressUtil, Percentage, ZERO } from "@orca-so/common-sdk";
 import { TickSpacing } from "../../../utils";
 import { u64 } from "@solana/spl-token";
-import { swapQuoteWithParamsImpl } from "../../../../src/quotes/swap/swap-quote-impl";
 import { SwapErrorCode, WhirlpoolsError } from "../../../../src/errors/errors";
 import { adjustForSlippage } from "../../../../src/utils/position-util";
 import { getTickArrays } from "../../../utils/testDataTypes";
@@ -33,7 +32,7 @@ describe("swap arrays test", async () => {
   const fetcher = new AccountFetcher(ctx.connection);
   const client = buildWhirlpoolClient(ctx, fetcher);
   const tickSpacing = TickSpacing.SixtyFour;
-  const slippageTolerance = Percentage.fromFraction(1, 100);
+  const slippageTolerance = Percentage.fromFraction(0, 100);
 
   /**
    * |-------------c2-----|xxxxxxxxxxxxxxxxx|------c1-----------|
@@ -65,10 +64,9 @@ describe("swap arrays test", async () => {
         whirlpool,
         whirlpoolData.tokenMintA,
         new u64(10000),
-        true,
         slippageTolerance,
-        fetcher,
         ctx.program.programId,
+        fetcher,
         true
       ),
       (err: Error) => err.message.indexOf(expectedError) != -1
@@ -105,10 +103,9 @@ describe("swap arrays test", async () => {
         whirlpool,
         whirlpoolData.tokenMintB,
         new u64(10000),
-        true,
         slippageTolerance,
-        fetcher,
         ctx.program.programId,
+        fetcher,
         true
       ),
       (err: Error) => err.message.indexOf(expectedError) != -1
@@ -139,7 +136,7 @@ describe("swap arrays test", async () => {
 
     const whirlpoolData = await whirlpool.refreshData();
     const aToB = true;
-    const tickArrays = await PoolUtil.getTickArraysForSwap(
+    const tickArrays = await SwapUtils.getTickArrays(
       arrayTickIndexToTickIndex({ arrayIndex: 0, offsetIndex: 10 }, tickSpacing),
       tickSpacing,
       aToB,
@@ -150,14 +147,14 @@ describe("swap arrays test", async () => {
     );
     assert.throws(
       () =>
-        swapQuoteWithParamsImpl({
+        swapQuoteWithParams({
           aToB,
           amountSpecifiedIsInput: true,
           slippageTolerance,
           tokenAmount: new u64("10000"),
           whirlpoolData,
           tickArrays,
-          sqrtPriceLimit: getDefaultSqrtPriceLimit(aToB),
+          sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
           otherAmountThreshold: ZERO,
         }),
       (err) => (err as WhirlpoolsError).errorCode === SwapErrorCode.TickArraySequenceInvalid
@@ -188,7 +185,7 @@ describe("swap arrays test", async () => {
 
     const whirlpoolData = await whirlpool.getData();
     const aToB = false;
-    const tickArrays = await PoolUtil.getTickArraysForSwap(
+    const tickArrays = await SwapUtils.getTickArrays(
       arrayTickIndexToTickIndex({ arrayIndex: 0, offsetIndex: 10 }, tickSpacing),
       tickSpacing,
       aToB,
@@ -199,14 +196,14 @@ describe("swap arrays test", async () => {
     );
     assert.throws(
       () =>
-        swapQuoteWithParamsImpl({
+        swapQuoteWithParams({
           aToB,
           amountSpecifiedIsInput: true,
           slippageTolerance,
           tokenAmount: new u64("10000"),
           whirlpoolData,
           tickArrays,
-          sqrtPriceLimit: getDefaultSqrtPriceLimit(aToB),
+          sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
           otherAmountThreshold: ZERO,
         }),
       (err) => (err as WhirlpoolsError).errorCode === SwapErrorCode.TickArraySequenceInvalid
@@ -236,7 +233,7 @@ describe("swap arrays test", async () => {
 
     const whirlpoolData = await whirlpool.refreshData();
     const aToB = true;
-    const tickArrays = await PoolUtil.getTickArraysForSwap(
+    const tickArrays = await SwapUtils.getTickArrays(
       arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 10 }, tickSpacing),
       tickSpacing,
       aToB,
@@ -247,14 +244,14 @@ describe("swap arrays test", async () => {
     );
     assert.throws(
       () =>
-        swapQuoteWithParamsImpl({
+        swapQuoteWithParams({
           aToB,
           amountSpecifiedIsInput: true,
           slippageTolerance,
           tokenAmount: new u64("10000"),
           whirlpoolData,
           tickArrays,
-          sqrtPriceLimit: getDefaultSqrtPriceLimit(aToB),
+          sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
           otherAmountThreshold: ZERO,
         }),
       (err) => (err as WhirlpoolsError).errorCode === SwapErrorCode.TickArraySequenceInvalid
@@ -284,7 +281,7 @@ describe("swap arrays test", async () => {
 
     const whirlpoolData = await whirlpool.refreshData();
     const aToB = false;
-    const tickArrays = await PoolUtil.getTickArraysForSwap(
+    const tickArrays = await SwapUtils.getTickArrays(
       arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 10 }, tickSpacing),
       tickSpacing,
       aToB,
@@ -296,14 +293,14 @@ describe("swap arrays test", async () => {
 
     assert.throws(
       () =>
-        swapQuoteWithParamsImpl({
+        swapQuoteWithParams({
           aToB,
           amountSpecifiedIsInput: true,
           slippageTolerance,
           tokenAmount: new u64("10000"),
           whirlpoolData,
           tickArrays,
-          sqrtPriceLimit: getDefaultSqrtPriceLimit(aToB),
+          sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
           otherAmountThreshold: ZERO,
         }),
       (err) => (err as WhirlpoolsError).errorCode === SwapErrorCode.TickArraySequenceInvalid
@@ -341,14 +338,14 @@ describe("swap arrays test", async () => {
     );
     assert.throws(
       () =>
-        swapQuoteWithParamsImpl({
+        swapQuoteWithParams({
           aToB,
           amountSpecifiedIsInput: true,
           slippageTolerance,
           tokenAmount: new u64("10000"),
           whirlpoolData,
           tickArrays,
-          sqrtPriceLimit: getDefaultSqrtPriceLimit(aToB),
+          sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
           otherAmountThreshold: ZERO,
         }),
       (err) => {
@@ -391,14 +388,14 @@ describe("swap arrays test", async () => {
     );
     assert.throws(
       () =>
-        swapQuoteWithParamsImpl({
+        swapQuoteWithParams({
           aToB,
           amountSpecifiedIsInput: true,
           slippageTolerance,
           tokenAmount: new u64("10000"),
           whirlpoolData,
           tickArrays,
-          sqrtPriceLimit: getDefaultSqrtPriceLimit(aToB),
+          sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
           otherAmountThreshold: ZERO,
         }),
       (err) => {
@@ -443,21 +440,24 @@ describe("swap arrays test", async () => {
       fetcher
     );
     const tradeAmount = new u64("33588");
-    const quote = swapQuoteWithParamsImpl({
+    const quote = swapQuoteWithParams({
       aToB,
       amountSpecifiedIsInput: true,
       slippageTolerance,
       tokenAmount: tradeAmount,
       whirlpoolData,
       tickArrays,
-      sqrtPriceLimit: getDefaultSqrtPriceLimit(aToB),
+      sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
       otherAmountThreshold: ZERO,
     });
 
     // Verify with an actual swap.
     assert.equal(quote.aToB, aToB);
     assert.equal(quote.amountSpecifiedIsInput, true);
-    assert.equal(quote.sqrtPriceLimit.toString(), getDefaultSqrtPriceLimit(aToB).toString());
+    assert.equal(
+      quote.sqrtPriceLimit.toString(),
+      SwapUtils.getDefaultSqrtPriceLimit(aToB).toString()
+    );
     assert.equal(quote.otherAmountThreshold, ZERO);
     assert.equal(
       quote.estimatedAmountIn.toString(),
@@ -496,21 +496,24 @@ describe("swap arrays test", async () => {
       fetcher
     );
     const tradeAmount = new u64("33588");
-    const quote = swapQuoteWithParamsImpl({
+    const quote = swapQuoteWithParams({
       aToB,
       amountSpecifiedIsInput: true,
       slippageTolerance,
       tokenAmount: tradeAmount,
       whirlpoolData,
       tickArrays,
-      sqrtPriceLimit: getDefaultSqrtPriceLimit(aToB),
+      sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
       otherAmountThreshold: ZERO,
     });
 
     // Verify with an actual swap.
     assert.equal(quote.aToB, aToB);
     assert.equal(quote.amountSpecifiedIsInput, true);
-    assert.equal(quote.sqrtPriceLimit.toString(), getDefaultSqrtPriceLimit(aToB).toString());
+    assert.equal(
+      quote.sqrtPriceLimit.toString(),
+      SwapUtils.getDefaultSqrtPriceLimit(aToB).toString()
+    );
     assert.equal(quote.otherAmountThreshold, ZERO);
     assert.equal(
       quote.estimatedAmountIn.toString(),

--- a/sdk/tests/sdk/whirlpools/swap/swap-array.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/swap-array.test.ts
@@ -147,16 +147,18 @@ describe("swap arrays test", async () => {
     );
     assert.throws(
       () =>
-        swapQuoteWithParams({
-          aToB,
-          amountSpecifiedIsInput: true,
-          slippageTolerance,
-          tokenAmount: new u64("10000"),
-          whirlpoolData,
-          tickArrays,
-          sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
-          otherAmountThreshold: ZERO,
-        }),
+        swapQuoteWithParams(
+          {
+            aToB,
+            amountSpecifiedIsInput: true,
+            tokenAmount: new u64("10000"),
+            whirlpoolData,
+            tickArrays,
+            sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
+            otherAmountThreshold: ZERO,
+          },
+          slippageTolerance
+        ),
       (err) => (err as WhirlpoolsError).errorCode === SwapErrorCode.TickArraySequenceInvalid
     );
   });
@@ -196,16 +198,18 @@ describe("swap arrays test", async () => {
     );
     assert.throws(
       () =>
-        swapQuoteWithParams({
-          aToB,
-          amountSpecifiedIsInput: true,
-          slippageTolerance,
-          tokenAmount: new u64("10000"),
-          whirlpoolData,
-          tickArrays,
-          sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
-          otherAmountThreshold: ZERO,
-        }),
+        swapQuoteWithParams(
+          {
+            aToB,
+            amountSpecifiedIsInput: true,
+            tokenAmount: new u64("10000"),
+            whirlpoolData,
+            tickArrays,
+            sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
+            otherAmountThreshold: ZERO,
+          },
+          slippageTolerance
+        ),
       (err) => (err as WhirlpoolsError).errorCode === SwapErrorCode.TickArraySequenceInvalid
     );
   });
@@ -244,16 +248,18 @@ describe("swap arrays test", async () => {
     );
     assert.throws(
       () =>
-        swapQuoteWithParams({
-          aToB,
-          amountSpecifiedIsInput: true,
-          slippageTolerance,
-          tokenAmount: new u64("10000"),
-          whirlpoolData,
-          tickArrays,
-          sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
-          otherAmountThreshold: ZERO,
-        }),
+        swapQuoteWithParams(
+          {
+            aToB,
+            amountSpecifiedIsInput: true,
+            tokenAmount: new u64("10000"),
+            whirlpoolData,
+            tickArrays,
+            sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
+            otherAmountThreshold: ZERO,
+          },
+          slippageTolerance
+        ),
       (err) => (err as WhirlpoolsError).errorCode === SwapErrorCode.TickArraySequenceInvalid
     );
   });
@@ -293,16 +299,18 @@ describe("swap arrays test", async () => {
 
     assert.throws(
       () =>
-        swapQuoteWithParams({
-          aToB,
-          amountSpecifiedIsInput: true,
-          slippageTolerance,
-          tokenAmount: new u64("10000"),
-          whirlpoolData,
-          tickArrays,
-          sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
-          otherAmountThreshold: ZERO,
-        }),
+        swapQuoteWithParams(
+          {
+            aToB,
+            amountSpecifiedIsInput: true,
+            tokenAmount: new u64("10000"),
+            whirlpoolData,
+            tickArrays,
+            sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
+            otherAmountThreshold: ZERO,
+          },
+          slippageTolerance
+        ),
       (err) => (err as WhirlpoolsError).errorCode === SwapErrorCode.TickArraySequenceInvalid
     );
   });
@@ -338,16 +346,18 @@ describe("swap arrays test", async () => {
     );
     assert.throws(
       () =>
-        swapQuoteWithParams({
-          aToB,
-          amountSpecifiedIsInput: true,
-          slippageTolerance,
-          tokenAmount: new u64("10000"),
-          whirlpoolData,
-          tickArrays,
-          sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
-          otherAmountThreshold: ZERO,
-        }),
+        swapQuoteWithParams(
+          {
+            aToB,
+            amountSpecifiedIsInput: true,
+            tokenAmount: new u64("10000"),
+            whirlpoolData,
+            tickArrays,
+            sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
+            otherAmountThreshold: ZERO,
+          },
+          slippageTolerance
+        ),
       (err) => {
         const whirlErr = err as WhirlpoolsError;
         const errorCodeMatch = whirlErr.errorCode === SwapErrorCode.TickArraySequenceInvalid;
@@ -388,16 +398,18 @@ describe("swap arrays test", async () => {
     );
     assert.throws(
       () =>
-        swapQuoteWithParams({
-          aToB,
-          amountSpecifiedIsInput: true,
-          slippageTolerance,
-          tokenAmount: new u64("10000"),
-          whirlpoolData,
-          tickArrays,
-          sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
-          otherAmountThreshold: ZERO,
-        }),
+        swapQuoteWithParams(
+          {
+            aToB,
+            amountSpecifiedIsInput: true,
+            tokenAmount: new u64("10000"),
+            whirlpoolData,
+            tickArrays,
+            sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
+            otherAmountThreshold: ZERO,
+          },
+          slippageTolerance
+        ),
       (err) => {
         const whirlErr = err as WhirlpoolsError;
         const errorCodeMatch = whirlErr.errorCode === SwapErrorCode.TickArraySequenceInvalid;
@@ -440,16 +452,18 @@ describe("swap arrays test", async () => {
       fetcher
     );
     const tradeAmount = new u64("33588");
-    const quote = swapQuoteWithParams({
-      aToB,
-      amountSpecifiedIsInput: true,
-      slippageTolerance,
-      tokenAmount: tradeAmount,
-      whirlpoolData,
-      tickArrays,
-      sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
-      otherAmountThreshold: ZERO,
-    });
+    const quote = swapQuoteWithParams(
+      {
+        aToB,
+        amountSpecifiedIsInput: true,
+        tokenAmount: tradeAmount,
+        whirlpoolData,
+        tickArrays,
+        sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
+        otherAmountThreshold: ZERO,
+      },
+      slippageTolerance
+    );
 
     // Verify with an actual swap.
     assert.equal(quote.aToB, aToB);
@@ -458,11 +472,11 @@ describe("swap arrays test", async () => {
       quote.sqrtPriceLimit.toString(),
       SwapUtils.getDefaultSqrtPriceLimit(aToB).toString()
     );
-    assert.equal(quote.otherAmountThreshold, ZERO);
     assert.equal(
-      quote.estimatedAmountIn.toString(),
-      adjustForSlippage(tradeAmount, slippageTolerance, true).toString()
+      quote.otherAmountThreshold.toString(),
+      adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
     );
+    assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
     assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
   });
 
@@ -496,16 +510,18 @@ describe("swap arrays test", async () => {
       fetcher
     );
     const tradeAmount = new u64("33588");
-    const quote = swapQuoteWithParams({
-      aToB,
-      amountSpecifiedIsInput: true,
-      slippageTolerance,
-      tokenAmount: tradeAmount,
-      whirlpoolData,
-      tickArrays,
-      sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
-      otherAmountThreshold: ZERO,
-    });
+    const quote = swapQuoteWithParams(
+      {
+        aToB,
+        amountSpecifiedIsInput: true,
+        tokenAmount: tradeAmount,
+        whirlpoolData,
+        tickArrays,
+        sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
+        otherAmountThreshold: ZERO,
+      },
+      slippageTolerance
+    );
 
     // Verify with an actual swap.
     assert.equal(quote.aToB, aToB);
@@ -514,11 +530,11 @@ describe("swap arrays test", async () => {
       quote.sqrtPriceLimit.toString(),
       SwapUtils.getDefaultSqrtPriceLimit(aToB).toString()
     );
-    assert.equal(quote.otherAmountThreshold, ZERO);
     assert.equal(
-      quote.estimatedAmountIn.toString(),
-      adjustForSlippage(tradeAmount, slippageTolerance, true).toString()
+      quote.otherAmountThreshold.toString(),
+      adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
     );
+    assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
     assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
   });
 });

--- a/sdk/tests/sdk/whirlpools/swap/swap-traverse.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/swap-traverse.test.ts
@@ -164,11 +164,9 @@ describe("swap traversal tests", async () => {
   });
 
   /**
-   * // TODO: 0x1787
-   * // setting tick to [1, 1] works. but [1,0] (on the first tick) will fail the contract
    * b|-----x2---------|a---------------|a,x1-------------b|
    */
-  it.skip("curr_index on the first initializable tick, a->b", async () => {
+  it("curr_index on the first initializable tick, a->b", async () => {
     const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 0 }, tickSpacing);
     const aToB = true;
     const whirlpool = await setupSwapTest({
@@ -459,10 +457,9 @@ describe("swap traversal tests", async () => {
   });
 
   /**
-   * TODO: 0x1787
    * |-----------b--x2--|-------a-----b-----|x1,a-------------|
    */
-  it.skip("curr_index btw end of last offset and next array, with the next tick initialized, a->b", async () => {
+  it("curr_index btw end of last offset and next array, with the next tick initialized, a->b", async () => {
     const currIndex = 11264 + 30;
     const aToB = true;
     const whirlpool = await setupSwapTest({

--- a/sdk/tests/sdk/whirlpools/swap/swap-traverse.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/swap-traverse.test.ts
@@ -1,0 +1,890 @@
+import * as anchor from "@project-serum/anchor";
+import * as assert from "assert";
+import {
+  WhirlpoolContext,
+  AccountFetcher,
+  buildWhirlpoolClient,
+  PriceMath,
+  TICK_ARRAY_SIZE,
+  swapQuoteByInputToken,
+  MAX_TICK_INDEX,
+  MIN_TICK_INDEX,
+  SwapQuote,
+  WhirlpoolData,
+  SwapInput,
+} from "../../../../src";
+import { assertQuoteAndResults, getTokenBalance, TickSpacing } from "../../../utils";
+import { Percentage } from "@orca-so/common-sdk";
+import { u64 } from "@solana/spl-token";
+import { BN } from "bn.js";
+import {
+  arrayTickIndexToTickIndex,
+  buildPosition,
+  setupSwapTest,
+} from "../../../utils/swap-test-utils";
+import { SwapErrorCode, WhirlpoolsError } from "../../../../src/errors/errors";
+import { getVaultAmounts } from "../../../utils/whirlpools-test-utils";
+
+describe("swap traversal tests", async () => {
+  const provider = anchor.Provider.local();
+  anchor.setProvider(anchor.Provider.env());
+  const program = anchor.workspace.Whirlpool;
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
+  const fetcher = new AccountFetcher(ctx.connection);
+  const client = buildWhirlpoolClient(ctx, fetcher);
+  const tickSpacing = TickSpacing.SixtyFour;
+  const slippageTolerance = Percentage.fromFraction(0, 100);
+
+  /**
+   * Swap - a->b
+   * Curr - last initializable tick
+   * |--------------------|b-----x2----a-------b-|x1-a------------------|
+   */
+  it("curr_index on the last initializable tick, a->b", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 0, offsetIndex: 15 }, tickSpacing);
+    const aToB = true;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -1, offsetIndex: 44 },
+          { arrayIndex: 0, offsetIndex: 30 },
+          tickSpacing,
+          new BN(250_000)
+        ),
+        buildPosition(
+          //b
+          { arrayIndex: -1, offsetIndex: 0 },
+          { arrayIndex: -1, offsetIndex: TICK_ARRAY_SIZE - 1 },
+          tickSpacing,
+          new BN(350_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      new u64(150000),
+      true,
+      slippageTolerance,
+      fetcher,
+      ctx.program.programId,
+      true
+    );
+
+    await (await whirlpool.swap(quote)).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(aToB, quote, newData, beforeVaultAmounts, afterVaultAmounts);
+  });
+
+  /**
+   * |--------------------x1,a|-b--------a----x2---b-|-------------------|
+   */
+  it("curr_index on the last initializable tick, b->a", async () => {
+    const currIndex = arrayTickIndexToTickIndex(
+      { arrayIndex: 0, offsetIndex: TICK_ARRAY_SIZE - 1 },
+      tickSpacing
+    );
+    const aToB = false;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: 0, offsetIndex: TICK_ARRAY_SIZE - 1 },
+          { arrayIndex: 1, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+        buildPosition(
+          //b
+          { arrayIndex: 1, offsetIndex: 0 },
+          { arrayIndex: 1, offsetIndex: TICK_ARRAY_SIZE - 1 },
+          tickSpacing,
+          new BN(350_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      new u64(190000000),
+      true,
+      slippageTolerance,
+      fetcher,
+      ctx.program.programId,
+      true
+    );
+    await (await whirlpool.swap(quote)).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(aToB, quote, newData, beforeVaultAmounts, afterVaultAmounts);
+  });
+
+  /**
+   * // TODO: 0x1787
+   * // setting tick to [1, 1] works. but [1,0] (on the first tick) will fail the contract
+   * b|-----x2---------|a---------------|a,x1-------------b|
+   */
+  it("curr_index on the first initializable tick, a->b", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 0 }, tickSpacing);
+    const aToB = true;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: 0, offsetIndex: 0 },
+          { arrayIndex: 1, offsetIndex: 0 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+        buildPosition(
+          //b
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: TICK_ARRAY_SIZE - 1 },
+          tickSpacing,
+          new BN(350_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      new u64(200000000),
+      true,
+      slippageTolerance,
+      fetcher,
+      ctx.program.programId,
+      true
+    );
+    await (await whirlpool.swap(quote)).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(aToB, quote, newData, beforeVaultAmounts, afterVaultAmounts);
+  });
+
+  /**
+   * b|a,x1--------------|a---------------|---------x2--------b|
+   */
+  it("curr_index on the first initializable tick, b->a", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 0, offsetIndex: 0 }, tickSpacing);
+    const aToB = false;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: 0, offsetIndex: 0 },
+          { arrayIndex: 1, offsetIndex: 0 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+        buildPosition(
+          //b
+          { arrayIndex: -1, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: TICK_ARRAY_SIZE - 1 },
+          tickSpacing,
+          new BN(350_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      new u64(450000000),
+      true,
+      slippageTolerance,
+      fetcher,
+      ctx.program.programId,
+      true
+    );
+    await (await whirlpool.swap(quote)).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(aToB, quote, newData, beforeVaultAmounts, afterVaultAmounts);
+  });
+
+  /**
+   * |--------b-----x1-a|------a---x2---b--|-------------------|
+   */
+  it("curr_index on the 2nd last initialized tick, with the next tick initialized, b->a", async () => {
+    const currIndex = arrayTickIndexToTickIndex(
+      { arrayIndex: 0, offsetIndex: TICK_ARRAY_SIZE - 2 }, // 5504
+      tickSpacing
+    );
+    const aToB = false;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: 0, offsetIndex: TICK_ARRAY_SIZE - 1 },
+          { arrayIndex: 1, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+        buildPosition(
+          //b
+          { arrayIndex: 0, offsetIndex: 44 },
+          { arrayIndex: 1, offsetIndex: TICK_ARRAY_SIZE - 4 },
+          tickSpacing,
+          new BN(350_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      new u64(150000000),
+      true,
+      slippageTolerance,
+      fetcher,
+      ctx.program.programId,
+      true
+    );
+    await (await whirlpool.swap(quote)).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(aToB, quote, newData, beforeVaultAmounts, afterVaultAmounts);
+  });
+
+  /**
+   * |-----------b--x2--|-------a-----b-----|a-x1-------------|
+   */
+  it("curr_index on the 2nd initialized tick, with the first tick initialized, a->b", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 2, offsetIndex: 1 }, tickSpacing);
+    const aToB = true;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: 1, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 0 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+        buildPosition(
+          //b
+          { arrayIndex: 0, offsetIndex: 44 },
+          { arrayIndex: 1, offsetIndex: 64 },
+          tickSpacing,
+          new BN(350_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      new u64(75000000),
+      true,
+      slippageTolerance,
+      fetcher,
+      ctx.program.programId,
+      true
+    );
+    await (await whirlpool.swap(quote)).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(aToB, quote, newData, beforeVaultAmounts, afterVaultAmounts);
+  });
+
+  /**
+   * |--------b-----a-x1|a---------x2---b--|-------------------|
+   */
+  it("curr_index btw end of last offset and next array, with the next tick initialized, b->a", async () => {
+    const currIndex = 5629;
+    const aToB = false;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: 0, offsetIndex: TICK_ARRAY_SIZE - 1 },
+          { arrayIndex: 1, offsetIndex: 1 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+        buildPosition(
+          //b
+          { arrayIndex: 0, offsetIndex: 44 },
+          { arrayIndex: 1, offsetIndex: TICK_ARRAY_SIZE - 4 },
+          tickSpacing,
+          new BN(350_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      new u64(15000000),
+      true,
+      slippageTolerance,
+      fetcher,
+      ctx.program.programId,
+      true
+    );
+    await (await whirlpool.swap(quote)).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(aToB, quote, newData, beforeVaultAmounts, afterVaultAmounts);
+  });
+
+  /**
+   * TODO: 0x1787
+   * |-----------b--x2--|-------a-----b-----|x1,a-------------|
+   */
+  it("curr_index btw end of last offset and next array, with the next tick initialized, a->b", async () => {
+    const currIndex = 11264 + 30;
+    const aToB = true;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: 1, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 0 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+        buildPosition(
+          //b
+          { arrayIndex: 0, offsetIndex: 44 },
+          { arrayIndex: 1, offsetIndex: 64 },
+          tickSpacing,
+          new BN(350_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      new u64(7500000),
+      true,
+      slippageTolerance,
+      fetcher,
+      ctx.program.programId,
+      true
+    );
+    await (await whirlpool.swap(quote)).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(aToB, quote, newData, beforeVaultAmounts, afterVaultAmounts);
+  });
+
+  /**
+   * |----------------|-----a----x2-----b|--------x1----a---b----|
+   */
+  it("on some tick, traverse to the 1st initialized tick in the next tick-array, a->b", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 2, offsetIndex: 22 }, tickSpacing);
+    const aToB = true;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: 1, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+        buildPosition(
+          //b
+          { arrayIndex: 1, offsetIndex: TICK_ARRAY_SIZE - 1 },
+          { arrayIndex: 2, offsetIndex: 64 },
+          tickSpacing,
+          new BN(350_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      new u64(45000000),
+      true,
+      slippageTolerance,
+      fetcher,
+      ctx.program.programId,
+      true
+    );
+
+    await (await whirlpool.swap(quote)).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(aToB, quote, newData, beforeVaultAmounts, afterVaultAmounts);
+  });
+
+  /**
+   * |----a--b---x1------|a---x2-----b-------|------------------|
+   */
+  it("on some tick, traverse to the 1st initialized tick in the next tick-array, b->a", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -1, offsetIndex: 64 }, tickSpacing);
+    const aToB = false;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-5632, 0, 5632],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -1, offsetIndex: 10 },
+          { arrayIndex: 0, offsetIndex: 0 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+        buildPosition(
+          //b
+          { arrayIndex: -1, offsetIndex: 22 },
+          { arrayIndex: 0, offsetIndex: 64 },
+          tickSpacing,
+          new BN(350_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      new u64(49500000),
+      true,
+      slippageTolerance,
+      fetcher,
+      ctx.program.programId,
+      true
+    );
+    await (await whirlpool.swap(quote)).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(aToB, quote, newData, beforeVaultAmounts, afterVaultAmounts);
+  });
+
+  /**
+   * |-------a----x2------|-----------------|----x1-----a-------|
+   */
+  it("on some tick, traverse to the next tick in the n+2 tick-array, a->b", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 22 }, tickSpacing);
+    const aToB = true;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-5632, 0, 5632],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -1, offsetIndex: 10 },
+          { arrayIndex: 1, offsetIndex: 23 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      new u64(119500000),
+      true,
+      slippageTolerance,
+      fetcher,
+      ctx.program.programId,
+      true
+    );
+    await (await whirlpool.swap(quote)).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(aToB, quote, newData, beforeVaultAmounts, afterVaultAmounts);
+  });
+
+  /**
+   * |-------a------x1----|-----------------|-----x2--------a---|
+   */
+  it("on some tick, traverse to the next tick in the n+2 tick-array, b->a", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -1, offsetIndex: 22 }, tickSpacing);
+    const aToB = false;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-5632, 0, 5632],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -1, offsetIndex: 10 },
+          { arrayIndex: 1, offsetIndex: 23 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      new u64(119500000),
+      true,
+      slippageTolerance,
+      fetcher,
+      ctx.program.programId,
+      true
+    );
+    await (await whirlpool.swap(quote)).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(aToB, quote, newData, beforeVaultAmounts, afterVaultAmounts);
+  });
+
+  /**
+   * a|----------------|-----------------|-------x1--------|a
+   */
+  it("3 arrays, on some initialized tick, no other initialized tick in the sequence, a->b", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 22 }, tickSpacing);
+    const aToB = true;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 10 },
+          { arrayIndex: 2, offsetIndex: 23 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      new u64(119500000),
+      true,
+      slippageTolerance,
+      fetcher,
+      ctx.program.programId,
+      true
+    );
+    await (await whirlpool.swap(quote)).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(aToB, quote, newData, beforeVaultAmounts, afterVaultAmounts);
+  });
+
+  /**
+   * |-----x1-------------|-----------------|-------------------|
+   */
+  it("3 arrays, on some initialized tick, no other initialized tick in the sequence, b->a", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -1, offsetIndex: 22 }, tickSpacing);
+    const aToB = false;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 10 },
+          { arrayIndex: 2, offsetIndex: 23 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      new u64(159500000),
+      true,
+      slippageTolerance,
+      fetcher,
+      ctx.program.programId,
+      true
+    );
+    await (await whirlpool.swap(quote)).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(aToB, quote, newData, beforeVaultAmounts, afterVaultAmounts);
+  });
+
+  /**
+   * trade amount > liquidity
+   * |----------x1----------|-----------------|-------------------|
+   */
+  it("3 arrays, trade amount exceeds liquidity available in array sequence, b->a", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -1, offsetIndex: 22 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 10 },
+          { arrayIndex: 2, offsetIndex: 23 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    await assert.rejects(
+      async () =>
+        await swapQuoteByInputToken(
+          whirlpool,
+          whirlpoolData.tokenMintB,
+          new u64(9159500000),
+          true,
+          slippageTolerance,
+          fetcher,
+          ctx.program.programId,
+          true
+        ),
+      (err) => {
+        const whirlErr = err as WhirlpoolsError;
+        const errorMatch = whirlErr.errorCode === SwapErrorCode.TickArraySequenceInvalid;
+        // Message contains failure on finding beyond tickIndex
+        const messageMatch = whirlErr.message.indexOf("11264") >= 0;
+        assert.ok(messageMatch, "Error Message must match condition.");
+        assert.ok(errorMatch, "Error Code must match condition.");
+        return true;
+      }
+    );
+  });
+
+  /**
+   * trade amount > liquidity
+   * |--------------------|-----------------|---------x1----------|
+   */
+  it("3 arrays, trade amount exceeds liquidity available in array sequence, a->b", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 22 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 10 },
+          { arrayIndex: 2, offsetIndex: 23 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    await assert.rejects(
+      async () =>
+        await swapQuoteByInputToken(
+          whirlpool,
+          whirlpoolData.tokenMintA,
+          new u64(9159500000),
+          true,
+          slippageTolerance,
+          fetcher,
+          ctx.program.programId,
+          true
+        ),
+      (err) => {
+        const whirlErr = err as WhirlpoolsError;
+        const errorMatch = whirlErr.errorCode === SwapErrorCode.TickArraySequenceInvalid;
+        // Message contains failure on finding beyond tickIndex
+        const messageMatch = whirlErr.message.indexOf("-5696") >= 0;
+        assert.ok(messageMatch, "Error Message must match condition.");
+        assert.ok(errorMatch, "Error Code must match condition.");
+        return true;
+      }
+    );
+  });
+
+  /**
+   * |a--------x1----------a| Max
+   */
+  it("on the last tick-array, traverse to the MAX_TICK_INDEX tick", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 78, offsetIndex: 22 }, tickSpacing);
+    const aToB = false;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [MAX_TICK_INDEX],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: 78, offsetIndex: 0 }, // 439,296
+          { arrayIndex: 78, offsetIndex: 67 }, // 443,584
+          tickSpacing,
+          new BN(250)
+        ),
+      ],
+      tokenMintAmount: new BN("95000000000000000"),
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      new u64("12595000000000"),
+      true,
+      slippageTolerance,
+      fetcher,
+      ctx.program.programId,
+      true
+    );
+    await (await whirlpool.swap(quote)).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(aToB, quote, newData, beforeVaultAmounts, afterVaultAmounts);
+  });
+
+  /**
+   * Min |a--------x2--------a----|-----------------|-------------------|
+   */
+  it("on the first tick-array, traverse to the MIN_TICK_INDEX tick", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -79, offsetIndex: 22 }, tickSpacing);
+    const aToB = true;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [MIN_TICK_INDEX],
+      fundedPositions: [
+        buildPosition(
+          // a -444,928
+          { arrayIndex: -79, offsetIndex: 21 },
+          { arrayIndex: -79, offsetIndex: TICK_ARRAY_SIZE - 1 },
+          tickSpacing,
+          new BN(250)
+        ),
+      ],
+      tokenMintAmount: new BN("95000000000000000"),
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      new u64("12595000000000"),
+      true,
+      slippageTolerance,
+      fetcher,
+      ctx.program.programId,
+      true
+    );
+    await (await whirlpool.swap(quote)).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(aToB, quote, newData, beforeVaultAmounts, afterVaultAmounts);
+  });
+});

--- a/sdk/tests/sdk/whirlpools/swap/swap-traverse.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/swap-traverse.test.ts
@@ -9,17 +9,9 @@ import {
   swapQuoteByInputToken,
   MAX_TICK_INDEX,
   MIN_TICK_INDEX,
-  SwapQuote,
-  WhirlpoolData,
-  SwapInput,
   swapQuoteByOutputToken,
 } from "../../../../src";
-import {
-  assertInputOutputQuoteEqual,
-  assertQuoteAndResults,
-  getTokenBalance,
-  TickSpacing,
-} from "../../../utils";
+import { assertInputOutputQuoteEqual, assertQuoteAndResults, TickSpacing } from "../../../utils";
 import { Percentage } from "@orca-so/common-sdk";
 import { u64 } from "@solana/spl-token";
 import { BN } from "bn.js";

--- a/sdk/tests/sdk/whirlpools/utils/pool-utils.test.ts
+++ b/sdk/tests/sdk/whirlpools/utils/pool-utils.test.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import { PoolUtil, SwapDirection, TokenType } from "../../../../src";
+import { TokenType, PoolUtil } from "../../../../src";
 import { testWhirlpoolData } from "../../../utils/testDataTypes";
 import { Keypair } from "@solana/web3.js";
 
@@ -21,44 +21,6 @@ describe("PoolUtils tests", () => {
       const whirlpoolData = testWhirlpoolData;
       const result = PoolUtil.getTokenType(whirlpoolData, Keypair.generate().publicKey);
       assert.ok(result === undefined);
-    });
-  });
-
-  describe("getSwapDirection", () => {
-    it("SwapToken is tokenA and is an input", async () => {
-      const whirlpoolData = testWhirlpoolData;
-      const result = PoolUtil.getSwapDirection(whirlpoolData, whirlpoolData.tokenMintA, true);
-      assert.equal(result, SwapDirection.AtoB);
-    });
-
-    it("SwapToken is tokenB and is an input", async () => {
-      const whirlpoolData = testWhirlpoolData;
-      const result = PoolUtil.getSwapDirection(whirlpoolData, whirlpoolData.tokenMintB, true);
-      assert.equal(result, SwapDirection.BtoA);
-    });
-
-    it("SwapToken is tokenA and is not an input", async () => {
-      const whirlpoolData = testWhirlpoolData;
-      const result = PoolUtil.getSwapDirection(whirlpoolData, whirlpoolData.tokenMintA, false);
-      assert.equal(result, SwapDirection.BtoA);
-    });
-
-    it("SwapToken is tokenB and is not an input", async () => {
-      const whirlpoolData = testWhirlpoolData;
-      const result = PoolUtil.getSwapDirection(whirlpoolData, whirlpoolData.tokenMintB, false);
-      assert.equal(result, SwapDirection.AtoB);
-    });
-
-    it("SwapToken is a random mint and is an input", async () => {
-      const whirlpoolData = testWhirlpoolData;
-      const result = PoolUtil.getSwapDirection(whirlpoolData, Keypair.generate().publicKey, true);
-      assert.equal(result, undefined);
-    });
-
-    it("SwapToken is a random mint and is not an input", async () => {
-      const whirlpoolData = testWhirlpoolData;
-      const result = PoolUtil.getSwapDirection(whirlpoolData, Keypair.generate().publicKey, false);
-      assert.equal(result, undefined);
     });
   });
 });

--- a/sdk/tests/sdk/whirlpools/utils/swap-utils.test.ts
+++ b/sdk/tests/sdk/whirlpools/utils/swap-utils.test.ts
@@ -1,0 +1,44 @@
+import * as assert from "assert";
+import { SwapUtils, SwapDirection } from "../../../../src";
+import { testWhirlpoolData } from "../../../utils/testDataTypes";
+import { Keypair } from "@solana/web3.js";
+
+describe("SwapUtils tests", () => {
+  describe("getSwapDirection", () => {
+    it("SwapToken is tokenA and is an input", async () => {
+      const whirlpoolData = testWhirlpoolData;
+      const result = SwapUtils.getSwapDirection(whirlpoolData, whirlpoolData.tokenMintA, true);
+      assert.equal(result, SwapDirection.AtoB);
+    });
+
+    it("SwapToken is tokenB and is an input", async () => {
+      const whirlpoolData = testWhirlpoolData;
+      const result = SwapUtils.getSwapDirection(whirlpoolData, whirlpoolData.tokenMintB, true);
+      assert.equal(result, SwapDirection.BtoA);
+    });
+
+    it("SwapToken is tokenA and is not an input", async () => {
+      const whirlpoolData = testWhirlpoolData;
+      const result = SwapUtils.getSwapDirection(whirlpoolData, whirlpoolData.tokenMintA, false);
+      assert.equal(result, SwapDirection.BtoA);
+    });
+
+    it("SwapToken is tokenB and is not an input", async () => {
+      const whirlpoolData = testWhirlpoolData;
+      const result = SwapUtils.getSwapDirection(whirlpoolData, whirlpoolData.tokenMintB, false);
+      assert.equal(result, SwapDirection.AtoB);
+    });
+
+    it("SwapToken is a random mint and is an input", async () => {
+      const whirlpoolData = testWhirlpoolData;
+      const result = SwapUtils.getSwapDirection(whirlpoolData, Keypair.generate().publicKey, true);
+      assert.equal(result, undefined);
+    });
+
+    it("SwapToken is a random mint and is not an input", async () => {
+      const whirlpoolData = testWhirlpoolData;
+      const result = SwapUtils.getSwapDirection(whirlpoolData, Keypair.generate().publicKey, false);
+      assert.equal(result, undefined);
+    });
+  });
+});

--- a/sdk/tests/sdk/whirlpools/utils/tick-array-sequence.test.ts
+++ b/sdk/tests/sdk/whirlpools/utils/tick-array-sequence.test.ts
@@ -1,0 +1,209 @@
+import { TICK_ARRAY_SIZE } from "../../../../src";
+import * as assert from "assert";
+import { TickArraySequence } from "../../../../src/quotes/swap/tick-array-sequence";
+import { buildTickArrayData, testEmptyTickArrray } from "../../../utils/testDataTypes";
+import { TickArrayIndex } from "../../../../src/quotes/swap/tick-array-index";
+import { Whirlpool } from "../../../../src/artifacts/whirlpool";
+import { SwapErrorCode, WhirlpoolsError } from "../../../../src/errors/errors";
+
+describe("TickArray Sequence tests", () => {
+  const ts64 = 64;
+  const ts128 = 128;
+
+  describe("checkArrayContainsTickIndex tests", () => {
+    const ta0 = buildTickArrayData(0, [0, 32, 63]);
+    const ta1 = buildTickArrayData(ts64 * TICK_ARRAY_SIZE * -1, [0, 50]);
+    const ta2 = buildTickArrayData(ts64 * TICK_ARRAY_SIZE * -2, [25, 50]);
+
+    it("a->b, arrayIndex 0 contains index", () => {
+      const seq = new TickArraySequence([ta0, ta1, ta2], ts64, true);
+      assert.ok(seq.checkArrayContainsTickIndex(0, 250));
+    });
+
+    it("a->b, arrayIndex 0 does not contain index", () => {
+      const seq = new TickArraySequence([ta0, ta1, ta2], ts64, true);
+      assert.ok(!seq.checkArrayContainsTickIndex(0, -64));
+    });
+
+    it("b->a, arrayIndex 0 contains index", () => {
+      const seq = new TickArraySequence([ta2, ta1, ta0], ts64, false);
+      assert.ok(seq.checkArrayContainsTickIndex(0, -10000));
+    });
+
+    it("a->b, arrayIndex 0 does not contain index", () => {
+      const seq = new TickArraySequence([ta2, ta1, ta0], ts64, false);
+      assert.ok(!seq.checkArrayContainsTickIndex(0, -64));
+    });
+
+    it("check null does not contain index", () => {
+      const seq = new TickArraySequence([ta2, testEmptyTickArrray, ta0], ts64, false);
+      assert.ok(!seq.checkArrayContainsTickIndex(1, -64));
+    });
+  });
+
+  describe("findNextInitializedTickIndex tests", () => {
+    it("a->b, search reaches left bounds", async () => {
+      const ta0 = buildTickArrayData(0, [0, 32, 63]);
+      const ta1 = buildTickArrayData(ts64 * TICK_ARRAY_SIZE * -1, [0, 50]);
+      const ta2 = buildTickArrayData(ts64 * TICK_ARRAY_SIZE * -2, [25, 50]);
+      const seq = new TickArraySequence([ta0, ta1, ta2], ts64, true);
+      let i = 0;
+      let searchIndex = new TickArrayIndex(-2, 12, ts64).toTickIndex();
+
+      // First traversal brings swap to the left most edge
+      const { nextIndex } = seq.findNextInitializedTickIndex(searchIndex);
+      assert.equal(nextIndex, ta2.data!.startTickIndex);
+
+      // The next one will throw an error
+      assert.throws(
+        () => seq.findNextInitializedTickIndex(nextIndex - 1),
+        (err) => {
+          const whirlErr = err as WhirlpoolsError;
+          return whirlErr.errorCode === SwapErrorCode.TickArraySequenceInvalid;
+        }
+      );
+    });
+
+    it("b->a, search reaches right bounds", async () => {
+      const ta0 = buildTickArrayData(0, [0, 32]);
+      const ta1 = buildTickArrayData(ts64 * TICK_ARRAY_SIZE * -1, [0, 50]);
+      const ta2 = buildTickArrayData(ts64 * TICK_ARRAY_SIZE * -2, [25, 50]);
+      const seq = new TickArraySequence([ta2, ta1, ta0], ts64, false);
+      let i = 0;
+      let searchIndex = new TickArrayIndex(0, 33, ts64).toTickIndex();
+
+      // First traversal brings swap to the right most edge
+      const { nextIndex } = seq.findNextInitializedTickIndex(searchIndex);
+      assert.equal(nextIndex, ta0.data!.startTickIndex + TICK_ARRAY_SIZE * ts64 - 1);
+
+      // The next one will throw an error
+      assert.throws(
+        () => seq.findNextInitializedTickIndex(nextIndex),
+        (err) => {
+          const whirlErr = err as WhirlpoolsError;
+          return whirlErr.errorCode === SwapErrorCode.TickArraySequenceInvalid;
+        }
+      );
+    });
+
+    it("a->b, on initializable index, ts = 64", async () => {
+      const ta0 = buildTickArrayData(0, [0, 32, 63]);
+      const ta1 = buildTickArrayData(ts64 * TICK_ARRAY_SIZE * -1, [0, 50]);
+      const ta2 = buildTickArrayData(ts64 * TICK_ARRAY_SIZE * -2, [25, 50]);
+      const seq = new TickArraySequence([ta0, ta1, ta2], ts64, true);
+      let i = 0;
+      let searchIndex = new TickArrayIndex(0, 32, ts64).toTickIndex();
+      const expectedIndicies = [
+        new TickArrayIndex(0, 32, ts64).toTickIndex(),
+        new TickArrayIndex(0, 0, ts64).toTickIndex(),
+        new TickArrayIndex(-1, 50, ts64).toTickIndex(),
+        new TickArrayIndex(-1, 0, ts64).toTickIndex(),
+        new TickArrayIndex(-2, 50, ts64).toTickIndex(),
+        new TickArrayIndex(-2, 25, ts64).toTickIndex(),
+        ta2.data!.startTickIndex, // Last index in array 3
+      ];
+
+      expectedIndicies.forEach((expectedIndex, expectedResultIndex) => {
+        const { nextIndex, nextTickData } = seq.findNextInitializedTickIndex(searchIndex)!;
+        if (expectedResultIndex === expectedIndicies.length - 1) {
+          assert.equal(nextIndex, expectedIndex);
+          assert.ok(nextTickData === null);
+        } else {
+          assert.equal(nextIndex, expectedIndex);
+          assert.ok(nextTickData!.initialized);
+        }
+        searchIndex = nextIndex - 1;
+      });
+    });
+
+    it("a->b, on initializable index, ts = 64", async () => {
+      const ta0 = buildTickArrayData(0, [0, 32, 63]);
+      const ta1 = buildTickArrayData(ts64 * TICK_ARRAY_SIZE * -1, [0, 50]);
+      const ta2 = buildTickArrayData(ts64 * TICK_ARRAY_SIZE * -2, [25, 50]);
+      const seq = new TickArraySequence([ta0, ta1, ta2], ts64, true);
+      let i = 0;
+      let searchIndex = new TickArrayIndex(0, 32, ts64).toTickIndex();
+      const expectedIndicies = [
+        new TickArrayIndex(0, 32, ts64).toTickIndex(),
+        new TickArrayIndex(0, 0, ts64).toTickIndex(),
+        new TickArrayIndex(-1, 50, ts64).toTickIndex(),
+        new TickArrayIndex(-1, 0, ts64).toTickIndex(),
+        new TickArrayIndex(-2, 50, ts64).toTickIndex(),
+        new TickArrayIndex(-2, 25, ts64).toTickIndex(),
+        ta2.data!.startTickIndex, // Last index in array 3
+      ];
+
+      expectedIndicies.forEach((expectedIndex, expectedResultIndex) => {
+        const { nextIndex, nextTickData } = seq.findNextInitializedTickIndex(searchIndex)!;
+        if (expectedResultIndex === expectedIndicies.length - 1) {
+          assert.equal(nextIndex, expectedIndex);
+          assert.ok(nextTickData === null);
+        } else {
+          assert.equal(nextIndex, expectedIndex);
+          assert.ok(nextTickData!.initialized);
+        }
+        searchIndex = nextIndex - 1;
+      });
+    });
+
+    it("b->a, not on initializable index, ts = 128", async () => {
+      const ta0 = buildTickArrayData(0, [0, 32, 63]);
+      const ta1 = buildTickArrayData(ts128 * TICK_ARRAY_SIZE, [0, 50]);
+      const ta2 = buildTickArrayData(ts128 * TICK_ARRAY_SIZE * 2, [25, 50]);
+      const seq = new TickArraySequence([ta0, ta1, ta2], ts128, false);
+      let i = 0;
+      let searchIndex = new TickArrayIndex(0, 25, ts128).toTickIndex() + 64;
+      const expectedIndicies = [
+        new TickArrayIndex(0, 32, ts128).toTickIndex(),
+        new TickArrayIndex(0, 63, ts128).toTickIndex(),
+        new TickArrayIndex(1, 0, ts128).toTickIndex(),
+        new TickArrayIndex(1, 50, ts128).toTickIndex(),
+        new TickArrayIndex(2, 25, ts128).toTickIndex(),
+        new TickArrayIndex(2, 50, ts128).toTickIndex(),
+        ta2.data!.startTickIndex + TICK_ARRAY_SIZE * ts128 - 1, // Last index in array 3
+      ];
+
+      expectedIndicies.forEach((expectedIndex, expectedResultIndex) => {
+        const { nextIndex, nextTickData } = seq.findNextInitializedTickIndex(searchIndex)!;
+        if (expectedResultIndex === expectedIndicies.length - 1) {
+          assert.equal(nextIndex, expectedIndex);
+          assert.ok(nextTickData === null);
+        } else {
+          assert.equal(nextIndex, expectedIndex);
+          assert.ok(nextTickData!.initialized);
+        }
+        searchIndex = nextIndex;
+      });
+    });
+
+    it("b->a, on initializable index, ts = 64", async () => {
+      const ta0 = buildTickArrayData(0, [0, 32, 63]);
+      const ta1 = buildTickArrayData(ts64 * TICK_ARRAY_SIZE, [0, 50]);
+      const ta2 = buildTickArrayData(ts64 * TICK_ARRAY_SIZE * 2, [25, 50]);
+      const seq = new TickArraySequence([ta0, ta1, ta2], ts64, false);
+      let i = 0;
+      let searchIndex = new TickArrayIndex(0, 25, ts64).toTickIndex();
+      const expectedIndicies = [
+        new TickArrayIndex(0, 32, ts64).toTickIndex(),
+        new TickArrayIndex(0, 63, ts64).toTickIndex(),
+        new TickArrayIndex(1, 0, ts64).toTickIndex(),
+        new TickArrayIndex(1, 50, ts64).toTickIndex(),
+        new TickArrayIndex(2, 25, ts64).toTickIndex(),
+        new TickArrayIndex(2, 50, ts64).toTickIndex(),
+        ta2.data!.startTickIndex + TICK_ARRAY_SIZE * ts64 - 1, // Last index in array 3
+      ];
+
+      expectedIndicies.forEach((expectedIndex, expectedResultIndex) => {
+        const { nextIndex, nextTickData } = seq.findNextInitializedTickIndex(searchIndex)!;
+        if (expectedResultIndex === expectedIndicies.length - 1) {
+          assert.equal(nextIndex, expectedIndex);
+          assert.ok(nextTickData === null);
+        } else {
+          assert.equal(nextIndex, expectedIndex);
+          assert.ok(nextTickData!.initialized);
+        }
+        searchIndex = nextIndex;
+      });
+    });
+  });
+});

--- a/sdk/tests/utils/assert.ts
+++ b/sdk/tests/utils/assert.ts
@@ -1,9 +1,30 @@
 import * as assert from "assert";
-import { Program, web3, Coder, BN } from "@project-serum/anchor";
+import { Program, web3, BN } from "@project-serum/anchor";
 import { AccountLayout } from "@solana/spl-token";
 import { TEST_TOKEN_PROGRAM_ID } from "./test-consts";
 import { Whirlpool } from "../../src/artifacts/whirlpool";
-import { TickData } from "../../src/types/public";
+import { TickData, WhirlpoolData } from "../../src/types/public";
+import { SwapQuote } from "../../src";
+import { VaultAmounts } from "./whirlpools-test-utils";
+
+export function assertQuoteAndResults(
+  aToB: boolean,
+  quote: SwapQuote,
+  endData: WhirlpoolData,
+  beforeVaultAmounts: VaultAmounts,
+  afterVaultAmounts: VaultAmounts
+) {
+  const tokenADelta = beforeVaultAmounts.tokenA.sub(afterVaultAmounts.tokenA);
+  const tokenBDelta = beforeVaultAmounts.tokenB.sub(afterVaultAmounts.tokenB);
+
+  assert.equal(
+    quote.estimatedAmountIn.toString(),
+    (aToB ? tokenADelta : tokenBDelta).neg().toString()
+  );
+  assert.equal(quote.estimatedAmountOut.toString(), (aToB ? tokenBDelta : tokenADelta).toString());
+  assert.equal(endData.tickCurrentIndex, quote.estimatedEndTickIndex);
+  assert.equal(quote.estimatedEndSqrtPrice.toString(), endData.sqrtPrice.toString());
+}
 
 // Helper for token vault assertion checks.
 export async function asyncAssertTokenVault(

--- a/sdk/tests/utils/assert.ts
+++ b/sdk/tests/utils/assert.ts
@@ -6,6 +6,38 @@ import { Whirlpool } from "../../src/artifacts/whirlpool";
 import { TickData, WhirlpoolData } from "../../src/types/public";
 import { SwapQuote } from "../../src";
 import { VaultAmounts } from "./whirlpools-test-utils";
+import { ONE } from "@orca-so/common-sdk";
+
+export function assertInputOutputQuoteEqual(
+  inputTokenQuote: SwapQuote,
+  outputTokenQuote: SwapQuote
+) {
+  assert.equal(inputTokenQuote.aToB, outputTokenQuote.aToB, "aToB not equal");
+  // TODO: Sometimes input & output estimated In is off by 1. Same goes for sqrt-price
+  assert.ok(
+    inputTokenQuote.estimatedAmountIn.sub(outputTokenQuote.estimatedAmountIn).abs().lte(ONE),
+    `input estimated In ${inputTokenQuote.estimatedAmountIn} does not equal output estimated in ${outputTokenQuote.estimatedAmountIn}`
+  );
+  assert.ok(
+    inputTokenQuote.estimatedAmountOut.sub(outputTokenQuote.estimatedAmountOut).abs().lte(ONE),
+    `input estimated out ${inputTokenQuote.estimatedAmountOut} does not equal output estimated out ${outputTokenQuote.estimatedAmountOut}`
+  );
+  assert.equal(
+    inputTokenQuote.estimatedEndTickIndex,
+    outputTokenQuote.estimatedEndTickIndex,
+    "estimatedEndTickIndex not equal"
+  );
+  assert.equal(
+    inputTokenQuote.estimatedFeeAmount.toString(),
+    outputTokenQuote.estimatedFeeAmount.toString(),
+    "estimatedFeeAmount not equal"
+  );
+  assert.notEqual(
+    inputTokenQuote.amountSpecifiedIsInput,
+    outputTokenQuote.amountSpecifiedIsInput,
+    "amountSpecifiedIsInput equals"
+  );
+}
 
 export function assertQuoteAndResults(
   aToB: boolean,

--- a/sdk/tests/utils/init-utils.ts
+++ b/sdk/tests/utils/init-utils.ts
@@ -23,7 +23,7 @@ import {
 } from "./test-builders";
 import { PublicKey, Keypair } from "@solana/web3.js";
 import {
-  createAndMintToTokenAccount,
+  createAndMintToAssociatedTokenAccount,
   createMint,
   mintToByAuthority,
   TickSpacing,
@@ -301,8 +301,16 @@ export async function initTestPoolWithTokens(
   );
 
   const { tokenMintA, tokenMintB, whirlpoolPda } = poolInitInfo;
-  const tokenAccountA = await createAndMintToTokenAccount(provider, tokenMintA, mintAmount);
-  const tokenAccountB = await createAndMintToTokenAccount(provider, tokenMintB, mintAmount);
+  const tokenAccountA = await createAndMintToAssociatedTokenAccount(
+    provider,
+    tokenMintA,
+    mintAmount
+  );
+  const tokenAccountB = await createAndMintToAssociatedTokenAccount(
+    provider,
+    tokenMintB,
+    mintAmount
+  );
   return {
     poolInitInfo,
     configInitInfo,

--- a/sdk/tests/utils/init-utils.ts
+++ b/sdk/tests/utils/init-utils.ts
@@ -32,6 +32,7 @@ import {
 import { u64 } from "@solana/spl-token";
 import { PoolUtil } from "../../src/utils/public/pool-utils";
 import { MathUtil, PDA } from "@orca-so/common-sdk";
+import { BN } from "bn.js";
 
 const defaultInitSqrtPrice = MathUtil.toX64_BN(new u64(5));
 
@@ -288,6 +289,7 @@ export async function initTickArray(
 export async function initTestPoolWithTokens(
   ctx: WhirlpoolContext,
   tickSpacing: number,
+  mintAmount = new BN("15000000000"),
   initSqrtPrice = defaultInitSqrtPrice
 ) {
   const provider = ctx.provider;
@@ -299,8 +301,8 @@ export async function initTestPoolWithTokens(
   );
 
   const { tokenMintA, tokenMintB, whirlpoolPda } = poolInitInfo;
-  const tokenAccountA = await createAndMintToTokenAccount(provider, tokenMintA, 15_000_000);
-  const tokenAccountB = await createAndMintToTokenAccount(provider, tokenMintB, 15_000_000);
+  const tokenAccountA = await createAndMintToTokenAccount(provider, tokenMintA, mintAmount);
+  const tokenAccountB = await createAndMintToTokenAccount(provider, tokenMintB, mintAmount);
   return {
     poolInitInfo,
     configInitInfo,

--- a/sdk/tests/utils/init-utils.ts
+++ b/sdk/tests/utils/init-utils.ts
@@ -289,8 +289,8 @@ export async function initTickArray(
 export async function initTestPoolWithTokens(
   ctx: WhirlpoolContext,
   tickSpacing: number,
-  mintAmount = new BN("15000000000"),
-  initSqrtPrice = defaultInitSqrtPrice
+  initSqrtPrice = defaultInitSqrtPrice,
+  mintAmount = new BN("15000000000")
 ) {
   const provider = ctx.provider;
 

--- a/sdk/tests/utils/swap-test-utils.ts
+++ b/sdk/tests/utils/swap-test-utils.ts
@@ -5,7 +5,6 @@ import { u64 } from "@solana/spl-token";
 import { TickSpacing } from ".";
 import { WhirlpoolContext, WhirlpoolClient, Whirlpool, TICK_ARRAY_SIZE } from "../../src";
 import { FundedPositionParams, initTestPoolWithTokens, fundPositions } from "./init-utils";
-import { BN } from "bn.js";
 
 export interface SwapTestPoolParams {
   ctx: WhirlpoolContext;
@@ -34,8 +33,8 @@ export async function setupSwapTest(setup: SwapTestPoolParams) {
   const { poolInitInfo, whirlpoolPda, tokenAccountA, tokenAccountB } = await initTestPoolWithTokens(
     setup.ctx,
     setup.tickSpacing,
-    setup.tokenMintAmount,
-    setup.initSqrtPrice
+    setup.initSqrtPrice,
+    setup.tokenMintAmount
   );
 
   const whirlpool = await setup.client.getPool(whirlpoolPda.publicKey, true);

--- a/sdk/tests/utils/swap-test-utils.ts
+++ b/sdk/tests/utils/swap-test-utils.ts
@@ -1,0 +1,69 @@
+import * as anchor from "@project-serum/anchor";
+import { PublicKey } from "@solana/web3.js";
+import { Percentage } from "@orca-so/common-sdk";
+import { u64 } from "@solana/spl-token";
+import { TickSpacing } from ".";
+import { WhirlpoolContext, WhirlpoolClient, Whirlpool, TICK_ARRAY_SIZE } from "../../src";
+import { FundedPositionParams, initTestPoolWithTokens, fundPositions } from "./init-utils";
+import { BN } from "bn.js";
+
+export interface SwapTestPoolParams {
+  ctx: WhirlpoolContext;
+  client: WhirlpoolClient;
+  tickSpacing: TickSpacing;
+  initSqrtPrice: anchor.BN;
+  initArrayStartTicks: number[];
+  fundedPositions: FundedPositionParams[];
+  tokenMintAmount?: anchor.BN;
+}
+
+export interface SwapTestSwapParams {
+  swapAmount: u64;
+  aToB: boolean;
+  amountSpecifiedIsInput: boolean;
+  slippageTolerance: Percentage;
+  tickArrayAddresses: PublicKey[];
+}
+
+export interface SwapTestSetup {
+  whirlpool: Whirlpool;
+  tickArrayAddresses: PublicKey[];
+}
+
+export async function setupSwapTest(setup: SwapTestPoolParams) {
+  const { poolInitInfo, whirlpoolPda, tokenAccountA, tokenAccountB } = await initTestPoolWithTokens(
+    setup.ctx,
+    setup.tickSpacing,
+    setup.tokenMintAmount,
+    setup.initSqrtPrice
+  );
+
+  const whirlpool = await setup.client.getPool(whirlpoolPda.publicKey, true);
+
+  (await whirlpool.initTickArrayForTicks(setup.initArrayStartTicks))?.buildAndExecute();
+
+  await fundPositions(setup.ctx, poolInitInfo, tokenAccountA, tokenAccountB, setup.fundedPositions);
+  return whirlpool;
+}
+
+export interface ArrayTickIndex {
+  arrayIndex: number;
+  offsetIndex: number;
+}
+
+export function arrayTickIndexToTickIndex(index: ArrayTickIndex, tickSpacing: number) {
+  return index.arrayIndex * TICK_ARRAY_SIZE * tickSpacing + index.offsetIndex * tickSpacing;
+}
+
+export function buildPosition(
+  lower: ArrayTickIndex,
+  upper: ArrayTickIndex,
+  tickSpacing: number,
+  liquidityAmount: anchor.BN
+) {
+  return {
+    tickLowerIndex: arrayTickIndexToTickIndex(lower, tickSpacing),
+    tickUpperIndex: arrayTickIndexToTickIndex(upper, tickSpacing),
+    liquidityAmount,
+  };
+}

--- a/sdk/tests/utils/token.ts
+++ b/sdk/tests/utils/token.ts
@@ -1,4 +1,4 @@
-import { deriveATA, resolveOrCreateATA, TransactionBuilder } from "@orca-so/common-sdk";
+import { deriveATA } from "@orca-so/common-sdk";
 import { BN, Provider, web3 } from "@project-serum/anchor";
 import {
   ASSOCIATED_TOKEN_PROGRAM_ID,
@@ -7,7 +7,6 @@ import {
   TOKEN_PROGRAM_ID,
   u64,
 } from "@solana/spl-token";
-import { AccountFetcher } from "../../src";
 import { TEST_TOKEN_PROGRAM_ID } from "./test-consts";
 
 export async function createMint(

--- a/sdk/tests/utils/whirlpools-test-utils.ts
+++ b/sdk/tests/utils/whirlpools-test-utils.ts
@@ -1,0 +1,15 @@
+import BN from "bn.js";
+import { WhirlpoolContext, WhirlpoolData } from "../../src";
+import { getTokenBalance } from "./token";
+
+export type VaultAmounts = {
+  tokenA: BN;
+  tokenB: BN;
+};
+
+export async function getVaultAmounts(ctx: WhirlpoolContext, whirlpoolData: WhirlpoolData) {
+  return {
+    tokenA: new BN(await getTokenBalance(ctx.provider, whirlpoolData.tokenVaultA)),
+    tokenB: new BN(await getTokenBalance(ctx.provider, whirlpoolData.tokenVaultB)),
+  };
+}


### PR DESCRIPTION
## Improvements
- More accurate quote values - ported the swap logic from contract & add comprehensive unit-test suite to confirm quote values are identical to contract results
- More info available in quote - endTickIndex, sqrtPrice, feeAmount etc...
- Additional swapQuoteFromOutputToken to allow users to ask for a quote (and swap input parameters) based on the desired receive amount
- Bug fix on TickArray calculation that led to the annoying 0x1787 (InvalidTickArraySequence) error
- Addresses all errors in the old-swap quote where it fails to traverse tick-arrays in many cases
- Bug fix on WhirlpoolClient.swap where it incorrectly uses the quote.estimated values rather than the user defined tokenAmount value

### Breaking API changes
- Parameter changes for the SwapQuote functions - `swapQuoteByInputToken`, `swapQuoteWithParams`
- Reorganized some swap specific methods in PoolUtils into a new SwapUtils class
  - Most notably, `PoolUtil.getTickArrayPublicKeysForSwap` is now `SwapUtils.getTickArrayPublicKeys`
  - To get the `TickArray` object that you can plug into the quote, use `SwapUtils.getTickArrays`

## Notes
- `anchor test` passes all unit-tests
