### PR TITLE
Add resolveATA option for Position's increase_liquidity

### DIFF
--- a/sdk/src/impl/position-impl.ts
+++ b/sdk/src/impl/position-impl.ts
@@ -71,7 +71,10 @@ export class PositionImpl implements Position {
       const [ataA, ataB] = await resolveOrCreateATAs(
         this.ctx.connection,
         sourceWalletKey,
-        [{ tokenMint: whirlpool.tokenMintA }, { tokenMint: whirlpool.tokenMintB }],
+        [
+          { tokenMint: whirlpool.tokenMintA, wrappedSolAmountIn: liquidityInput.tokenMaxA },
+          { tokenMint: whirlpool.tokenMintB, wrappedSolAmountIn: liquidityInput.tokenMaxB },
+        ],
         () => this.fetcher.getAccountRentExempt(),
         ataPayerKey
       );

--- a/sdk/src/impl/position-impl.ts
+++ b/sdk/src/impl/position-impl.ts
@@ -45,7 +45,9 @@ export class PositionImpl implements Position {
   async increaseLiquidity(
     liquidityInput: IncreaseLiquidityInput,
     sourceWallet?: Address,
-    positionWallet?: Address
+    positionWallet?: Address,
+    resolveATA?: boolean,
+    ataPayer?: Address
   ) {
     const sourceWalletKey = sourceWallet
       ? AddressUtil.toPubKey(sourceWallet)
@@ -53,6 +55,7 @@ export class PositionImpl implements Position {
     const positionWalletKey = positionWallet
       ? AddressUtil.toPubKey(positionWallet)
       : this.ctx.wallet.publicKey;
+    const ataPayerKey = ataPayer ? AddressUtil.toPubKey(ataPayer) : this.ctx.wallet.publicKey;
 
     const whirlpool = await this.fetcher.getPool(this.data.whirlpool, true);
     if (!whirlpool) {
@@ -60,8 +63,28 @@ export class PositionImpl implements Position {
     }
 
     const txBuilder = new TransactionBuilder(this.ctx.provider);
-    const tokenOwnerAccountA = await deriveATA(sourceWalletKey, whirlpool.tokenMintA);
-    const tokenOwnerAccountB = await deriveATA(sourceWalletKey, whirlpool.tokenMintB);
+
+    let tokenOwnerAccountA: PublicKey;
+    let tokenOwnerAccountB: PublicKey;
+
+    if (resolveATA) {
+      const [ataA, ataB] = await resolveOrCreateATAs(
+        this.ctx.connection,
+        sourceWalletKey,
+        [{ tokenMint: whirlpool.tokenMintA }, { tokenMint: whirlpool.tokenMintB }],
+        () => this.fetcher.getAccountRentExempt(),
+        ataPayerKey
+      );
+      const { address: ataAddrA, ...tokenOwnerAccountAIx } = ataA!;
+      const { address: ataAddrB, ...tokenOwnerAccountBIx } = ataB!;
+      tokenOwnerAccountA = ataAddrA;
+      tokenOwnerAccountB = ataAddrB;
+      txBuilder.addInstruction(tokenOwnerAccountAIx);
+      txBuilder.addInstruction(tokenOwnerAccountBIx);
+    } else {
+      tokenOwnerAccountA = await deriveATA(sourceWalletKey, whirlpool.tokenMintA);
+      tokenOwnerAccountB = await deriveATA(sourceWalletKey, whirlpool.tokenMintB);
+    }
     const positionTokenAccount = await deriveATA(positionWalletKey, this.data.positionMint);
 
     const increaseIx = increaseLiquidityIx(this.ctx.program, {

--- a/sdk/src/whirlpool-client.ts
+++ b/sdk/src/whirlpool-client.ts
@@ -207,15 +207,21 @@ export interface Position {
   /**
    * Deposit additional tokens into this postiion.
    * The wallet must contain the position token and the necessary token A & B to complete the deposit.
-   * If `wallet` is provided, the wallet owners have to sign this transaction.
+   * If  `positionWallet` are `wallet` is provided, the wallet owners have to sign this transaction.
    *
    * @param liquidityInput - input that defines the desired liquidity amount and maximum tokens willing to be to deposited.
    * @param wallet - the wallet to withdraw tokens to deposit into the position. If null, the WhirlpoolContext wallet is used.
+   * @param positionWallet - optional - the wallet to that houses the position token. If null, the WhirlpoolContext wallet is used.
+   * @param resolveATA - optional - if true, add instructions to create associated token accounts for tokenA,B for the destinationWallet if necessary.
+   * @param ataPayer - optional - wallet that will fund the creation of the new associated token accounts
    * @return the transaction that will deposit the tokens into the position when executed.
    */
   increaseLiquidity: (
     liquidityInput: IncreaseLiquidityInput,
-    wallet?: Address
+    wallet?: Address,
+    positionWallet?: Address,
+    resolveATA?: boolean,
+    ataPayer?: Address
   ) => Promise<TransactionBuilder>;
 
   /**

--- a/sdk/tests/sdk/whirlpools/whirlpool-impl.test.ts
+++ b/sdk/tests/sdk/whirlpools/whirlpool-impl.test.ts
@@ -28,7 +28,7 @@ import {
 } from "@orca-so/common-sdk";
 import { mintTokensToTestAccount } from "../../utils/test-builders";
 
-describe.only("whirlpool-impl", () => {
+describe("whirlpool-impl", () => {
   const provider = anchor.Provider.local();
   anchor.setProvider(anchor.Provider.env());
   const program = anchor.workspace.Whirlpool;

--- a/sdk/tests/utils/test-builders.ts
+++ b/sdk/tests/utils/test-builders.ts
@@ -237,7 +237,6 @@ export async function initPosition(
     upperTick,
     quote,
     sourceWalletKey,
-    sourceWalletKey,
     ctx.wallet.publicKey
   );
 


### PR DESCRIPTION
- Add an option to auto-generate ATA to perform increase_liquidity for Whirlpool's position class

NOTES:
- Modified the position impl test to call increase_liquidity using tokens from another wallet & to auto-gen the ATA
- Performed a test on the SOL/USDC pool to confirm that resolveATA works (because SOL always generates a new ATA to transfer)
- Ran the whole test suite again to confirm that the test-builder change didn't break any tests.