### PR TITLE
update anchor installation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The contract has been audited by Kudelski and Neodyme.
 
 ## Setup
 
-Install Anchor using instructions found [here](https://project-serum.github.io/anchor/getting-started/installation.html#install-rust).
+Install Anchor using instructions found [here](https://book.anchor-lang.com/getting_started/installation.html#anchor).
 
 Set up a valid Solana keypair at the path specified in the `wallet` in `Anchor.toml` to do local testing with `anchor test` flows.
 


### PR DESCRIPTION
Old (not working): https://project-serum.github.io/anchor/getting-started/installation.html#install-rust
New (working): https://book.anchor-lang.com/getting_started/installation.html#anchor