### PR TITLE
Upgrade Anchor (Typescript) dependency to 0.25

### DIFF
--- a/scripts/calcRentExempt.ts
+++ b/scripts/calcRentExempt.ts
@@ -27,10 +27,10 @@ async function run() {
   const connection = new anchor.web3.Connection(
     "https://api.mainnet-beta.solana.com"
   );
-  const provider = new anchor.Provider(
+  const provider = new anchor.AnchorProvider(
     connection,
     wallet,
-    anchor.Provider.defaultOptions()
+    anchor.AnchorProvider.defaultOptions()
   );
 
   const sizeInBytes = [

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -2,7 +2,7 @@
   "name": "scripts",
   "version": "1.0.0",
   "dependencies": {
-    "@project-serum/anchor": "^0.20.1",
+    "@project-serum/anchor": "~0.25.0",
     "@solana/spl-token": "^0.1.8",
     "@orca-so/whirlpool-client-sdk": "0.0.7"
   },

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/whirlpools-sdk",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Typescript SDK to interact with Orca's Whirlpool program.",
   "license": "Apache-2.0",
   "main": "dist/index.js",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@metaplex-foundation/mpl-token-metadata": "1.2.5",
     "@orca-so/common-sdk": "^0.0.7",
-    "@project-serum/anchor": "^0.20.1",
+    "@project-serum/anchor": "~0.25.0",
     "@solana/spl-token": "^0.1.8",
     "decimal.js": "^10.3.1",
     "tiny-invariant": "^1.2.0"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -7,7 +7,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@metaplex-foundation/mpl-token-metadata": "1.2.5",
-    "@orca-so/common-sdk": "^0.0.7",
+    "@orca-so/common-sdk": "~0.1.0",
     "@project-serum/anchor": "~0.25.0",
     "@solana/spl-token": "^0.1.8",
     "decimal.js": "^10.3.1",

--- a/sdk/src/context.ts
+++ b/sdk/src/context.ts
@@ -1,8 +1,8 @@
-import { PublicKey, Connection, ConfirmOptions } from "@solana/web3.js";
-import { AnchorProvider, Program, Idl } from "@project-serum/anchor";
-import WhirlpoolIDL from "./artifacts/whirlpool.json";
-import { Whirlpool } from "./artifacts/whirlpool";
+import { AnchorProvider, Idl, Program } from "@project-serum/anchor";
 import { Wallet } from "@project-serum/anchor/dist/cjs/provider";
+import { ConfirmOptions, Connection, PublicKey } from "@solana/web3.js";
+import { Whirlpool } from "./artifacts/whirlpool";
+import WhirlpoolIDL from "./artifacts/whirlpool.json";
 import { AccountFetcher } from "./network/public";
 /**
  * @category Core
@@ -29,23 +29,21 @@ export class WhirlpoolContext {
 
   public static fromWorkspace(
     provider: AnchorProvider,
-    wallet: Wallet,
     program: Program,
     fetcher = new AccountFetcher(provider.connection),
     opts: ConfirmOptions = AnchorProvider.defaultOptions()
   ) {
-    return new WhirlpoolContext(provider, wallet, program, fetcher, opts);
+    return new WhirlpoolContext(provider, provider.wallet, program, fetcher, opts);
   }
 
   public static withProvider(
     provider: AnchorProvider,
-    wallet: Wallet,
     programId: PublicKey,
     fetcher = new AccountFetcher(provider.connection),
     opts: ConfirmOptions = AnchorProvider.defaultOptions()
   ): WhirlpoolContext {
     const program = new Program(WhirlpoolIDL as Idl, programId, provider);
-    return new WhirlpoolContext(provider, wallet, program, fetcher, opts);
+    return new WhirlpoolContext(provider, provider.wallet, program, fetcher, opts);
   }
 
   public constructor(

--- a/sdk/src/context.ts
+++ b/sdk/src/context.ts
@@ -1,9 +1,9 @@
 import { PublicKey, Connection, ConfirmOptions } from "@solana/web3.js";
-import { Provider, Program, Idl } from "@project-serum/anchor";
+import { AnchorProvider, Program, Idl } from "@project-serum/anchor";
 import WhirlpoolIDL from "./artifacts/whirlpool.json";
 import { Whirlpool } from "./artifacts/whirlpool";
 import { Wallet } from "@project-serum/anchor/dist/cjs/provider";
-
+import { AccountFetcher } from "./network/public";
 /**
  * @category Core
  */
@@ -12,43 +12,56 @@ export class WhirlpoolContext {
   readonly wallet: Wallet;
   readonly opts: ConfirmOptions;
   readonly program: Program<Whirlpool>;
-  readonly provider: Provider;
+  readonly provider: AnchorProvider;
+  readonly fetcher: AccountFetcher;
 
   public static from(
     connection: Connection,
     wallet: Wallet,
     programId: PublicKey,
-    opts: ConfirmOptions = Provider.defaultOptions()
+    fetcher = new AccountFetcher(connection),
+    opts: ConfirmOptions = AnchorProvider.defaultOptions()
   ): WhirlpoolContext {
-    const provider = new Provider(connection, wallet, opts);
-    const program = new Program(WhirlpoolIDL as Idl, programId, provider);
-    return new WhirlpoolContext(provider, program, opts);
+    const anchorProvider = new AnchorProvider(connection, wallet, opts);
+    const program = new Program(WhirlpoolIDL as Idl, programId, anchorProvider);
+    return new WhirlpoolContext(anchorProvider, anchorProvider.wallet, program, fetcher, opts);
   }
 
   public static fromWorkspace(
-    provider: Provider,
+    provider: AnchorProvider,
+    wallet: Wallet,
     program: Program,
-    opts: ConfirmOptions = Provider.defaultOptions()
+    fetcher = new AccountFetcher(provider.connection),
+    opts: ConfirmOptions = AnchorProvider.defaultOptions()
   ) {
-    return new WhirlpoolContext(provider, program, opts);
+    return new WhirlpoolContext(provider, wallet, program, fetcher, opts);
   }
 
   public static withProvider(
-    provider: Provider,
+    provider: AnchorProvider,
+    wallet: Wallet,
     programId: PublicKey,
-    opts: ConfirmOptions = Provider.defaultOptions()
+    fetcher = new AccountFetcher(provider.connection),
+    opts: ConfirmOptions = AnchorProvider.defaultOptions()
   ): WhirlpoolContext {
     const program = new Program(WhirlpoolIDL as Idl, programId, provider);
-    return new WhirlpoolContext(provider, program, opts);
+    return new WhirlpoolContext(provider, wallet, program, fetcher, opts);
   }
 
-  public constructor(provider: Provider, program: Program, opts: ConfirmOptions) {
+  public constructor(
+    provider: AnchorProvider,
+    wallet: Wallet,
+    program: Program,
+    fetcher: AccountFetcher,
+    opts: ConfirmOptions
+  ) {
     this.connection = provider.connection;
-    this.wallet = provider.wallet;
+    this.wallet = wallet;
     this.opts = opts;
     // It's a hack but it works on Anchor workspace *shrug*
     this.program = program as unknown as Program<Whirlpool>;
     this.provider = provider;
+    this.fetcher = fetcher;
   }
 
   // TODO: Add another factory method to build from on-chain IDL

--- a/sdk/src/impl/position-impl.ts
+++ b/sdk/src/impl/position-impl.ts
@@ -62,7 +62,10 @@ export class PositionImpl implements Position {
       throw new Error("Unable to fetch whirlpool for this position.");
     }
 
-    const txBuilder = new TransactionBuilder(this.ctx.provider);
+    const txBuilder = new TransactionBuilder(
+      this.ctx.provider.connection,
+      this.ctx.provider.wallet
+    );
 
     let tokenOwnerAccountA: PublicKey;
     let tokenOwnerAccountB: PublicKey;
@@ -135,7 +138,10 @@ export class PositionImpl implements Position {
       throw new Error("Unable to fetch whirlpool for this position.");
     }
 
-    const txBuilder = new TransactionBuilder(this.ctx.provider);
+    const txBuilder = new TransactionBuilder(
+      this.ctx.provider.connection,
+      this.ctx.provider.wallet
+    );
     let tokenOwnerAccountA: PublicKey;
     let tokenOwnerAccountB: PublicKey;
 

--- a/sdk/src/impl/whirlpool-client-impl.ts
+++ b/sdk/src/impl/whirlpool-client-impl.ts
@@ -8,21 +8,25 @@ import { PositionImpl } from "./position-impl";
 import { WhirlpoolImpl } from "./whirlpool-impl";
 
 export class WhirlpoolClientImpl implements WhirlpoolClient {
-  constructor(readonly ctx: WhirlpoolContext, readonly fetcher: AccountFetcher) {}
+  constructor(readonly ctx: WhirlpoolContext) {}
+
+  public getContext(): WhirlpoolContext {
+    return this.ctx;
+  }
 
   public getFetcher(): AccountFetcher {
-    return this.fetcher;
+    return this.ctx.fetcher;
   }
 
   public async getPool(poolAddress: Address, refresh = false): Promise<Whirlpool> {
-    const account = await this.fetcher.getPool(poolAddress, refresh);
+    const account = await this.ctx.fetcher.getPool(poolAddress, refresh);
     if (!account) {
       throw new Error(`Unable to fetch Whirlpool at address at ${poolAddress}`);
     }
-    const tokenInfos = await getTokenInfos(this.fetcher, account, false);
+    const tokenInfos = await getTokenInfos(this.ctx.fetcher, account, false);
     return new WhirlpoolImpl(
       this.ctx,
-      this.fetcher,
+      this.ctx.fetcher,
       AddressUtil.toPubKey(poolAddress),
       tokenInfos[0],
       tokenInfos[1],
@@ -31,11 +35,16 @@ export class WhirlpoolClientImpl implements WhirlpoolClient {
   }
 
   public async getPosition(positionAddress: Address, refresh = false): Promise<Position> {
-    const account = await this.fetcher.getPosition(positionAddress, refresh);
+    const account = await this.ctx.fetcher.getPosition(positionAddress, refresh);
     if (!account) {
       throw new Error(`Unable to fetch Position at address at ${positionAddress}`);
     }
-    return new PositionImpl(this.ctx, this.fetcher, AddressUtil.toPubKey(positionAddress), account);
+    return new PositionImpl(
+      this.ctx,
+      this.ctx.fetcher,
+      AddressUtil.toPubKey(positionAddress),
+      account
+    );
   }
 }
 

--- a/sdk/src/impl/whirlpool-impl.ts
+++ b/sdk/src/impl/whirlpool-impl.ts
@@ -112,7 +112,10 @@ export class WhirlpoolImpl implements Whirlpool {
       return null;
     }
 
-    const txBuilder = new TransactionBuilder(this.ctx.provider);
+    const txBuilder = new TransactionBuilder(
+      this.ctx.provider.connection,
+      this.ctx.provider.wallet
+    );
     initTickArrayStartPdas.forEach((initTickArrayInfo) => {
       txBuilder.addInstruction(
         initTickArrayIx(this.ctx.program, {
@@ -197,7 +200,10 @@ export class WhirlpoolImpl implements Whirlpool {
     const metadataPda = PDAUtil.getPositionMetadata(positionMintKeypair.publicKey);
     const positionTokenAccountAddress = await deriveATA(wallet, positionMintKeypair.publicKey);
 
-    const txBuilder = new TransactionBuilder(this.ctx.provider);
+    const txBuilder = new TransactionBuilder(
+      this.ctx.provider.connection,
+      this.ctx.provider.wallet
+    );
 
     const positionIx = (withMetadata ? openPositionWithMetadataIx : openPositionIx)(
       this.ctx.program,
@@ -300,7 +306,10 @@ export class WhirlpoolImpl implements Whirlpool {
 
     const positionTokenAccount = await deriveATA(positionWallet, position.positionMint);
 
-    const txBuilder = new TransactionBuilder(this.ctx.provider);
+    const txBuilder = new TransactionBuilder(
+      this.ctx.provider.connection,
+      this.ctx.provider.wallet
+    );
 
     const resolvedAssociatedTokenAddresses: Record<string, PublicKey> = {};
     const [ataA, ataB] = await resolveOrCreateATAs(
@@ -372,7 +381,10 @@ export class WhirlpoolImpl implements Whirlpool {
   private async getSwapTx(input: SwapInput, wallet: PublicKey): Promise<TransactionBuilder> {
     const { amount, aToB } = input;
     const whirlpool = this.data;
-    const txBuilder = new TransactionBuilder(this.ctx.provider);
+    const txBuilder = new TransactionBuilder(
+      this.ctx.provider.connection,
+      this.ctx.provider.wallet
+    );
 
     const [ataA, ataB] = await resolveOrCreateATAs(
       this.ctx.connection,

--- a/sdk/src/network/public/parsing.ts
+++ b/sdk/src/network/public/parsing.ts
@@ -8,7 +8,7 @@ import {
   AccountName,
   FeeTierData,
 } from "../../types/public";
-import { AccountsCoder, Coder, Idl } from "@project-serum/anchor";
+import { BorshAccountsCoder, BorshCoder, Idl } from "@project-serum/anchor";
 import * as WhirlpoolIDL from "../../artifacts/whirlpool.json";
 import { TokenUtil } from "@orca-so/common-sdk";
 
@@ -194,17 +194,17 @@ function staticImplements<T>() {
   };
 }
 
-const WhirlpoolCoder = new Coder(WhirlpoolIDL as Idl);
+const WhirlpoolCoder = new BorshAccountsCoder(WhirlpoolIDL as Idl);
 
 function parseAnchorAccount(accountName: AccountName, data: Buffer) {
-  const discriminator = AccountsCoder.accountDiscriminator(accountName);
+  const discriminator = BorshAccountsCoder.accountDiscriminator(accountName);
   if (discriminator.compare(data.slice(0, 8))) {
     console.error("incorrect account name during parsing");
     return null;
   }
 
   try {
-    return WhirlpoolCoder.accounts.decode(accountName, data);
+    return WhirlpoolCoder.decode(accountName, data);
   } catch (_e) {
     console.error("unknown account name during parsing");
     return null;

--- a/sdk/src/utils/public/ix-utils.ts
+++ b/sdk/src/utils/public/ix-utils.ts
@@ -2,5 +2,5 @@ import { TransactionBuilder, Instruction } from "@orca-so/common-sdk";
 import { WhirlpoolContext } from "../../context";
 
 export function toTx(ctx: WhirlpoolContext, ix: Instruction): TransactionBuilder {
-  return new TransactionBuilder(ctx.provider).addInstruction(ix);
+  return new TransactionBuilder(ctx.provider.connection, ctx.provider.wallet).addInstruction(ix);
 }

--- a/sdk/src/whirlpool-client.ts
+++ b/sdk/src/whirlpool-client.ts
@@ -1,17 +1,17 @@
 import { Percentage, TransactionBuilder } from "@orca-so/common-sdk";
 import { Address } from "@project-serum/anchor";
+import { PublicKey } from "@solana/web3.js";
 import { WhirlpoolContext } from "./context";
+import { WhirlpoolClientImpl } from "./impl/whirlpool-client-impl";
 import { AccountFetcher } from "./network/public";
+import { SwapQuote } from "./quotes/public";
 import {
-  WhirlpoolData,
-  PositionData,
-  IncreaseLiquidityInput,
   DecreaseLiquidityInput,
+  IncreaseLiquidityInput,
+  PositionData,
+  WhirlpoolData,
 } from "./types/public";
 import { TokenInfo } from "./types/public/client-types";
-import { PublicKey } from "@solana/web3.js";
-import { SwapQuote } from "./quotes/public";
-import { WhirlpoolClientImpl } from "./impl/whirlpool-client-impl";
 
 /**
  * Helper class to help interact with Whirlpool Accounts with a simpler interface.
@@ -19,6 +19,12 @@ import { WhirlpoolClientImpl } from "./impl/whirlpool-client-impl";
  * @category Core
  */
 export interface WhirlpoolClient {
+  /**
+   * Get this client's WhirlpoolContext object
+   * @return a WhirlpoolContext object
+   */
+  getContext: () => WhirlpoolContext;
+
   /**
    * Get an AccountFetcher to fetch Whirlpool accounts
    * @return an AccountFetcher instance
@@ -45,14 +51,10 @@ export interface WhirlpoolClient {
  *
  * @category WhirlpoolClient
  * @param ctx - WhirlpoolContext object
- * @param fetcher - AccountFetcher instance to help fetch data with.
  * @returns a WhirlpoolClient instance to help with interacting with Whirlpools accounts.
  */
-export function buildWhirlpoolClient(
-  ctx: WhirlpoolContext,
-  fetcher: AccountFetcher
-): WhirlpoolClient {
-  return new WhirlpoolClientImpl(ctx, fetcher);
+export function buildWhirlpoolClient(ctx: WhirlpoolContext): WhirlpoolClient {
+  return new WhirlpoolClientImpl(ctx);
 }
 
 /**

--- a/sdk/tests/integration/close_position.test.ts
+++ b/sdk/tests/integration/close_position.test.ts
@@ -15,10 +15,10 @@ import { WhirlpoolTestFixture } from "../utils/fixture";
 import { toTx, WhirlpoolIx } from "../../src";
 
 describe("close_position", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
 
   it("successfully closes an open position", async () => {
     const { poolInitInfo } = await initTestPool(ctx, TickSpacing.Standard);

--- a/sdk/tests/integration/close_position.test.ts
+++ b/sdk/tests/integration/close_position.test.ts
@@ -1,7 +1,7 @@
-import * as assert from "assert";
 import * as anchor from "@project-serum/anchor";
+import * as assert from "assert";
+import { toTx, WhirlpoolIx } from "../../src";
 import { WhirlpoolContext } from "../../src/context";
-import { initTestPool, initTestPoolWithLiquidity, openPosition } from "../utils/init-utils";
 import {
   approveToken,
   createAndMintToTokenAccount,
@@ -12,13 +12,13 @@ import {
   ZERO_BN,
 } from "../utils";
 import { WhirlpoolTestFixture } from "../utils/fixture";
-import { toTx, WhirlpoolIx } from "../../src";
+import { initTestPool, initTestPoolWithLiquidity, openPosition } from "../utils/init-utils";
 
 describe("close_position", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
 
   it("successfully closes an open position", async () => {
     const { poolInitInfo } = await initTestPool(ctx, TickSpacing.Standard);

--- a/sdk/tests/integration/collect_fees.test.ts
+++ b/sdk/tests/integration/collect_fees.test.ts
@@ -29,7 +29,7 @@ describe("collect_fees", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   it("successfully collect fees", async () => {

--- a/sdk/tests/integration/collect_fees.test.ts
+++ b/sdk/tests/integration/collect_fees.test.ts
@@ -1,37 +1,36 @@
-import * as assert from "assert";
+import { MathUtil } from "@orca-so/common-sdk";
 import * as anchor from "@project-serum/anchor";
 import { u64 } from "@solana/spl-token";
+import * as assert from "assert";
 import Decimal from "decimal.js";
 import {
-  WhirlpoolContext,
-  AccountFetcher,
-  PositionData,
   collectFeesQuote,
+  PDAUtil,
+  PositionData,
   TickArrayData,
+  TickArrayUtil,
   toTx,
+  WhirlpoolContext,
   WhirlpoolData,
   WhirlpoolIx,
-  PDAUtil,
-  TickArrayUtil,
 } from "../../src";
 import {
-  TickSpacing,
-  ZERO_BN,
+  approveToken,
   createTokenAccount,
   getTokenBalance,
-  approveToken,
+  TickSpacing,
   transfer,
+  ZERO_BN,
 } from "../utils";
 import { WhirlpoolTestFixture } from "../utils/fixture";
 import { initTestPool } from "../utils/init-utils";
-import { MathUtil } from "@orca-so/common-sdk";
 
 describe("collect_fees", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
 
   it("successfully collect fees", async () => {
     // In same tick array - start index 22528

--- a/sdk/tests/integration/collect_protocol_fees.test.ts
+++ b/sdk/tests/integration/collect_protocol_fees.test.ts
@@ -1,26 +1,19 @@
-import * as assert from "assert";
+import { MathUtil } from "@orca-so/common-sdk";
 import * as anchor from "@project-serum/anchor";
 import { u64 } from "@solana/spl-token";
+import * as assert from "assert";
 import Decimal from "decimal.js";
-import {
-  WhirlpoolContext,
-  AccountFetcher,
-  WhirlpoolData,
-  WhirlpoolIx,
-  PDAUtil,
-  toTx,
-} from "../../src";
-import { TickSpacing, ZERO_BN, createTokenAccount, getTokenBalance } from "../utils";
+import { PDAUtil, toTx, WhirlpoolContext, WhirlpoolData, WhirlpoolIx } from "../../src";
+import { createTokenAccount, getTokenBalance, TickSpacing, ZERO_BN } from "../utils";
 import { WhirlpoolTestFixture } from "../utils/fixture";
 import { initTestPool } from "../utils/init-utils";
-import { MathUtil } from "@orca-so/common-sdk";
 
 describe("collect_protocol_fees", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
 
   it("successfully collects fees", async () => {
     // In same tick array - start index 22528

--- a/sdk/tests/integration/collect_protocol_fees.test.ts
+++ b/sdk/tests/integration/collect_protocol_fees.test.ts
@@ -12,7 +12,7 @@ describe("collect_protocol_fees", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   it("successfully collects fees", async () => {

--- a/sdk/tests/integration/collect_reward.test.ts
+++ b/sdk/tests/integration/collect_reward.test.ts
@@ -1,40 +1,26 @@
-import * as assert from "assert";
+import { MathUtil } from "@orca-so/common-sdk";
 import * as anchor from "@project-serum/anchor";
 import { u64 } from "@solana/spl-token";
+import * as assert from "assert";
 import Decimal from "decimal.js";
 import {
-  WhirlpoolContext,
-  AccountFetcher,
-  NUM_REWARDS,
-  collectRewardsQuote,
-  WhirlpoolData,
-  PositionData,
-  TickArrayData,
-  WhirlpoolIx,
-  TickArrayUtil,
-  toTx,
+  collectRewardsQuote, NUM_REWARDS, PositionData,
+  TickArrayData, TickArrayUtil,
+  toTx, WhirlpoolContext, WhirlpoolData, WhirlpoolIx
 } from "../../src";
 import {
-  TickSpacing,
-  sleep,
-  createTokenAccount,
-  getTokenBalance,
-  ZERO_BN,
-  approveToken,
-  transfer,
-  createMint,
-  createAndMintToTokenAccount,
+  approveToken, createAndMintToTokenAccount, createMint, createTokenAccount,
+  getTokenBalance, sleep, TickSpacing, transfer, ZERO_BN
 } from "../utils";
 import { WhirlpoolTestFixture } from "../utils/fixture";
 import { initTestPool } from "../utils/init-utils";
-import { MathUtil } from "@orca-so/common-sdk";
 
 describe("collect_reward", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
 
   it("successfully collect rewards", async () => {
     const vaultStartBalance = 1_000_000;

--- a/sdk/tests/integration/collect_reward.test.ts
+++ b/sdk/tests/integration/collect_reward.test.ts
@@ -4,13 +4,26 @@ import { u64 } from "@solana/spl-token";
 import * as assert from "assert";
 import Decimal from "decimal.js";
 import {
-  collectRewardsQuote, NUM_REWARDS, PositionData,
-  TickArrayData, TickArrayUtil,
-  toTx, WhirlpoolContext, WhirlpoolData, WhirlpoolIx
+  collectRewardsQuote,
+  NUM_REWARDS,
+  PositionData,
+  TickArrayData,
+  TickArrayUtil,
+  toTx,
+  WhirlpoolContext,
+  WhirlpoolData,
+  WhirlpoolIx,
 } from "../../src";
 import {
-  approveToken, createAndMintToTokenAccount, createMint, createTokenAccount,
-  getTokenBalance, sleep, TickSpacing, transfer, ZERO_BN
+  approveToken,
+  createAndMintToTokenAccount,
+  createMint,
+  createTokenAccount,
+  getTokenBalance,
+  sleep,
+  TickSpacing,
+  transfer,
+  ZERO_BN,
 } from "../utils";
 import { WhirlpoolTestFixture } from "../utils/fixture";
 import { initTestPool } from "../utils/init-utils";
@@ -19,7 +32,7 @@ describe("collect_reward", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   it("successfully collect rewards", async () => {

--- a/sdk/tests/integration/decrease_liquidity.test.ts
+++ b/sdk/tests/integration/decrease_liquidity.test.ts
@@ -1,37 +1,26 @@
+import { MathUtil, Percentage } from "@orca-so/common-sdk";
 import * as anchor from "@project-serum/anchor";
-import * as assert from "assert";
 import { u64 } from "@solana/spl-token";
+import * as assert from "assert";
 import Decimal from "decimal.js";
 import {
-  WhirlpoolContext,
-  AccountFetcher,
-  WhirlpoolData,
-  TickArrayData,
-  PositionData,
-  WhirlpoolIx,
-  toTx,
+  PositionData, TickArrayData, toTx, WhirlpoolContext, WhirlpoolData, WhirlpoolIx
 } from "../../src";
+import { decreaseLiquidityQuoteByLiquidityWithParams } from "../../src/quotes/public/decrease-liquidity-quote";
 import {
-  TickSpacing,
-  assertTick,
-  approveToken,
-  createTokenAccount,
-  transfer,
-  ZERO_BN,
-  createAndMintToTokenAccount,
-  createMint,
+  approveToken, assertTick, createAndMintToTokenAccount,
+  createMint, createTokenAccount, TickSpacing, transfer,
+  ZERO_BN
 } from "../utils";
 import { WhirlpoolTestFixture } from "../utils/fixture";
-import { initTestPool, openPosition, initTickArray } from "../utils/init-utils";
-import { decreaseLiquidityQuoteByLiquidityWithParams } from "../../src/quotes/public/decrease-liquidity-quote";
-import { MathUtil, Percentage } from "@orca-so/common-sdk";
+import { initTestPool, initTickArray, openPosition } from "../utils/init-utils";
 
 describe("decrease_liquidity", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
 
   it("successfully decrease liquidity from position in one tick array", async () => {
     const liquidityAmount = new u64(1_250_000);

--- a/sdk/tests/integration/decrease_liquidity.test.ts
+++ b/sdk/tests/integration/decrease_liquidity.test.ts
@@ -4,13 +4,23 @@ import { u64 } from "@solana/spl-token";
 import * as assert from "assert";
 import Decimal from "decimal.js";
 import {
-  PositionData, TickArrayData, toTx, WhirlpoolContext, WhirlpoolData, WhirlpoolIx
+  PositionData,
+  TickArrayData,
+  toTx,
+  WhirlpoolContext,
+  WhirlpoolData,
+  WhirlpoolIx,
 } from "../../src";
 import { decreaseLiquidityQuoteByLiquidityWithParams } from "../../src/quotes/public/decrease-liquidity-quote";
 import {
-  approveToken, assertTick, createAndMintToTokenAccount,
-  createMint, createTokenAccount, TickSpacing, transfer,
-  ZERO_BN
+  approveToken,
+  assertTick,
+  createAndMintToTokenAccount,
+  createMint,
+  createTokenAccount,
+  TickSpacing,
+  transfer,
+  ZERO_BN,
 } from "../utils";
 import { WhirlpoolTestFixture } from "../utils/fixture";
 import { initTestPool, initTickArray, openPosition } from "../utils/init-utils";
@@ -19,7 +29,7 @@ describe("decrease_liquidity", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   it("successfully decrease liquidity from position in one tick array", async () => {

--- a/sdk/tests/integration/increase_liquidity.test.ts
+++ b/sdk/tests/integration/increase_liquidity.test.ts
@@ -1,46 +1,28 @@
-import * as assert from "assert";
+import { MathUtil, TransactionBuilder } from "@orca-so/common-sdk";
 import * as anchor from "@project-serum/anchor";
 import { u64 } from "@solana/spl-token";
+import * as assert from "assert";
 import Decimal from "decimal.js";
 import {
-  WhirlpoolContext,
-  AccountFetcher,
-  WhirlpoolData,
-  PositionData,
-  TickArrayData,
-  TickUtil,
-  PriceMath,
-  WhirlpoolIx,
-  PDAUtil,
-  toTx,
+  PDAUtil, PositionData, PriceMath, TickArrayData,
+  TickUtil, toTx, WhirlpoolContext, WhirlpoolData, WhirlpoolIx
 } from "../../src";
+import { PoolUtil, toTokenAmount } from "../../src/utils/public/pool-utils";
 import {
-  TickSpacing,
-  ZERO_BN,
-  getTokenBalance,
-  assertTick,
-  approveToken,
-  createAndMintToTokenAccount,
-  MAX_U64,
-  createTokenAccount,
-  transfer,
-  createMint,
+  approveToken, assertTick, createAndMintToTokenAccount, createMint, createTokenAccount, getTokenBalance, MAX_U64, TickSpacing, transfer, ZERO_BN
 } from "../utils";
 import { WhirlpoolTestFixture } from "../utils/fixture";
 import { initTestPool, initTickArray, openPosition } from "../utils/init-utils";
 import {
-  generateDefaultOpenPositionParams,
-  generateDefaultInitTickArrayParams,
+  generateDefaultInitTickArrayParams, generateDefaultOpenPositionParams
 } from "../utils/test-builders";
-import { PoolUtil, toTokenAmount } from "../../src/utils/public/pool-utils";
-import { MathUtil, TransactionBuilder } from "@orca-so/common-sdk";
 
 describe("increase_liquidity", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
 
   it("increase liquidity of a position spanning two tick arrays", async () => {
     const currTick = 0;
@@ -218,7 +200,7 @@ describe("increase_liquidity", () => {
       TickUtil.getStartTickIndex(tickUpperIndex, tickSpacing)
     ).publicKey;
 
-    await new TransactionBuilder(ctx.provider)
+    await new TransactionBuilder(ctx.provider.connection, ctx.provider.wallet)
       // TODO: create a ComputeBudgetInstruction to request more compute
       .addInstruction(
         WhirlpoolIx.initTickArrayIx(

--- a/sdk/tests/integration/increase_liquidity.test.ts
+++ b/sdk/tests/integration/increase_liquidity.test.ts
@@ -4,24 +4,41 @@ import { u64 } from "@solana/spl-token";
 import * as assert from "assert";
 import Decimal from "decimal.js";
 import {
-  PDAUtil, PositionData, PriceMath, TickArrayData,
-  TickUtil, toTx, WhirlpoolContext, WhirlpoolData, WhirlpoolIx
+  PDAUtil,
+  PositionData,
+  PriceMath,
+  TickArrayData,
+  TickUtil,
+  toTx,
+  WhirlpoolContext,
+  WhirlpoolData,
+  WhirlpoolIx,
 } from "../../src";
 import { PoolUtil, toTokenAmount } from "../../src/utils/public/pool-utils";
 import {
-  approveToken, assertTick, createAndMintToTokenAccount, createMint, createTokenAccount, getTokenBalance, MAX_U64, TickSpacing, transfer, ZERO_BN
+  approveToken,
+  assertTick,
+  createAndMintToTokenAccount,
+  createMint,
+  createTokenAccount,
+  getTokenBalance,
+  MAX_U64,
+  TickSpacing,
+  transfer,
+  ZERO_BN,
 } from "../utils";
 import { WhirlpoolTestFixture } from "../utils/fixture";
 import { initTestPool, initTickArray, openPosition } from "../utils/init-utils";
 import {
-  generateDefaultInitTickArrayParams, generateDefaultOpenPositionParams
+  generateDefaultInitTickArrayParams,
+  generateDefaultOpenPositionParams,
 } from "../utils/test-builders";
 
 describe("increase_liquidity", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   it("increase liquidity of a position spanning two tick arrays", async () => {

--- a/sdk/tests/integration/initialize_config.test.ts
+++ b/sdk/tests/integration/initialize_config.test.ts
@@ -1,22 +1,21 @@
-import * as assert from "assert";
 import * as anchor from "@project-serum/anchor";
+import * as assert from "assert";
 import {
-  WhirlpoolContext,
-  AccountFetcher,
-  WhirlpoolsConfigData,
-  WhirlpoolIx,
   InitConfigParams,
   toTx,
+  WhirlpoolContext,
+  WhirlpoolIx,
+  WhirlpoolsConfigData,
 } from "../../src";
-import { systemTransferTx, ONE_SOL } from "../utils";
+import { ONE_SOL, systemTransferTx } from "../utils";
 import { generateDefaultConfigParams } from "../utils/test-builders";
 
 describe("initialize_config", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
 
   let initializedConfigInfo: InitConfigParams;
 

--- a/sdk/tests/integration/initialize_config.test.ts
+++ b/sdk/tests/integration/initialize_config.test.ts
@@ -14,7 +14,7 @@ describe("initialize_config", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   let initializedConfigInfo: InitConfigParams;

--- a/sdk/tests/integration/initialize_fee_tier.test.ts
+++ b/sdk/tests/integration/initialize_fee_tier.test.ts
@@ -1,14 +1,7 @@
-import * as assert from "assert";
 import * as anchor from "@project-serum/anchor";
-import {
-  WhirlpoolContext,
-  AccountFetcher,
-  FeeTierData,
-  WhirlpoolIx,
-  PDAUtil,
-  toTx,
-} from "../../src";
-import { TickSpacing, systemTransferTx, ONE_SOL } from "../utils";
+import * as assert from "assert";
+import { FeeTierData, PDAUtil, toTx, WhirlpoolContext, WhirlpoolIx } from "../../src";
+import { ONE_SOL, systemTransferTx, TickSpacing } from "../utils";
 import { initFeeTier } from "../utils/init-utils";
 import {
   generateDefaultConfigParams,
@@ -16,11 +9,11 @@ import {
 } from "../utils/test-builders";
 
 describe("initialize_fee_tier", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
 
   it("successfully init a FeeRate stable account", async () => {
     const { configInitInfo, configKeypairs } = generateDefaultConfigParams(ctx);

--- a/sdk/tests/integration/initialize_fee_tier.test.ts
+++ b/sdk/tests/integration/initialize_fee_tier.test.ts
@@ -12,7 +12,7 @@ describe("initialize_fee_tier", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   it("successfully init a FeeRate stable account", async () => {

--- a/sdk/tests/integration/initialize_pool.test.ts
+++ b/sdk/tests/integration/initialize_pool.test.ts
@@ -1,35 +1,34 @@
-import * as assert from "assert";
+import { MathUtil } from "@orca-so/common-sdk";
 import * as anchor from "@project-serum/anchor";
+import * as assert from "assert";
 import Decimal from "decimal.js";
 import {
-  WhirlpoolContext,
-  AccountFetcher,
-  WhirlpoolData,
   InitPoolParams,
   MAX_SQRT_PRICE,
   MIN_SQRT_PRICE,
-  PriceMath,
-  WhirlpoolIx,
   PDAUtil,
+  PriceMath,
   toTx,
+  WhirlpoolContext,
+  WhirlpoolData,
+  WhirlpoolIx,
 } from "../../src";
 import {
+  asyncAssertTokenVault,
+  createMint,
+  ONE_SOL,
+  systemTransferTx,
   TickSpacing,
   ZERO_BN,
-  asyncAssertTokenVault,
-  systemTransferTx,
-  ONE_SOL,
-  createMint,
 } from "../utils";
-import { initTestPool, buildTestPoolParams } from "../utils/init-utils";
-import { MathUtil } from "@orca-so/common-sdk";
+import { buildTestPoolParams, initTestPool } from "../utils/init-utils";
 
 describe("initialize_pool", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
 
   it("successfully init a Standard account", async () => {
     const price = MathUtil.toX64(new Decimal(5));

--- a/sdk/tests/integration/initialize_pool.test.ts
+++ b/sdk/tests/integration/initialize_pool.test.ts
@@ -27,7 +27,7 @@ describe("initialize_pool", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   it("successfully init a Standard account", async () => {

--- a/sdk/tests/integration/initialize_reward.test.ts
+++ b/sdk/tests/integration/initialize_reward.test.ts
@@ -1,15 +1,15 @@
-import * as assert from "assert";
 import * as anchor from "@project-serum/anchor";
-import { WhirlpoolContext, AccountFetcher, WhirlpoolData, WhirlpoolIx, toTx } from "../../src";
-import { TickSpacing, systemTransferTx, ONE_SOL, createMint } from "../utils";
-import { initTestPool, initializeReward } from "../utils/init-utils";
+import * as assert from "assert";
+import { toTx, WhirlpoolContext, WhirlpoolData, WhirlpoolIx } from "../../src";
+import { createMint, ONE_SOL, systemTransferTx, TickSpacing } from "../utils";
+import { initializeReward, initTestPool } from "../utils/init-utils";
 
 describe("initialize_reward", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
 
   it("successfully initializes reward at index 0", async () => {
     const { poolInitInfo, configKeypairs } = await initTestPool(ctx, TickSpacing.Standard);

--- a/sdk/tests/integration/initialize_reward.test.ts
+++ b/sdk/tests/integration/initialize_reward.test.ts
@@ -8,7 +8,7 @@ describe("initialize_reward", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   it("successfully initializes reward at index 0", async () => {

--- a/sdk/tests/integration/initialize_tick_array.test.ts
+++ b/sdk/tests/integration/initialize_tick_array.test.ts
@@ -17,7 +17,7 @@ describe("initialize_tick_array", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   it("successfully init a TickArray account", async () => {

--- a/sdk/tests/integration/initialize_tick_array.test.ts
+++ b/sdk/tests/integration/initialize_tick_array.test.ts
@@ -1,25 +1,24 @@
 import * as anchor from "@project-serum/anchor";
 import * as assert from "assert";
 import {
-  WhirlpoolContext,
-  AccountFetcher,
-  TICK_ARRAY_SIZE,
-  InitTickArrayParams,
   InitPoolParams,
+  InitTickArrayParams,
   TickArrayData,
-  WhirlpoolIx,
+  TICK_ARRAY_SIZE,
   toTx,
+  WhirlpoolContext,
+  WhirlpoolIx,
 } from "../../src";
-import { TickSpacing, systemTransferTx, ONE_SOL } from "../utils";
+import { ONE_SOL, systemTransferTx, TickSpacing } from "../utils";
 import { initTestPool, initTickArray } from "../utils/init-utils";
 import { generateDefaultInitTickArrayParams } from "../utils/test-builders";
 
 describe("initialize_tick_array", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
 
   it("successfully init a TickArray account", async () => {
     const tickSpacing = TickSpacing.Standard;

--- a/sdk/tests/integration/multi-ix/position_management.test.ts
+++ b/sdk/tests/integration/multi-ix/position_management.test.ts
@@ -7,11 +7,11 @@ import { TickSpacing } from "../../utils";
 import { AccountFetcher, toTx, WhirlpoolIx } from "../../../src";
 
 describe("position management tests", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
 
   it("successfully closes and opens a position in one transaction", async () => {
     const { poolInitInfo } = await initTestPool(ctx, TickSpacing.Standard);

--- a/sdk/tests/integration/multi-ix/position_management.test.ts
+++ b/sdk/tests/integration/multi-ix/position_management.test.ts
@@ -1,16 +1,16 @@
-import * as assert from "assert";
 import * as anchor from "@project-serum/anchor";
+import * as assert from "assert";
+import { toTx, WhirlpoolIx } from "../../../src";
 import { WhirlpoolContext } from "../../../src/context";
+import { TickSpacing } from "../../utils";
 import { initTestPool, openPosition } from "../../utils/init-utils";
 import { generateDefaultOpenPositionParams } from "../../utils/test-builders";
-import { TickSpacing } from "../../utils";
-import { AccountFetcher, toTx, WhirlpoolIx } from "../../../src";
 
 describe("position management tests", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   it("successfully closes and opens a position in one transaction", async () => {

--- a/sdk/tests/integration/open_position.test.ts
+++ b/sdk/tests/integration/open_position.test.ts
@@ -1,40 +1,38 @@
-import * as assert from "assert";
+import { PDA } from "@orca-so/common-sdk";
 import * as anchor from "@project-serum/anchor";
 import { web3 } from "@project-serum/anchor";
+import { ASSOCIATED_TOKEN_PROGRAM_ID, Token, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { Keypair } from "@solana/web3.js";
-import { ASSOCIATED_TOKEN_PROGRAM_ID, Token } from "@solana/spl-token";
-import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
+import * as assert from "assert";
 import {
-  WhirlpoolContext,
-  AccountFetcher,
-  OpenPositionParams,
   InitPoolParams,
-  PositionData,
   MAX_TICK_INDEX,
   MIN_TICK_INDEX,
-  WhirlpoolIx,
+  OpenPositionParams,
   PDAUtil,
+  PositionData,
   toTx,
+  WhirlpoolContext,
+  WhirlpoolIx,
 } from "../../src";
 import {
-  TickSpacing,
-  systemTransferTx,
-  ONE_SOL,
-  ZERO_BN,
-  mintToByAuthority,
   createMint,
   createMintInstructions,
+  mintToByAuthority,
+  ONE_SOL,
+  systemTransferTx,
+  TickSpacing,
+  ZERO_BN,
 } from "../utils";
 import { initTestPool, openPosition } from "../utils/init-utils";
 import { generateDefaultOpenPositionParams } from "../utils/test-builders";
-import { PDA } from "@orca-so/common-sdk";
 
 describe("open_position", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
 
   let defaultParams: OpenPositionParams;
   let defaultMint: Keypair;
@@ -208,7 +206,7 @@ describe("open_position", () => {
       ))
     );
 
-    await provider.send(tx, [positionMintKeypair], { commitment: "confirmed" });
+    await provider.sendAndConfirm(tx, [positionMintKeypair], { commitment: "confirmed" });
 
     await assert.rejects(
       toTx(

--- a/sdk/tests/integration/open_position.test.ts
+++ b/sdk/tests/integration/open_position.test.ts
@@ -31,7 +31,7 @@ describe("open_position", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   let defaultParams: OpenPositionParams;

--- a/sdk/tests/integration/open_position_with_metadata.test.ts
+++ b/sdk/tests/integration/open_position_with_metadata.test.ts
@@ -35,7 +35,7 @@ describe("open_position_with_metadata", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   let defaultParams: Required<OpenPositionParams & { metadataPda: PDA }>;

--- a/sdk/tests/integration/set_collect_protocol_fee_authority.test.ts
+++ b/sdk/tests/integration/set_collect_protocol_fee_authority.test.ts
@@ -1,20 +1,14 @@
-import * as assert from "assert";
 import * as anchor from "@project-serum/anchor";
-import {
-  WhirlpoolContext,
-  AccountFetcher,
-  WhirlpoolsConfigData,
-  WhirlpoolIx,
-  toTx,
-} from "../../src";
+import * as assert from "assert";
+import { toTx, WhirlpoolContext, WhirlpoolIx, WhirlpoolsConfigData } from "../../src";
 import { generateDefaultConfigParams } from "../utils/test-builders";
 
 describe("set_collect_protocol_fee_authority", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
 
   it("successfully set_collect_protocol_fee_authority", async () => {
     const {

--- a/sdk/tests/integration/set_collect_protocol_fee_authority.test.ts
+++ b/sdk/tests/integration/set_collect_protocol_fee_authority.test.ts
@@ -7,7 +7,7 @@ describe("set_collect_protocol_fee_authority", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   it("successfully set_collect_protocol_fee_authority", async () => {

--- a/sdk/tests/integration/set_default_fee_rate.test.ts
+++ b/sdk/tests/integration/set_default_fee_rate.test.ts
@@ -1,24 +1,19 @@
-import * as assert from "assert";
 import * as anchor from "@project-serum/anchor";
+import * as assert from "assert";
 import {
-  WhirlpoolContext,
-  AccountFetcher,
-  WhirlpoolData,
-  InitPoolParams,
-  WhirlpoolIx,
-  PDAUtil,
-  toTx,
+  InitPoolParams, PDAUtil,
+  toTx, WhirlpoolContext, WhirlpoolData, WhirlpoolIx
 } from "../../src";
 import { TickSpacing } from "../utils";
 import { initTestPool } from "../utils/init-utils";
 import { createInOrderMints, generateDefaultConfigParams } from "../utils/test-builders";
 
 describe("set_default_fee_rate", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
 
   it("successfully set_default_fee_rate", async () => {
     const { poolInitInfo, configInitInfo, configKeypairs, feeTierParams } = await initTestPool(

--- a/sdk/tests/integration/set_default_fee_rate.test.ts
+++ b/sdk/tests/integration/set_default_fee_rate.test.ts
@@ -1,8 +1,12 @@
 import * as anchor from "@project-serum/anchor";
 import * as assert from "assert";
 import {
-  InitPoolParams, PDAUtil,
-  toTx, WhirlpoolContext, WhirlpoolData, WhirlpoolIx
+  InitPoolParams,
+  PDAUtil,
+  toTx,
+  WhirlpoolContext,
+  WhirlpoolData,
+  WhirlpoolIx,
 } from "../../src";
 import { TickSpacing } from "../utils";
 import { initTestPool } from "../utils/init-utils";
@@ -12,7 +16,7 @@ describe("set_default_fee_rate", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   it("successfully set_default_fee_rate", async () => {

--- a/sdk/tests/integration/set_default_protocol_fee_rate.test.ts
+++ b/sdk/tests/integration/set_default_protocol_fee_rate.test.ts
@@ -1,24 +1,19 @@
-import * as assert from "assert";
 import * as anchor from "@project-serum/anchor";
+import * as assert from "assert";
 import {
-  WhirlpoolContext,
-  AccountFetcher,
-  WhirlpoolData,
-  InitPoolParams,
-  WhirlpoolIx,
-  PDAUtil,
-  toTx,
+  InitPoolParams, PDAUtil,
+  toTx, WhirlpoolContext, WhirlpoolData, WhirlpoolIx
 } from "../../src";
 import { TickSpacing } from "../utils";
 import { initTestPool } from "../utils/init-utils";
 import { createInOrderMints } from "../utils/test-builders";
 
 describe("set_default_protocol_fee_rate", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
 
   it("successfully set_default_protocol_fee_rate", async () => {
     const { poolInitInfo, configInitInfo, configKeypairs } = await initTestPool(

--- a/sdk/tests/integration/set_default_protocol_fee_rate.test.ts
+++ b/sdk/tests/integration/set_default_protocol_fee_rate.test.ts
@@ -1,8 +1,12 @@
 import * as anchor from "@project-serum/anchor";
 import * as assert from "assert";
 import {
-  InitPoolParams, PDAUtil,
-  toTx, WhirlpoolContext, WhirlpoolData, WhirlpoolIx
+  InitPoolParams,
+  PDAUtil,
+  toTx,
+  WhirlpoolContext,
+  WhirlpoolData,
+  WhirlpoolIx,
 } from "../../src";
 import { TickSpacing } from "../utils";
 import { initTestPool } from "../utils/init-utils";
@@ -12,7 +16,7 @@ describe("set_default_protocol_fee_rate", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   it("successfully set_default_protocol_fee_rate", async () => {

--- a/sdk/tests/integration/set_fee_authority.test.ts
+++ b/sdk/tests/integration/set_fee_authority.test.ts
@@ -1,20 +1,14 @@
-import * as assert from "assert";
 import * as anchor from "@project-serum/anchor";
-import {
-  WhirlpoolContext,
-  AccountFetcher,
-  WhirlpoolsConfigData,
-  WhirlpoolIx,
-  toTx,
-} from "../../src";
+import * as assert from "assert";
+import { toTx, WhirlpoolContext, WhirlpoolIx, WhirlpoolsConfigData } from "../../src";
 import { generateDefaultConfigParams } from "../utils/test-builders";
 
 describe("set_fee_authority", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
 
   it("successfully set_fee_authority", async () => {
     const {

--- a/sdk/tests/integration/set_fee_authority.test.ts
+++ b/sdk/tests/integration/set_fee_authority.test.ts
@@ -7,7 +7,7 @@ describe("set_fee_authority", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   it("successfully set_fee_authority", async () => {

--- a/sdk/tests/integration/set_fee_rate.test.ts
+++ b/sdk/tests/integration/set_fee_rate.test.ts
@@ -9,7 +9,7 @@ describe("set_fee_rate", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   it("successfully sets_fee_rate", async () => {

--- a/sdk/tests/integration/set_fee_rate.test.ts
+++ b/sdk/tests/integration/set_fee_rate.test.ts
@@ -1,16 +1,16 @@
-import * as assert from "assert";
 import * as anchor from "@project-serum/anchor";
-import { WhirlpoolContext, AccountFetcher, WhirlpoolData, WhirlpoolIx, toTx } from "../../src";
+import * as assert from "assert";
+import { toTx, WhirlpoolContext, WhirlpoolData, WhirlpoolIx } from "../../src";
 import { TickSpacing } from "../utils";
 import { initTestPool } from "../utils/init-utils";
 import { generateDefaultConfigParams } from "../utils/test-builders";
 
 describe("set_fee_rate", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
 
   it("successfully sets_fee_rate", async () => {
     const { poolInitInfo, configInitInfo, configKeypairs, feeTierParams } = await initTestPool(

--- a/sdk/tests/integration/set_protocol_fee_rate.test.ts
+++ b/sdk/tests/integration/set_protocol_fee_rate.test.ts
@@ -9,7 +9,7 @@ describe("set_protocol_fee_rate", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   it("successfully sets_protocol_fee_rate", async () => {

--- a/sdk/tests/integration/set_protocol_fee_rate.test.ts
+++ b/sdk/tests/integration/set_protocol_fee_rate.test.ts
@@ -1,16 +1,16 @@
-import * as assert from "assert";
 import * as anchor from "@project-serum/anchor";
-import { WhirlpoolContext, AccountFetcher, WhirlpoolData, WhirlpoolIx, toTx } from "../../src";
+import * as assert from "assert";
+import { toTx, WhirlpoolContext, WhirlpoolData, WhirlpoolIx } from "../../src";
 import { TickSpacing } from "../utils";
 import { initTestPool } from "../utils/init-utils";
 import { generateDefaultConfigParams } from "../utils/test-builders";
 
 describe("set_protocol_fee_rate", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
 
   it("successfully sets_protocol_fee_rate", async () => {
     const { poolInitInfo, configInitInfo, configKeypairs } = await initTestPool(

--- a/sdk/tests/integration/set_reward_authority.test.ts
+++ b/sdk/tests/integration/set_reward_authority.test.ts
@@ -1,29 +1,22 @@
-import * as assert from "assert";
+import { TransactionBuilder } from "@orca-so/common-sdk";
 import * as anchor from "@project-serum/anchor";
-import {
-  WhirlpoolContext,
-  AccountFetcher,
-  NUM_REWARDS,
-  WhirlpoolData,
-  WhirlpoolIx,
-  toTx,
-} from "../../src";
+import * as assert from "assert";
+import { NUM_REWARDS, toTx, WhirlpoolContext, WhirlpoolData, WhirlpoolIx } from "../../src";
 import { TickSpacing } from "../utils";
 import { initTestPool } from "../utils/init-utils";
-import { TransactionBuilder } from "@orca-so/common-sdk";
 
 describe("set_reward_authority", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
 
   it("successfully set_reward_authority at every reward index", async () => {
     const { configKeypairs, poolInitInfo } = await initTestPool(ctx, TickSpacing.Standard);
 
     const newKeypairs = generateKeypairs(NUM_REWARDS);
-    const txBuilder = new TransactionBuilder(provider);
+    const txBuilder = new TransactionBuilder(provider.connection, provider.wallet);
     for (let i = 0; i < NUM_REWARDS; i++) {
       txBuilder.addInstruction(
         WhirlpoolIx.setRewardAuthorityIx(ctx.program, {

--- a/sdk/tests/integration/set_reward_authority.test.ts
+++ b/sdk/tests/integration/set_reward_authority.test.ts
@@ -9,7 +9,7 @@ describe("set_reward_authority", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   it("successfully set_reward_authority at every reward index", async () => {

--- a/sdk/tests/integration/set_reward_authority_by_super_authority.test.ts
+++ b/sdk/tests/integration/set_reward_authority_by_super_authority.test.ts
@@ -1,15 +1,15 @@
-import * as assert from "assert";
 import * as anchor from "@project-serum/anchor";
-import { WhirlpoolContext, AccountFetcher, WhirlpoolData, WhirlpoolIx, toTx } from "../../src";
+import * as assert from "assert";
+import { toTx, WhirlpoolContext, WhirlpoolData, WhirlpoolIx } from "../../src";
 import { TickSpacing } from "../utils";
 import { initTestPool } from "../utils/init-utils";
 
 describe("set_reward_authority_by_super_authority", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
 
   it("successfully set_reward_authority_by_super_authority", async () => {
     const { configKeypairs, poolInitInfo, configInitInfo } = await initTestPool(

--- a/sdk/tests/integration/set_reward_authority_by_super_authority.test.ts
+++ b/sdk/tests/integration/set_reward_authority_by_super_authority.test.ts
@@ -8,7 +8,7 @@ describe("set_reward_authority_by_super_authority", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   it("successfully set_reward_authority_by_super_authority", async () => {

--- a/sdk/tests/integration/set_reward_emissions.test.ts
+++ b/sdk/tests/integration/set_reward_emissions.test.ts
@@ -1,15 +1,15 @@
 import * as anchor from "@project-serum/anchor";
 import * as assert from "assert";
-import { WhirlpoolContext, AccountFetcher, WhirlpoolData, WhirlpoolIx, toTx } from "../../src";
-import { TickSpacing, mintToByAuthority, ZERO_BN, createAndMintToTokenAccount } from "../utils";
-import { initTestPool, initializeReward } from "../utils/init-utils";
+import { toTx, WhirlpoolContext, WhirlpoolData, WhirlpoolIx } from "../../src";
+import { createAndMintToTokenAccount, mintToByAuthority, TickSpacing, ZERO_BN } from "../utils";
+import { initializeReward, initTestPool } from "../utils/init-utils";
 
 describe("set_reward_emissions", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
 
   const emissionsPerSecondX64 = new anchor.BN(10_000).shln(64).div(new anchor.BN(60 * 60 * 24));
 

--- a/sdk/tests/integration/set_reward_emissions.test.ts
+++ b/sdk/tests/integration/set_reward_emissions.test.ts
@@ -8,7 +8,7 @@ describe("set_reward_emissions", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   const emissionsPerSecondX64 = new anchor.BN(10_000).shln(64).div(new anchor.BN(60 * 60 * 24));

--- a/sdk/tests/integration/set_reward_emissions_super_authority.test.ts
+++ b/sdk/tests/integration/set_reward_emissions_super_authority.test.ts
@@ -7,7 +7,7 @@ describe("set_reward_emissions_super_authority", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   it("successfully set_reward_emissions_super_authority with super authority keypair", async () => {

--- a/sdk/tests/integration/set_reward_emissions_super_authority.test.ts
+++ b/sdk/tests/integration/set_reward_emissions_super_authority.test.ts
@@ -1,20 +1,14 @@
-import * as assert from "assert";
 import * as anchor from "@project-serum/anchor";
-import {
-  WhirlpoolContext,
-  AccountFetcher,
-  WhirlpoolsConfigData,
-  WhirlpoolIx,
-  toTx,
-} from "../../src";
+import * as assert from "assert";
+import { toTx, WhirlpoolContext, WhirlpoolIx, WhirlpoolsConfigData } from "../../src";
 import { generateDefaultConfigParams } from "../utils/test-builders";
 
 describe("set_reward_emissions_super_authority", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
 
   it("successfully set_reward_emissions_super_authority with super authority keypair", async () => {
     const {

--- a/sdk/tests/integration/swap.test.ts
+++ b/sdk/tests/integration/swap.test.ts
@@ -1,41 +1,40 @@
+import { MathUtil, Percentage } from "@orca-so/common-sdk";
 import * as anchor from "@project-serum/anchor";
-import * as assert from "assert";
 import { web3 } from "@project-serum/anchor";
-import Decimal from "decimal.js";
 import { u64 } from "@solana/spl-token";
+import * as assert from "assert";
+import Decimal from "decimal.js";
 import {
-  WhirlpoolContext,
-  AccountFetcher,
-  SwapParams,
+  buildWhirlpoolClient,
   MAX_SQRT_PRICE,
   MIN_SQRT_PRICE,
-  TickArrayData,
-  PriceMath,
-  WhirlpoolIx,
   PDAUtil,
-  toTx,
+  PriceMath,
+  SwapParams,
   swapQuoteByInputToken,
-  buildWhirlpoolClient,
+  TickArrayData,
+  toTx,
+  WhirlpoolContext,
+  WhirlpoolIx,
 } from "../../src";
-import { TickSpacing, ZERO_BN, getTokenBalance, MAX_U64 } from "../utils";
+import { getTokenBalance, MAX_U64, TickSpacing, ZERO_BN } from "../utils";
 import {
-  initTestPoolWithTokens,
-  initTickArrayRange,
-  initTestPool,
   FundedPositionParams,
   fundPositions,
+  initTestPool,
   initTestPoolWithLiquidity,
+  initTestPoolWithTokens,
+  initTickArrayRange,
   withdrawPositions,
 } from "../utils/init-utils";
-import { MathUtil, Percentage } from "@orca-so/common-sdk";
 
 describe("swap", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
-  const client = buildWhirlpoolClient(ctx, fetcher);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
+  const client = buildWhirlpoolClient(ctx);
 
   it("fail on token vault mint a does not match whirlpool token a", async () => {
     const { poolInitInfo, whirlpoolPda, tokenAccountA, tokenAccountB } =

--- a/sdk/tests/integration/swap.test.ts
+++ b/sdk/tests/integration/swap.test.ts
@@ -32,7 +32,7 @@ describe("swap", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
   const client = buildWhirlpoolClient(ctx);
 

--- a/sdk/tests/integration/update_fees_and_rewards.test.ts
+++ b/sdk/tests/integration/update_fees_and_rewards.test.ts
@@ -12,7 +12,7 @@ describe("update_fees_and_rewards", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
   it("successfully updates fees and rewards", async () => {

--- a/sdk/tests/integration/update_fees_and_rewards.test.ts
+++ b/sdk/tests/integration/update_fees_and_rewards.test.ts
@@ -1,26 +1,19 @@
+import { MathUtil } from "@orca-so/common-sdk";
 import * as anchor from "@project-serum/anchor";
-import * as assert from "assert";
 import { u64 } from "@solana/spl-token";
+import * as assert from "assert";
 import Decimal from "decimal.js";
-import {
-  WhirlpoolContext,
-  AccountFetcher,
-  PositionData,
-  WhirlpoolIx,
-  PDAUtil,
-  toTx,
-} from "../../src";
-import { TickSpacing, ZERO_BN, sleep } from "../utils";
+import { PDAUtil, PositionData, toTx, WhirlpoolContext, WhirlpoolIx } from "../../src";
+import { sleep, TickSpacing, ZERO_BN } from "../utils";
 import { WhirlpoolTestFixture } from "../utils/fixture";
 import { initTestPool } from "../utils/init-utils";
-import { MathUtil } from "@orca-so/common-sdk";
 
 describe("update_fees_and_rewards", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
 
   it("successfully updates fees and rewards", async () => {
     // In same tick array - start index 22528

--- a/sdk/tests/sdk/whirlpools/position-impl.test.ts
+++ b/sdk/tests/sdk/whirlpools/position-impl.test.ts
@@ -15,12 +15,12 @@ import { deriveATA, Percentage } from "@orca-so/common-sdk";
 import { initPosition, mintTokensToTestAccount } from "../../utils/test-builders";
 
 describe("position-impl", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
-  const client = buildWhirlpoolClient(ctx, fetcher);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
+  const client = buildWhirlpoolClient(ctx);
 
   it("increase and decrease liquidity on position", async () => {
     const { poolInitInfo } = await initTestPool(

--- a/sdk/tests/sdk/whirlpools/position-impl.test.ts
+++ b/sdk/tests/sdk/whirlpools/position-impl.test.ts
@@ -1,24 +1,23 @@
+import { deriveATA, Percentage } from "@orca-so/common-sdk";
 import * as anchor from "@project-serum/anchor";
 import * as assert from "assert";
-import { WhirlpoolContext } from "../../../src/context";
-import { initTestPool } from "../../utils/init-utils";
-import { createAssociatedTokenAccount, TickSpacing, transfer } from "../../utils";
+import Decimal from "decimal.js";
 import {
-  AccountFetcher,
   buildWhirlpoolClient,
   decreaseLiquidityQuoteByLiquidity,
   increaseLiquidityQuoteByInputToken,
   PriceMath,
 } from "../../../src";
-import Decimal from "decimal.js";
-import { deriveATA, Percentage } from "@orca-so/common-sdk";
+import { WhirlpoolContext } from "../../../src/context";
+import { createAssociatedTokenAccount, TickSpacing, transfer } from "../../utils";
+import { initTestPool } from "../../utils/init-utils";
 import { initPosition, mintTokensToTestAccount } from "../../utils/test-builders";
 
 describe("position-impl", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
   const client = buildWhirlpoolClient(ctx);
 

--- a/sdk/tests/sdk/whirlpools/swap/swap-array.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/swap-array.test.ts
@@ -1,36 +1,35 @@
-import BN from "bn.js";
-import * as anchor from "@project-serum/anchor";
-import * as assert from "assert";
-import {
-  PriceMath,
-  AccountFetcher,
-  buildWhirlpoolClient,
-  WhirlpoolContext,
-  TICK_ARRAY_SIZE,
-  swapQuoteByInputToken,
-  PDAUtil,
-  SwapUtils,
-  swapQuoteWithParams,
-} from "../../../../src";
-import {
-  arrayTickIndexToTickIndex,
-  setupSwapTest,
-  buildPosition,
-} from "../../../utils/swap-test-utils";
 import { AddressUtil, Percentage, ZERO } from "@orca-so/common-sdk";
-import { TickSpacing } from "../../../utils";
+import * as anchor from "@project-serum/anchor";
 import { u64 } from "@solana/spl-token";
+import * as assert from "assert";
+import BN from "bn.js";
+import {
+  buildWhirlpoolClient,
+  PDAUtil,
+  PriceMath,
+  swapQuoteByInputToken,
+  swapQuoteWithParams,
+  SwapUtils,
+  TICK_ARRAY_SIZE,
+  WhirlpoolContext,
+} from "../../../../src";
 import { SwapErrorCode, WhirlpoolsError } from "../../../../src/errors/errors";
 import { adjustForSlippage } from "../../../../src/utils/position-util";
+import { TickSpacing } from "../../../utils";
+import {
+  arrayTickIndexToTickIndex,
+  buildPosition,
+  setupSwapTest,
+} from "../../../utils/swap-test-utils";
 import { getTickArrays } from "../../../utils/testDataTypes";
 
 describe("swap arrays test", async () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
-  const client = buildWhirlpoolClient(ctx, fetcher);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
+  const client = buildWhirlpoolClient(ctx);
   const tickSpacing = TickSpacing.SixtyFour;
   const slippageTolerance = Percentage.fromFraction(0, 100);
 

--- a/sdk/tests/sdk/whirlpools/swap/swap-array.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/swap-array.test.ts
@@ -27,7 +27,7 @@ describe("swap arrays test", async () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
   const client = buildWhirlpoolClient(ctx);
   const tickSpacing = TickSpacing.SixtyFour;

--- a/sdk/tests/sdk/whirlpools/swap/swap-traverse.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/swap-traverse.test.ts
@@ -1,35 +1,34 @@
+import { Percentage } from "@orca-so/common-sdk";
 import * as anchor from "@project-serum/anchor";
+import { u64 } from "@solana/spl-token";
 import * as assert from "assert";
+import { BN } from "bn.js";
 import {
-  WhirlpoolContext,
-  AccountFetcher,
   buildWhirlpoolClient,
-  PriceMath,
-  TICK_ARRAY_SIZE,
-  swapQuoteByInputToken,
   MAX_TICK_INDEX,
   MIN_TICK_INDEX,
+  PriceMath,
+  swapQuoteByInputToken,
   swapQuoteByOutputToken,
+  TICK_ARRAY_SIZE,
+  WhirlpoolContext,
 } from "../../../../src";
+import { SwapErrorCode, WhirlpoolsError } from "../../../../src/errors/errors";
 import { assertInputOutputQuoteEqual, assertQuoteAndResults, TickSpacing } from "../../../utils";
-import { Percentage } from "@orca-so/common-sdk";
-import { u64 } from "@solana/spl-token";
-import { BN } from "bn.js";
 import {
   arrayTickIndexToTickIndex,
   buildPosition,
   setupSwapTest,
 } from "../../../utils/swap-test-utils";
-import { SwapErrorCode, WhirlpoolsError } from "../../../../src/errors/errors";
 import { getVaultAmounts } from "../../../utils/whirlpools-test-utils";
 
 describe("swap traversal tests", async () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
-  const client = buildWhirlpoolClient(ctx, fetcher);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
+  const client = buildWhirlpoolClient(ctx);
   const tickSpacing = TickSpacing.SixtyFour;
   const slippageTolerance = Percentage.fromFraction(0, 100);
 

--- a/sdk/tests/sdk/whirlpools/swap/swap-traverse.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/swap-traverse.test.ts
@@ -26,7 +26,7 @@ describe("swap traversal tests", async () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
   const client = buildWhirlpoolClient(ctx);
   const tickSpacing = TickSpacing.SixtyFour;

--- a/sdk/tests/sdk/whirlpools/whirlpool-impl.test.ts
+++ b/sdk/tests/sdk/whirlpools/whirlpool-impl.test.ts
@@ -1,7 +1,16 @@
-import * as assert from "assert";
+import { deriveATA, Percentage, TransactionBuilder } from "@orca-so/common-sdk";
 import * as anchor from "@project-serum/anchor";
+import * as assert from "assert";
+import Decimal from "decimal.js";
+import {
+  buildWhirlpoolClient,
+  decreaseLiquidityQuoteByLiquidity,
+  increaseLiquidityQuoteByInputToken,
+  PDAUtil,
+  PriceMath,
+  TickUtil,
+} from "../../../src";
 import { WhirlpoolContext } from "../../../src/context";
-import { initTestPool } from "../../utils/init-utils";
 import {
   createAssociatedTokenAccount,
   getTokenBalance,
@@ -10,24 +19,14 @@ import {
   TickSpacing,
   transfer,
 } from "../../utils";
-import {
-  AccountFetcher,
-  buildWhirlpoolClient,
-  decreaseLiquidityQuoteByLiquidity,
-  increaseLiquidityQuoteByInputToken,
-  PDAUtil,
-  PriceMath,
-  TickUtil,
-} from "../../../src";
-import Decimal from "decimal.js";
-import { deriveATA, Percentage, TransactionBuilder } from "@orca-so/common-sdk";
+import { initTestPool } from "../../utils/init-utils";
 import { mintTokensToTestAccount } from "../../utils/test-builders";
 
 describe("whirlpool-impl", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
   const client = buildWhirlpoolClient(ctx);
 

--- a/sdk/tests/sdk/whirlpools/whirlpool-impl.test.ts
+++ b/sdk/tests/sdk/whirlpools/whirlpool-impl.test.ts
@@ -24,12 +24,12 @@ import { deriveATA, Percentage, TransactionBuilder } from "@orca-so/common-sdk";
 import { mintTokensToTestAccount } from "../../utils/test-builders";
 
 describe("whirlpool-impl", () => {
-  const provider = anchor.Provider.local();
-  anchor.setProvider(anchor.Provider.env());
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
-  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
-  const fetcher = new AccountFetcher(ctx.connection);
-  const client = buildWhirlpoolClient(ctx, fetcher);
+  const ctx = WhirlpoolContext.fromWorkspace(provider, provider.wallet, program);
+  const fetcher = ctx.fetcher;
+  const client = buildWhirlpoolClient(ctx);
 
   it("open and add liquidity to a position, then close", async () => {
     const funderKeypair = anchor.web3.Keypair.generate();

--- a/sdk/tests/utils/init-utils.ts
+++ b/sdk/tests/utils/init-utils.ts
@@ -357,7 +357,7 @@ export async function withdrawPositions(
   tokenOwnerAccountA: PublicKey,
   tokenOwnerAccountB: PublicKey
 ) {
-  const fetcher = new AccountFetcher(ctx.connection);
+  const fetcher = ctx.fetcher;
   await Promise.all(
     positionInfos.map(async (info) => {
       const pool = await fetcher.getPool(info.initParams.whirlpool);

--- a/sdk/tests/utils/test-builders.ts
+++ b/sdk/tests/utils/test-builders.ts
@@ -1,5 +1,5 @@
 import { MathUtil, PDA, Percentage } from "@orca-so/common-sdk";
-import { Provider } from "@project-serum/anchor";
+import { AnchorProvider } from "@project-serum/anchor";
 import { ASSOCIATED_TOKEN_PROGRAM_ID, Token, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { Keypair, PublicKey } from "@solana/web3.js";
 import Decimal from "decimal.js";
@@ -174,7 +174,7 @@ export async function generateDefaultOpenPositionParams(
 }
 
 export async function mintTokensToTestAccount(
-  provider: Provider,
+  provider: AnchorProvider,
   tokenAMint: PublicKey,
   tokenMintForA: number,
   tokenBMint: PublicKey,

--- a/sdk/tests/utils/token.ts
+++ b/sdk/tests/utils/token.ts
@@ -1,5 +1,5 @@
 import { deriveATA } from "@orca-so/common-sdk";
-import { BN, Provider, web3 } from "@project-serum/anchor";
+import { BN, AnchorProvider, web3 } from "@project-serum/anchor";
 import {
   ASSOCIATED_TOKEN_PROGRAM_ID,
   AuthorityType,
@@ -10,7 +10,7 @@ import {
 import { TEST_TOKEN_PROGRAM_ID } from "./test-consts";
 
 export async function createMint(
-  provider: Provider,
+  provider: AnchorProvider,
   authority?: web3.PublicKey
 ): Promise<web3.PublicKey> {
   if (authority === undefined) {
@@ -22,13 +22,13 @@ export async function createMint(
   const tx = new web3.Transaction();
   tx.add(...instructions);
 
-  await provider.send(tx, [mint], { commitment: "confirmed" });
+  await provider.sendAndConfirm(tx, [mint], { commitment: "confirmed" });
 
   return mint.publicKey;
 }
 
 export async function createMintInstructions(
-  provider: Provider,
+  provider: AnchorProvider,
   authority: web3.PublicKey,
   mint: web3.PublicKey
 ) {
@@ -46,19 +46,19 @@ export async function createMintInstructions(
 }
 
 export async function createTokenAccount(
-  provider: Provider,
+  provider: AnchorProvider,
   mint: web3.PublicKey,
   owner: web3.PublicKey
 ) {
   const tokenAccount = web3.Keypair.generate();
   const tx = new web3.Transaction();
   tx.add(...(await createTokenAccountInstrs(provider, tokenAccount.publicKey, mint, owner)));
-  await provider.send(tx, [tokenAccount], { commitment: "confirmed" });
+  await provider.sendAndConfirm(tx, [tokenAccount], { commitment: "confirmed" });
   return tokenAccount.publicKey;
 }
 
 export async function createAssociatedTokenAccount(
-  provider: Provider,
+  provider: AnchorProvider,
   mint: web3.PublicKey,
   owner: web3.PublicKey,
   payer: web3.PublicKey
@@ -75,12 +75,12 @@ export async function createAssociatedTokenAccount(
   );
   const tx = new web3.Transaction();
   tx.add(instr);
-  await provider.send(tx, [], { commitment: "confirmed" });
+  await provider.sendAndConfirm(tx, [], { commitment: "confirmed" });
   return ataAddress;
 }
 
 async function createTokenAccountInstrs(
-  provider: Provider,
+  provider: AnchorProvider,
   newAccountPubkey: web3.PublicKey,
   mint: web3.PublicKey,
   owner: web3.PublicKey,
@@ -103,13 +103,13 @@ async function createTokenAccountInstrs(
 
 /**
  * Mints tokens to the specified destination token account.
- * @param provider An anchor Provider object used to send transactions
+ * @param provider An anchor AnchorProvider object used to send transactions
  * @param mint Mint address of the token
  * @param destination Destination token account to receive tokens
  * @param amount Number of tokens to mint
  */
 export async function mintToByAuthority(
-  provider: Provider,
+  provider: AnchorProvider,
   mint: web3.PublicKey,
   destination: web3.PublicKey,
   amount: number | BN
@@ -125,18 +125,18 @@ export async function mintToByAuthority(
       amount
     )
   );
-  return provider.send(tx, [], { commitment: "confirmed" });
+  return provider.sendAndConfirm(tx, [], { commitment: "confirmed" });
 }
 
 /**
  * Creates a token account for the mint and mints the specified amount of tokens into the token account.
  * The caller is assumed to be the mint authority.
- * @param provider An anchor Provider object used to send transactions
+ * @param provider An anchor AnchorProvider object used to send transactions
  * @param mint The mint address of the token
  * @param amount Number of tokens to mint to the newly created token account
  */
 export async function createAndMintToTokenAccount(
-  provider: Provider,
+  provider: AnchorProvider,
   mint: web3.PublicKey,
   amount: number | BN
 ): Promise<web3.PublicKey> {
@@ -146,7 +146,7 @@ export async function createAndMintToTokenAccount(
 }
 
 export async function createAndMintToAssociatedTokenAccount(
-  provider: Provider,
+  provider: AnchorProvider,
   mint: web3.PublicKey,
   amount: number | BN,
   destinationWallet?: web3.PublicKey,
@@ -164,12 +164,12 @@ export async function createAndMintToAssociatedTokenAccount(
   return tokenAccount;
 }
 
-export async function getTokenBalance(provider: Provider, vault: web3.PublicKey) {
+export async function getTokenBalance(provider: AnchorProvider, vault: web3.PublicKey) {
   return (await provider.connection.getTokenAccountBalance(vault, "confirmed")).value.amount;
 }
 
 export async function approveToken(
-  provider: Provider,
+  provider: AnchorProvider,
   tokenAccount: web3.PublicKey,
   delegate: web3.PublicKey,
   amount: number | u64,
@@ -186,11 +186,11 @@ export async function approveToken(
       amount
     )
   );
-  return provider.send(tx, [owner], { commitment: "confirmed" });
+  return provider.sendAndConfirm(tx, !!owner ? [owner] : [], { commitment: "confirmed" });
 }
 
 export async function setAuthority(
-  provider: Provider,
+  provider: AnchorProvider,
   tokenAccount: web3.PublicKey,
   newAuthority: web3.PublicKey,
   authorityType: AuthorityType,
@@ -208,11 +208,11 @@ export async function setAuthority(
     )
   );
 
-  return provider.send(tx, [authority], { commitment: "confirmed" });
+  return provider.sendAndConfirm(tx, [authority], { commitment: "confirmed" });
 }
 
 export async function transfer(
-  provider: Provider,
+  provider: AnchorProvider,
   source: web3.PublicKey,
   destination: web3.PublicKey,
   amount: number
@@ -228,5 +228,5 @@ export async function transfer(
       amount
     )
   );
-  return provider.send(tx, [], { commitment: "confirmed" });
+  return provider.sendAndConfirm(tx, [], { commitment: "confirmed" });
 }

--- a/sdk/tests/utils/utils.ts
+++ b/sdk/tests/utils/utils.ts
@@ -1,12 +1,12 @@
 import { TransactionBuilder } from "@orca-so/common-sdk";
-import { web3, Provider } from "@project-serum/anchor";
+import { web3, AnchorProvider } from "@project-serum/anchor";
 
 export function systemTransferTx(
-  provider: Provider,
+  provider: AnchorProvider,
   toPubkey: web3.PublicKey,
   lamports: number
 ): TransactionBuilder {
-  return new TransactionBuilder(provider).addInstruction({
+  return new TransactionBuilder(provider.connection, provider.wallet).addInstruction({
     instructions: [
       web3.SystemProgram.transfer({
         fromPubkey: provider.wallet.publicKey,

--- a/yarn.lock
+++ b/yarn.lock
@@ -565,12 +565,12 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@orca-so/common-sdk@^0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@orca-so/common-sdk/-/common-sdk-0.0.7.tgz#16f77a68beded3eda227f22be0d8b1f85fe7ebf3"
-  integrity sha512-DF2wR39dHPKnOh8zBlVy/uWA58HQ6Vgi6fOOY1FJCgZTuR8/k65ALC3z632iCJh0GP3Upmcmjqn3OeBiEZr6tA==
+"@orca-so/common-sdk@~0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@orca-so/common-sdk/-/common-sdk-0.1.0.tgz#25050f18e95bab6a7ef9b10e2d3bd44699ce9836"
+  integrity sha512-WH6mjrrJyuUMq0DC41jWW6opEIq5Ip/UOf8h7z/gM9Zx+9156JwP/dm8N5GJTNnIG6GYFfhemyNNPj1y3U5LIw==
   dependencies:
-    "@project-serum/anchor" "0.20.1"
+    "@project-serum/anchor" "~0.25.0"
     "@solana/spl-token" "0.1.8"
     decimal.js "^10.3.1"
 
@@ -584,7 +584,7 @@
     "@solana/spl-token" "^0.1.8"
     decimal.js "^10.3.1"
 
-"@project-serum/anchor@0.20.1", "@project-serum/anchor@^0.20.1":
+"@project-serum/anchor@^0.20.1":
   version "0.20.1"
   resolved "https://registry.yarnpkg.com/@project-serum/anchor/-/anchor-0.20.1.tgz#0937807e807e8332aa708cfef4bcb6cbb88b4129"
   integrity sha512-2TuBmGUn9qeYz6sJINJlElrBuPsaUAtYyUsJ3XplEBf1pczrANAgs5ceJUFzdiqGEWLn+84ObSdBeChT/AXYFA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -604,7 +604,28 @@
     snake-case "^3.0.4"
     toml "^3.0.0"
 
-"@project-serum/borsh@^0.2.2":
+"@project-serum/anchor@~0.25.0":
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/@project-serum/anchor/-/anchor-0.25.0.tgz#88ee4843336005cf5a64c80636ce626f0996f503"
+  integrity sha512-E6A5Y/ijqpfMJ5psJvbw0kVTzLZFUcOFgs6eSM2M2iWE1lVRF18T6hWZVNl6zqZsoz98jgnNHtVGJMs+ds9A7A==
+  dependencies:
+    "@project-serum/borsh" "^0.2.5"
+    "@solana/web3.js" "^1.36.0"
+    base64-js "^1.5.1"
+    bn.js "^5.1.2"
+    bs58 "^4.0.1"
+    buffer-layout "^1.2.2"
+    camelcase "^5.3.1"
+    cross-fetch "^3.1.5"
+    crypto-hash "^1.3.0"
+    eventemitter3 "^4.0.7"
+    js-sha256 "^0.9.0"
+    pako "^2.0.3"
+    snake-case "^3.0.4"
+    superstruct "^0.15.4"
+    toml "^3.0.0"
+
+"@project-serum/borsh@^0.2.2", "@project-serum/borsh@^0.2.5":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@project-serum/borsh/-/borsh-0.2.5.tgz#6059287aa624ecebbfc0edd35e4c28ff987d8663"
   integrity sha512-UmeUkUoKdQ7rhx6Leve1SssMR/Ghv8qrEiyywyxSWg7ooV7StdpPBhciiy5eB3T0qU1BXvdRNC8TdrkxK7WC5Q==
@@ -661,6 +682,29 @@
     jayson "^3.4.4"
     js-sha3 "^0.8.0"
     rpc-websockets "^7.4.2"
+    secp256k1 "^4.0.2"
+    superstruct "^0.14.2"
+    tweetnacl "^1.0.0"
+
+"@solana/web3.js@^1.36.0":
+  version "1.48.0"
+  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.48.0.tgz#331281b2d80640431fb3b6fdc6b704ec325917aa"
+  integrity sha512-Gb6XvdhGjGI7CdAXLmlMIEvEYvrwqc78JOtwCsSrTqzz7Ek/BhJpZ/Cv89gxRDrWxf6kHegAfaN2FxwuYMmDZQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@ethersproject/sha2" "^5.5.0"
+    "@solana/buffer-layout" "^4.0.0"
+    bigint-buffer "^1.1.5"
+    bn.js "^5.0.0"
+    borsh "^0.7.0"
+    bs58 "^4.0.1"
+    buffer "6.0.1"
+    fast-stable-stringify "^1.0.0"
+    jayson "^3.4.4"
+    js-sha3 "^0.8.0"
+    node-fetch "2"
+    react-native-url-polyfill "^1.3.0"
+    rpc-websockets "^7.5.0"
     secp256k1 "^4.0.2"
     superstruct "^0.14.2"
     tweetnacl "^1.0.0"
@@ -1117,10 +1161,24 @@ base64-js@^1.3.1, base64-js@^1.5.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
+bigint-buffer@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/bigint-buffer/-/bigint-buffer-1.1.5.tgz#d038f31c8e4534c1f8d0015209bf34b4fa6dd442"
+  integrity sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==
+  dependencies:
+    bindings "^1.3.0"
+
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+bindings@^1.3.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
 
 bn.js@^4.11.9:
   version "4.12.0"
@@ -1228,6 +1286,14 @@ buffer@6.0.3, buffer@~6.0.3:
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
+
+buffer@^5.4.3:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
 
 bufferutil@^4.0.1:
   version "4.0.6"
@@ -1388,7 +1454,7 @@ convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
-cross-fetch@^3.1.4:
+cross-fetch@^3.1.4, cross-fetch@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
@@ -1730,6 +1796,11 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-stable-stringify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz#5c5543462b22aeeefd36d05b34e51c78cb86d313"
+  integrity sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==
+
 fastq@^1.6.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c"
@@ -1743,6 +1814,11 @@ fb-watchman@^2.0.0:
   integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
   dependencies:
     bser "2.1.1"
+
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -1959,7 +2035,7 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-ieee754@^1.2.1:
+ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -2873,7 +2949,7 @@ node-addon-api@^2.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
 
-node-fetch@2.6.7:
+node-fetch@2, node-fetch@2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
@@ -3112,6 +3188,13 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+react-native-url-polyfill@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/react-native-url-polyfill/-/react-native-url-polyfill-1.3.0.tgz#c1763de0f2a8c22cc3e959b654c8790622b6ef6a"
+  integrity sha512-w9JfSkvpqqlix9UjDvJjm1EjSt652zVQ6iwCIj1cVVkwXf4jQhQgTNXY6EVTwuAmUjg6BC6k9RHCBynoLFo3IQ==
+  dependencies:
+    whatwg-url-without-unicode "8.0.0-3"
+
 readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
@@ -3176,6 +3259,19 @@ rpc-websockets@^7.4.2:
   version "7.4.18"
   resolved "https://registry.yarnpkg.com/rpc-websockets/-/rpc-websockets-7.4.18.tgz#274c825c0efadbf6fe75f10289229ae537fe9ffb"
   integrity sha512-bVu+4qM5CkGVlTqJa6FaAxLbb5uRnyH4te7yjFvoCzbnif7PT4BcvXtNTprHlNvsH+/StB81zUQicxMrUrIomA==
+  dependencies:
+    "@babel/runtime" "^7.17.2"
+    eventemitter3 "^4.0.7"
+    uuid "^8.3.2"
+    ws "^8.5.0"
+  optionalDependencies:
+    bufferutil "^4.0.1"
+    utf-8-validate "^5.0.2"
+
+rpc-websockets@^7.5.0:
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/rpc-websockets/-/rpc-websockets-7.5.0.tgz#bbeb87572e66703ff151e50af1658f98098e2748"
+  integrity sha512-9tIRi1uZGy7YmDjErf1Ax3wtqdSSLIlnmL5OtOzgd5eqPKbsPpwDP5whUDO2LQay3Xp0CcHlcNSGzacNRluBaQ==
   dependencies:
     "@babel/runtime" "^7.17.2"
     eventemitter3 "^4.0.7"
@@ -3355,6 +3451,11 @@ superstruct@^0.14.2:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.14.2.tgz#0dbcdf3d83676588828f1cf5ed35cda02f59025b"
   integrity sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ==
+
+superstruct@^0.15.4:
+  version "0.15.5"
+  resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.15.5.tgz#0f0a8d3ce31313f0d84c6096cd4fa1bfdedc9dab"
+  integrity sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ==
 
 supports-color@8.1.1, supports-color@^8.0.0:
   version "8.1.1"
@@ -3632,6 +3733,15 @@ whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url-without-unicode@8.0.0-3:
+  version "8.0.0-3"
+  resolved "https://registry.yarnpkg.com/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz#ab6df4bf6caaa6c85a59f6e82c026151d4bb376b"
+  integrity sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==
+  dependencies:
+    buffer "^5.4.3"
+    punycode "^2.1.1"
+    webidl-conversions "^5.0.0"
 
 whatwg-url@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
- Updating the Anchor SDK dependency (not smart-contract)
- API changes on the parameters on WhirlpoolContext & WhirlpoolClient


## API Changes:
- rename `Provider` -> `AnchorProvider`, `Coder` ->  `BorshAccountsCoder ` from 0.25 changes
- WhirlpoolContext is now retrievable from WhirlpoolClient
- AccountFetcher is now a part of WhirlpoolContext.  
