### PR TITLE
Change data type for liquidity and sqrtPrice to BN

### DIFF
--- a/sdk/src/impl/whirlpool-impl.ts
+++ b/sdk/src/impl/whirlpool-impl.ts
@@ -6,7 +6,7 @@ import {
   TransactionBuilder,
   ZERO,
 } from "@orca-so/common-sdk";
-import { Address, translateAddress } from "@project-serum/anchor";
+import { Address, translateAddress, BN } from "@project-serum/anchor";
 import { WhirlpoolContext } from "../context";
 import {
   IncreaseLiquidityInput,
@@ -22,7 +22,6 @@ import {
 import { TokenInfo, WhirlpoolData } from "../types/public";
 import { Whirlpool } from "../whirlpool-client";
 import { PublicKey, Keypair } from "@solana/web3.js";
-import { u64 } from "@solana/spl-token";
 import { AccountFetcher } from "../network/public";
 import invariant from "tiny-invariant";
 import { PDAUtil, PriceMath, TickArrayUtil, TickUtil } from "../utils/public";
@@ -176,7 +175,7 @@ export class WhirlpoolImpl implements Whirlpool {
 
     const { liquidityAmount: liquidity, tokenMaxA, tokenMaxB } = liquidityInput;
 
-    invariant(liquidity.gt(new u64(0)), "liquidity must be greater than zero");
+    invariant(liquidity.gt(new BN(0)), "liquidity must be greater than zero");
 
     const whirlpool = await this.fetcher.getPool(this.address, false);
     if (!whirlpool) {
@@ -337,7 +336,7 @@ export class WhirlpoolImpl implements Whirlpool {
     // txBuilder.addInstruction(collectTx.compressIx(false));
 
     /* Remove all liquidity remaining in the position */
-    if (position.liquidity.gt(new u64(0))) {
+    if (position.liquidity.gt(new BN(0))) {
       const decreaseLiqQuote = decreaseLiquidityQuoteByLiquidityWithParams({
         liquidity: position.liquidity,
         slippageTolerance,

--- a/sdk/src/instructions/decrease-liquidity-ix.ts
+++ b/sdk/src/instructions/decrease-liquidity-ix.ts
@@ -1,4 +1,4 @@
-import { TOKEN_PROGRAM_ID, u64 } from "@solana/spl-token";
+import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { Program } from "@project-serum/anchor";
 import { Whirlpool } from "../artifacts/whirlpool";
 import { Instruction } from "@orca-so/common-sdk";

--- a/sdk/src/instructions/increase-liquidity-ix.ts
+++ b/sdk/src/instructions/increase-liquidity-ix.ts
@@ -1,4 +1,4 @@
-import { Program } from "@project-serum/anchor";
+import { Program, BN } from "@project-serum/anchor";
 import { Whirlpool } from "../artifacts/whirlpool";
 import { TOKEN_PROGRAM_ID, u64 } from "@solana/spl-token";
 import { PublicKey } from "@solana/web3.js";
@@ -50,7 +50,7 @@ export type IncreaseLiquidityParams = {
 export type IncreaseLiquidityInput = {
   tokenMaxA: u64;
   tokenMaxB: u64;
-  liquidityAmount: u64;
+  liquidityAmount: BN;
 };
 
 /**

--- a/sdk/src/quotes/public/decrease-liquidity-quote.ts
+++ b/sdk/src/quotes/public/decrease-liquidity-quote.ts
@@ -1,6 +1,5 @@
 import { Percentage, ZERO } from "@orca-so/common-sdk";
 import { BN } from "@project-serum/anchor";
-import { u64 } from "@solana/spl-token";
 import invariant from "tiny-invariant";
 import { DecreaseLiquidityInput } from "../../instructions";
 import {
@@ -23,7 +22,7 @@ import { Position, Whirlpool } from "../../whirlpool-client";
  * @param slippageTolerance - The maximum slippage allowed when calculating the minimum tokens received.
  */
 export type DecreaseLiquidityQuoteParam = {
-  liquidity: u64;
+  liquidity: BN;
   tickCurrentIndex: number;
   sqrtPrice: BN;
   tickLowerIndex: number;
@@ -48,7 +47,7 @@ export type DecreaseLiquidityQuote = DecreaseLiquidityInput & { tokenEstA: BN; t
  * @returns An DecreaseLiquidityQuote object detailing the tokenMin & liquidity values to use when calling decrease-liquidity-ix.
  */
 export async function decreaseLiquidityQuoteByLiquidity(
-  liquidity: u64,
+  liquidity: BN,
   slippageTolerance: Percentage,
   position: Position,
   whirlpool: Whirlpool

--- a/sdk/src/quotes/public/swap-quote.ts
+++ b/sdk/src/quotes/public/swap-quote.ts
@@ -1,4 +1,4 @@
-import { Address } from "@project-serum/anchor";
+import { Address, BN } from "@project-serum/anchor";
 import { u64 } from "@solana/spl-token";
 import invariant from "tiny-invariant";
 import { PoolUtil } from "../../utils/public/pool-utils";
@@ -26,7 +26,7 @@ export type SwapQuoteParam = {
   whirlpoolData: WhirlpoolData;
   tokenAmount: u64;
   otherAmountThreshold: u64;
-  sqrtPriceLimit: u64;
+  sqrtPriceLimit: BN;
   aToB: boolean;
   amountSpecifiedIsInput: boolean;
   tickArrays: TickArray[];
@@ -45,7 +45,7 @@ export type SwapQuote = {
   estimatedAmountIn: u64;
   estimatedAmountOut: u64;
   estimatedEndTickIndex: number;
-  estimatedEndSqrtPrice: u64;
+  estimatedEndSqrtPrice: BN;
   estimatedFeeAmount: u64;
 } & SwapInput;
 

--- a/sdk/src/quotes/swap/swap-manager.ts
+++ b/sdk/src/quotes/swap/swap-manager.ts
@@ -18,7 +18,7 @@ export function computeSwap(
   whirlpoolData: WhirlpoolData,
   tickSequence: TickArraySequence,
   tokenAmount: u64,
-  sqrtPriceLimit: u64,
+  sqrtPriceLimit: BN,
   amountSpecifiedIsInput: boolean,
   aToB: boolean
 ): SwapResult {

--- a/sdk/src/quotes/swap/swap-quote-impl.ts
+++ b/sdk/src/quotes/swap/swap-quote-impl.ts
@@ -1,7 +1,6 @@
 import { ZERO } from "@orca-so/common-sdk";
 import { SwapQuoteParam, SwapQuote } from "../public";
 import { BN } from "@project-serum/anchor";
-import { u64 } from "@solana/spl-token";
 import { TickArraySequence } from "./tick-array-sequence";
 import { computeSwap } from "./swap-manager";
 import { MAX_SQRT_PRICE, MAX_SWAP_TICK_ARRAYS, MIN_SQRT_PRICE } from "../../types/public";
@@ -24,7 +23,7 @@ export function simulateSwap(params: SwapQuoteParam): SwapQuote {
     amountSpecifiedIsInput,
   } = params;
 
-  if (sqrtPriceLimit.gt(new u64(MAX_SQRT_PRICE) || sqrtPriceLimit.lt(new u64(MIN_SQRT_PRICE)))) {
+  if (sqrtPriceLimit.gt(new BN(MAX_SQRT_PRICE) || sqrtPriceLimit.lt(new BN(MIN_SQRT_PRICE)))) {
     throw new WhirlpoolsError(
       "Provided SqrtPriceLimit is out of bounds.",
       SwapErrorCode.SqrtPriceOutOfBounds

--- a/sdk/src/utils/public/pool-utils.ts
+++ b/sdk/src/utils/public/pool-utils.ts
@@ -82,7 +82,7 @@ export class PoolUtil {
    * @returns
    */
   public static getTokenAmountsFromLiquidity(
-    liquidity: u64,
+    liquidity: BN,
     currentPrice: u64,
     lowerPrice: u64,
     upperPrice: u64,

--- a/sdk/src/utils/public/pool-utils.ts
+++ b/sdk/src/utils/public/pool-utils.ts
@@ -75,31 +75,31 @@ export class PoolUtil {
   /**
    * @category Whirlpool Utils
    * @param liquidity
-   * @param currentPrice
-   * @param lowerPrice
-   * @param upperPrice
+   * @param currentSqrtPrice
+   * @param lowerSqrtPrice
+   * @param upperSqrtPrice
    * @param round_up
    * @returns
    */
   public static getTokenAmountsFromLiquidity(
     liquidity: BN,
-    currentPrice: u64,
-    lowerPrice: u64,
-    upperPrice: u64,
+    currentSqrtPrice: BN,
+    lowerSqrtPrice: BN,
+    upperSqrtPrice: BN,
     round_up: boolean
   ): TokenAmounts {
     const _liquidity = new Decimal(liquidity.toString());
-    const _currentPrice = new Decimal(currentPrice.toString());
-    const _lowerPrice = new Decimal(lowerPrice.toString());
-    const _upperPrice = new Decimal(upperPrice.toString());
+    const _currentPrice = new Decimal(currentSqrtPrice.toString());
+    const _lowerPrice = new Decimal(lowerSqrtPrice.toString());
+    const _upperPrice = new Decimal(upperSqrtPrice.toString());
     let tokenA, tokenB;
-    if (currentPrice.lt(lowerPrice)) {
+    if (currentSqrtPrice.lt(lowerSqrtPrice)) {
       // x = L * (pb - pa) / (pa * pb)
       tokenA = MathUtil.toX64_Decimal(_liquidity)
         .mul(_upperPrice.sub(_lowerPrice))
         .div(_lowerPrice.mul(_upperPrice));
       tokenB = new Decimal(0);
-    } else if (currentPrice.lt(upperPrice)) {
+    } else if (currentSqrtPrice.lt(upperSqrtPrice)) {
       // x = L * (pb - p) / (p * pb)
       // y = L * (p - pa)
       tokenA = MathUtil.toX64_Decimal(_liquidity)

--- a/sdk/tests/integration/collect_fees.test.ts
+++ b/sdk/tests/integration/collect_fees.test.ts
@@ -41,8 +41,8 @@ describe("collect_fees", () => {
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing,
       positions: [
-        { tickLowerIndex, tickUpperIndex, liquidityAmount: new u64(10_000_000) }, // In range position
-        { tickLowerIndex: 0, tickUpperIndex: 128, liquidityAmount: new u64(1_000_000) }, // Out of range position
+        { tickLowerIndex, tickUpperIndex, liquidityAmount: new anchor.BN(10_000_000) }, // In range position
+        { tickLowerIndex: 0, tickUpperIndex: 128, liquidityAmount: new anchor.BN(1_000_000) }, // Out of range position
       ],
     });
     const {
@@ -184,7 +184,7 @@ describe("collect_fees", () => {
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing,
       positions: [
-        { tickLowerIndex: 0, tickUpperIndex: 128, liquidityAmount: new u64(10_000_000) }, // In range position
+        { tickLowerIndex: 0, tickUpperIndex: 128, liquidityAmount: new anchor.BN(10_000_000) }, // In range position
       ],
     });
     const {
@@ -220,7 +220,7 @@ describe("collect_fees", () => {
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing,
       positions: [
-        { tickLowerIndex: 0, tickUpperIndex: 128, liquidityAmount: new u64(10_000_000) }, // In range position
+        { tickLowerIndex: 0, tickUpperIndex: 128, liquidityAmount: new anchor.BN(10_000_000) }, // In range position
       ],
     });
     const {
@@ -254,7 +254,7 @@ describe("collect_fees", () => {
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing,
       positions: [
-        { tickLowerIndex: 0, tickUpperIndex: 128, liquidityAmount: new u64(10_000_000) }, // In range position
+        { tickLowerIndex: 0, tickUpperIndex: 128, liquidityAmount: new anchor.BN(10_000_000) }, // In range position
       ],
     });
     const {
@@ -298,7 +298,7 @@ describe("collect_fees", () => {
     const tickSpacing = TickSpacing.Standard;
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing,
-      positions: [{ tickLowerIndex, tickUpperIndex, liquidityAmount: new u64(10_000_000) }],
+      positions: [{ tickLowerIndex, tickUpperIndex, liquidityAmount: new anchor.BN(10_000_000) }],
     });
     const {
       poolInitInfo: { tokenVaultAKeypair, tokenVaultBKeypair },
@@ -336,7 +336,7 @@ describe("collect_fees", () => {
     const tickSpacing = TickSpacing.Standard;
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing,
-      positions: [{ tickLowerIndex, tickUpperIndex, liquidityAmount: new u64(10_000_000) }],
+      positions: [{ tickLowerIndex, tickUpperIndex, liquidityAmount: new anchor.BN(10_000_000) }],
     });
     const {
       poolInitInfo: { whirlpoolPda, tokenVaultAKeypair, tokenVaultBKeypair },
@@ -395,7 +395,7 @@ describe("collect_fees", () => {
     const tickSpacing = TickSpacing.Standard;
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing,
-      positions: [{ tickLowerIndex, tickUpperIndex, liquidityAmount: new u64(10_000_000) }],
+      positions: [{ tickLowerIndex, tickUpperIndex, liquidityAmount: new anchor.BN(10_000_000) }],
     });
     const {
       poolInitInfo: { whirlpoolPda, tokenVaultAKeypair, tokenVaultBKeypair },
@@ -433,7 +433,7 @@ describe("collect_fees", () => {
     const tickSpacing = TickSpacing.Standard;
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing,
-      positions: [{ tickLowerIndex, tickUpperIndex, liquidityAmount: new u64(10_000_000) }],
+      positions: [{ tickLowerIndex, tickUpperIndex, liquidityAmount: new anchor.BN(10_000_000) }],
     });
     const {
       poolInitInfo: { whirlpoolPda, tokenVaultAKeypair, tokenVaultBKeypair },
@@ -472,7 +472,7 @@ describe("collect_fees", () => {
     const tickSpacing = TickSpacing.Standard;
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing,
-      positions: [{ tickLowerIndex, tickUpperIndex, liquidityAmount: new u64(10_000_000) }],
+      positions: [{ tickLowerIndex, tickUpperIndex, liquidityAmount: new anchor.BN(10_000_000) }],
     });
     const {
       poolInitInfo: { whirlpoolPda, tokenVaultAKeypair, tokenVaultBKeypair },
@@ -509,7 +509,7 @@ describe("collect_fees", () => {
     const tickSpacing = TickSpacing.Standard;
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing,
-      positions: [{ tickLowerIndex, tickUpperIndex, liquidityAmount: new u64(10_000_000) }],
+      positions: [{ tickLowerIndex, tickUpperIndex, liquidityAmount: new anchor.BN(10_000_000) }],
     });
     const {
       poolInitInfo: { whirlpoolPda, tokenVaultAKeypair, tokenVaultBKeypair, tokenMintA },
@@ -549,7 +549,7 @@ describe("collect_fees", () => {
     const tickSpacing = TickSpacing.Standard;
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing,
-      positions: [{ tickLowerIndex, tickUpperIndex, liquidityAmount: new u64(10_000_000) }],
+      positions: [{ tickLowerIndex, tickUpperIndex, liquidityAmount: new anchor.BN(10_000_000) }],
     });
     const {
       poolInitInfo: {
@@ -609,7 +609,7 @@ describe("collect_fees", () => {
     const tickSpacing = TickSpacing.Standard;
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing,
-      positions: [{ tickLowerIndex, tickUpperIndex, liquidityAmount: new u64(10_000_000) }],
+      positions: [{ tickLowerIndex, tickUpperIndex, liquidityAmount: new anchor.BN(10_000_000) }],
     });
     const {
       poolInitInfo: {

--- a/sdk/tests/integration/collect_protocol_fees.test.ts
+++ b/sdk/tests/integration/collect_protocol_fees.test.ts
@@ -23,7 +23,7 @@ describe("collect_protocol_fees", () => {
     const tickSpacing = TickSpacing.Standard;
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing,
-      positions: [{ tickLowerIndex, tickUpperIndex, liquidityAmount: new u64(10_000_000) }],
+      positions: [{ tickLowerIndex, tickUpperIndex, liquidityAmount: new anchor.BN(10_000_000) }],
     });
     const {
       poolInitInfo: {
@@ -139,7 +139,7 @@ describe("collect_protocol_fees", () => {
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing,
       positions: [
-        { tickLowerIndex: 29440, tickUpperIndex: 33536, liquidityAmount: new u64(10_000_000) },
+        { tickLowerIndex: 29440, tickUpperIndex: 33536, liquidityAmount: new anchor.BN(10_000_000) },
       ],
     });
     const {
@@ -172,7 +172,7 @@ describe("collect_protocol_fees", () => {
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing,
       positions: [
-        { tickLowerIndex: 29440, tickUpperIndex: 33536, liquidityAmount: new u64(10_000_000) },
+        { tickLowerIndex: 29440, tickUpperIndex: 33536, liquidityAmount: new anchor.BN(10_000_000) },
       ],
     });
     const {
@@ -207,7 +207,7 @@ describe("collect_protocol_fees", () => {
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing,
       positions: [
-        { tickLowerIndex: 29440, tickUpperIndex: 33536, liquidityAmount: new u64(10_000_000) },
+        { tickLowerIndex: 29440, tickUpperIndex: 33536, liquidityAmount: new anchor.BN(10_000_000) },
       ],
     });
     const {
@@ -245,7 +245,7 @@ describe("collect_protocol_fees", () => {
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing,
       positions: [
-        { tickLowerIndex: 29440, tickUpperIndex: 33536, liquidityAmount: new u64(10_000_000) },
+        { tickLowerIndex: 29440, tickUpperIndex: 33536, liquidityAmount: new anchor.BN(10_000_000) },
       ],
     });
     const {
@@ -307,7 +307,7 @@ describe("collect_protocol_fees", () => {
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing,
       positions: [
-        { tickLowerIndex: 29440, tickUpperIndex: 33536, liquidityAmount: new u64(10_000_000) },
+        { tickLowerIndex: 29440, tickUpperIndex: 33536, liquidityAmount: new anchor.BN(10_000_000) },
       ],
     });
     const {

--- a/sdk/tests/integration/decrease_liquidity.test.ts
+++ b/sdk/tests/integration/decrease_liquidity.test.ts
@@ -33,7 +33,7 @@ describe("decrease_liquidity", () => {
   const fetcher = ctx.fetcher;
 
   it("successfully decrease liquidity from position in one tick array", async () => {
-    const liquidityAmount = new u64(1_250_000);
+    const liquidityAmount = new anchor.BN(1_250_000);
     const tickLower = 7168,
       tickUpper = 8960;
     const fixture = await new WhirlpoolTestFixture(ctx).init({
@@ -46,7 +46,7 @@ describe("decrease_liquidity", () => {
     const poolBefore = (await fetcher.getPool(whirlpoolPda.publicKey, true)) as WhirlpoolData;
 
     const removalQuote = decreaseLiquidityQuoteByLiquidityWithParams({
-      liquidity: new u64(1_000_000),
+      liquidity: new anchor.BN(1_000_000),
       sqrtPrice: poolBefore.sqrtPrice,
       slippageTolerance: Percentage.fromFraction(1, 100),
       tickCurrentIndex: poolBefore.tickCurrentIndex,
@@ -88,7 +88,7 @@ describe("decrease_liquidity", () => {
   });
 
   it("successfully decrease liquidity from position in two tick arrays", async () => {
-    const liquidityAmount = new u64(1_250_000);
+    const liquidityAmount = new anchor.BN(1_250_000);
     const tickLower = -1280,
       tickUpper = 1280;
     const fixture = await new WhirlpoolTestFixture(ctx).init({
@@ -102,7 +102,7 @@ describe("decrease_liquidity", () => {
     const poolBefore = (await fetcher.getPool(whirlpoolPda.publicKey, true)) as WhirlpoolData;
 
     const removalQuote = decreaseLiquidityQuoteByLiquidityWithParams({
-      liquidity: new u64(1_000_000),
+      liquidity: new anchor.BN(1_000_000),
       sqrtPrice: poolBefore.sqrtPrice,
       slippageTolerance: Percentage.fromFraction(1, 100),
       tickCurrentIndex: poolBefore.tickCurrentIndex,
@@ -149,7 +149,7 @@ describe("decrease_liquidity", () => {
   });
 
   it("successfully decrease liquidity with approved delegate", async () => {
-    const liquidityAmount = new u64(1_250_000);
+    const liquidityAmount = new anchor.BN(1_250_000);
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing: TickSpacing.Standard,
       initialSqrtPrice: MathUtil.toX64(new Decimal(1)),
@@ -165,7 +165,7 @@ describe("decrease_liquidity", () => {
     await approveToken(provider, tokenAccountA, delegate.publicKey, 1_000_000);
     await approveToken(provider, tokenAccountB, delegate.publicKey, 1_000_000);
 
-    const removeAmount = new u64(1_000_000);
+    const removeAmount = new anchor.BN(1_000_000);
 
     await toTx(
       ctx,
@@ -190,7 +190,7 @@ describe("decrease_liquidity", () => {
   });
 
   it("successfully decrease liquidity with owner even if there is approved delegate", async () => {
-    const liquidityAmount = new u64(1_250_000);
+    const liquidityAmount = new anchor.BN(1_250_000);
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing: TickSpacing.Standard,
       initialSqrtPrice: MathUtil.toX64(new Decimal(1.48)),
@@ -206,7 +206,7 @@ describe("decrease_liquidity", () => {
     await approveToken(provider, tokenAccountA, delegate.publicKey, 1_000_000);
     await approveToken(provider, tokenAccountB, delegate.publicKey, 1_000_000);
 
-    const removeAmount = new u64(1_000_000);
+    const removeAmount = new anchor.BN(1_000_000);
 
     await toTx(
       ctx,
@@ -229,7 +229,7 @@ describe("decrease_liquidity", () => {
   });
 
   it("successfully decrease liquidity with transferred position token", async () => {
-    const liquidityAmount = new u64(1_250_000);
+    const liquidityAmount = new anchor.BN(1_250_000);
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing: TickSpacing.Standard,
       initialSqrtPrice: MathUtil.toX64(new Decimal(1.48)),
@@ -239,7 +239,7 @@ describe("decrease_liquidity", () => {
     const { whirlpoolPda } = poolInitInfo;
     const position = positions[0];
 
-    const removeAmount = new u64(1_000_000);
+    const removeAmount = new anchor.BN(1_000_000);
     const newOwner = anchor.web3.Keypair.generate();
     const newOwnerPositionTokenAccount = await createTokenAccount(
       provider,
@@ -271,7 +271,7 @@ describe("decrease_liquidity", () => {
   });
 
   it("fails when liquidity amount is zero", async () => {
-    const liquidityAmount = new u64(1_250_000);
+    const liquidityAmount = new anchor.BN(1_250_000);
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing: TickSpacing.Standard,
       initialSqrtPrice: MathUtil.toX64(new Decimal(1)),
@@ -285,7 +285,7 @@ describe("decrease_liquidity", () => {
       toTx(
         ctx,
         WhirlpoolIx.decreaseLiquidityIx(ctx.program, {
-          liquidityAmount: new u64(0),
+          liquidityAmount: new anchor.BN(0),
           tokenMinA: new u64(0),
           tokenMinB: new u64(0),
           whirlpool: whirlpoolPda.publicKey,
@@ -318,7 +318,7 @@ describe("decrease_liquidity", () => {
       toTx(
         ctx,
         WhirlpoolIx.decreaseLiquidityIx(ctx.program, {
-          liquidityAmount: new u64(1_000),
+          liquidityAmount: new anchor.BN(1_000),
           tokenMinA: new u64(0),
           tokenMinB: new u64(0),
           whirlpool: whirlpoolPda.publicKey,
@@ -338,7 +338,7 @@ describe("decrease_liquidity", () => {
   });
 
   it("fails when token min a subceeded", async () => {
-    const liquidityAmount = new u64(1_250_000);
+    const liquidityAmount = new anchor.BN(1_250_000);
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing: TickSpacing.Standard,
       initialSqrtPrice: MathUtil.toX64(new Decimal(0.005)),
@@ -372,7 +372,7 @@ describe("decrease_liquidity", () => {
   });
 
   it("fails when token min b subceeded", async () => {
-    const liquidityAmount = new u64(1_250_000);
+    const liquidityAmount = new anchor.BN(1_250_000);
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing: TickSpacing.Standard,
       initialSqrtPrice: MathUtil.toX64(new Decimal(5)),
@@ -405,7 +405,7 @@ describe("decrease_liquidity", () => {
   });
 
   it("fails when position account does not have exactly 1 token", async () => {
-    const liquidityAmount = new u64(1_250_000);
+    const liquidityAmount = new anchor.BN(1_250_000);
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing: TickSpacing.Standard,
       initialSqrtPrice: MathUtil.toX64(new Decimal(2.2)),
@@ -471,7 +471,7 @@ describe("decrease_liquidity", () => {
   });
 
   it("fails when position token account mint does not match position mint", async () => {
-    const liquidityAmount = new u64(6_500_000);
+    const liquidityAmount = new anchor.BN(6_500_000);
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing: TickSpacing.Standard,
       initialSqrtPrice: MathUtil.toX64(new Decimal(2.2)),
@@ -507,7 +507,7 @@ describe("decrease_liquidity", () => {
   });
 
   it("fails when position does not match whirlpool", async () => {
-    const liquidityAmount = new u64(6_500_000);
+    const liquidityAmount = new anchor.BN(6_500_000);
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing: TickSpacing.Standard,
       initialSqrtPrice: MathUtil.toX64(new Decimal(2.2)),
@@ -546,7 +546,7 @@ describe("decrease_liquidity", () => {
   });
 
   it("fails when token vaults do not match whirlpool vaults", async () => {
-    const liquidityAmount = new u64(6_500_000);
+    const liquidityAmount = new anchor.BN(6_500_000);
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing: TickSpacing.Standard,
       initialSqrtPrice: MathUtil.toX64(new Decimal(2.2)),
@@ -605,7 +605,7 @@ describe("decrease_liquidity", () => {
   });
 
   it("fails when owner token account mint does not match whirlpool token mint", async () => {
-    const liquidityAmount = new u64(6_500_000);
+    const liquidityAmount = new anchor.BN(6_500_000);
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing: TickSpacing.Standard,
       initialSqrtPrice: MathUtil.toX64(new Decimal(2.2)),
@@ -663,7 +663,7 @@ describe("decrease_liquidity", () => {
   });
 
   it("fails when position authority is not approved delegate for position token account", async () => {
-    const liquidityAmount = new u64(6_500_000);
+    const liquidityAmount = new anchor.BN(6_500_000);
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing: TickSpacing.Standard,
       initialSqrtPrice: MathUtil.toX64(new Decimal(2.2)),
@@ -703,7 +703,7 @@ describe("decrease_liquidity", () => {
   });
 
   it("fails when position authority is not authorized for exactly 1 token", async () => {
-    const liquidityAmount = new u64(6_500_000);
+    const liquidityAmount = new anchor.BN(6_500_000);
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing: TickSpacing.Standard,
       initialSqrtPrice: MathUtil.toX64(new Decimal(2.2)),
@@ -744,7 +744,7 @@ describe("decrease_liquidity", () => {
   });
 
   it("fails when position authority was not a signer", async () => {
-    const liquidityAmount = new u64(6_500_000);
+    const liquidityAmount = new anchor.BN(6_500_000);
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing: TickSpacing.Standard,
       initialSqrtPrice: MathUtil.toX64(new Decimal(2.2)),
@@ -783,7 +783,7 @@ describe("decrease_liquidity", () => {
   });
 
   it("fails when tick arrays do not match the position", async () => {
-    const liquidityAmount = new u64(6_500_000);
+    const liquidityAmount = new anchor.BN(6_500_000);
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing: TickSpacing.Standard,
       initialSqrtPrice: MathUtil.toX64(new Decimal(2.2)),
@@ -825,7 +825,7 @@ describe("decrease_liquidity", () => {
   });
 
   it("fails when the tick arrays are for a different whirlpool", async () => {
-    const liquidityAmount = new u64(6_500_000);
+    const liquidityAmount = new anchor.BN(6_500_000);
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing: TickSpacing.Standard,
       initialSqrtPrice: MathUtil.toX64(new Decimal(2.2)),

--- a/sdk/tests/integration/increase_liquidity.test.ts
+++ b/sdk/tests/integration/increase_liquidity.test.ts
@@ -524,7 +524,7 @@ describe("increase_liquidity", () => {
     const { whirlpoolPda } = poolInitInfo;
     const positionInitInfo = positions[0];
 
-    const liquidityAmount = new u64(6_500_000);
+    const liquidityAmount = new anchor.BN(6_500_000);
 
     await assert.rejects(
       toTx(
@@ -558,7 +558,7 @@ describe("increase_liquidity", () => {
     const { whirlpoolPda } = poolInitInfo;
     const positionInitInfo = positions[0];
 
-    const liquidityAmount = new u64(6_500_000);
+    const liquidityAmount = new anchor.BN(6_500_000);
 
     await assert.rejects(
       toTx(
@@ -599,7 +599,7 @@ describe("increase_liquidity", () => {
       provider.wallet.publicKey
     );
 
-    const liquidityAmount = new u64(6_500_000);
+    const liquidityAmount = new anchor.BN(6_500_000);
 
     await assert.rejects(
       toTx(
@@ -661,7 +661,7 @@ describe("increase_liquidity", () => {
     // Create a position token account that contains 0 tokens
     const invalidPositionTokenAccount = await createAndMintToTokenAccount(provider, tokenMintA, 1);
 
-    const liquidityAmount = new u64(6_500_000);
+    const liquidityAmount = new anchor.BN(6_500_000);
 
     await assert.rejects(
       toTx(
@@ -710,7 +710,7 @@ describe("increase_liquidity", () => {
       params: { tickArrayPda },
     } = await initTickArray(ctx, poolInitInfo2.whirlpoolPda.publicKey, 0);
 
-    const liquidityAmount = new u64(6_500_000);
+    const liquidityAmount = new anchor.BN(6_500_000);
 
     await assert.rejects(
       toTx(
@@ -743,7 +743,7 @@ describe("increase_liquidity", () => {
     const { poolInitInfo, positions, tokenAccountA, tokenAccountB } = fixture.getInfos();
     const { whirlpoolPda, tokenMintA, tokenMintB } = poolInitInfo;
     const positionInitInfo = positions[0];
-    const liquidityAmount = new u64(6_500_000);
+    const liquidityAmount = new anchor.BN(6_500_000);
 
     const fakeVaultA = await createAndMintToTokenAccount(provider, tokenMintA, 1_000);
     const fakeVaultB = await createAndMintToTokenAccount(provider, tokenMintB, 1_000);
@@ -801,7 +801,7 @@ describe("increase_liquidity", () => {
     const { poolInitInfo, positions, tokenAccountA, tokenAccountB } = fixture.getInfos();
     const { whirlpoolPda } = poolInitInfo;
     const positionInitInfo = positions[0];
-    const liquidityAmount = new u64(6_500_000);
+    const liquidityAmount = new anchor.BN(6_500_000);
 
     const invalidMint = await createMint(provider);
     const invalidTokenAccount = await createAndMintToTokenAccount(provider, invalidMint, 1_000_000);
@@ -862,7 +862,7 @@ describe("increase_liquidity", () => {
 
     const delegate = anchor.web3.Keypair.generate();
 
-    const liquidityAmount = new u64(1_250_000);
+    const liquidityAmount = new anchor.BN(1_250_000);
 
     await approveToken(provider, tokenAccountA, delegate.publicKey, 1_000_000);
     await approveToken(provider, tokenAccountB, delegate.publicKey, 1_000_000);
@@ -903,7 +903,7 @@ describe("increase_liquidity", () => {
 
     const delegate = anchor.web3.Keypair.generate();
 
-    const liquidityAmount = new u64(1_250_000);
+    const liquidityAmount = new anchor.BN(1_250_000);
 
     await approveToken(provider, positionInitInfo.tokenAccount, delegate.publicKey, 0);
     await approveToken(provider, tokenAccountA, delegate.publicKey, 1_000_000);
@@ -945,7 +945,7 @@ describe("increase_liquidity", () => {
 
     const delegate = anchor.web3.Keypair.generate();
 
-    const liquidityAmount = new u64(1_250_000);
+    const liquidityAmount = new anchor.BN(1_250_000);
 
     await approveToken(provider, positionInitInfo.tokenAccount, delegate.publicKey, 1);
     await approveToken(provider, tokenAccountA, delegate.publicKey, 1_000_000);
@@ -985,7 +985,7 @@ describe("increase_liquidity", () => {
 
     const delegate = anchor.web3.Keypair.generate();
 
-    const liquidityAmount = new u64(1_250_000);
+    const liquidityAmount = new anchor.BN(1_250_000);
 
     await approveToken(provider, positionInitInfo.tokenAccount, delegate.publicKey, 1);
 
@@ -1031,7 +1031,7 @@ describe("increase_liquidity", () => {
       params: { tickArrayPda: tickArrayUpperPda },
     } = await initTickArray(ctx, whirlpoolPda.publicKey, 22528);
 
-    const liquidityAmount = new u64(1_250_000);
+    const liquidityAmount = new anchor.BN(1_250_000);
 
     await assert.rejects(
       toTx(
@@ -1075,7 +1075,7 @@ describe("increase_liquidity", () => {
       params: { tickArrayPda: tickArrayUpperPda },
     } = await initTickArray(ctx, poolInitInfo2.whirlpoolPda.publicKey, 0);
 
-    const liquidityAmount = new u64(1_250_000);
+    const liquidityAmount = new anchor.BN(1_250_000);
 
     await assert.rejects(
       toTx(

--- a/sdk/tests/integration/swap.test.ts
+++ b/sdk/tests/integration/swap.test.ts
@@ -713,7 +713,7 @@ describe("swap", () => {
     const params: SwapParams = {
       amount: new u64(10),
       otherAmountThreshold: ZERO_BN,
-      sqrtPriceLimit: new u64(MAX_SQRT_PRICE).add(new u64(1)),
+      sqrtPriceLimit: new anchor.BN(MAX_SQRT_PRICE).add(new anchor.BN(1)),
       amountSpecifiedIsInput: true,
       aToB: true,
       whirlpool: whirlpool,
@@ -747,7 +747,7 @@ describe("swap", () => {
     const params: SwapParams = {
       amount: new u64(10),
       otherAmountThreshold: ZERO_BN,
-      sqrtPriceLimit: new u64(MIN_SQRT_PRICE).sub(new u64(1)),
+      sqrtPriceLimit: new anchor.BN(MIN_SQRT_PRICE).sub(new anchor.BN(1)),
       amountSpecifiedIsInput: true,
       aToB: true,
       whirlpool: whirlpool,

--- a/sdk/tests/integration/swap.test.ts
+++ b/sdk/tests/integration/swap.test.ts
@@ -530,7 +530,7 @@ describe("swap", () => {
 
     const fundParams: FundedPositionParams[] = [
       {
-        liquidityAmount: new u64(10_000_000),
+        liquidityAmount: new anchor.BN(10_000_000),
         tickLowerIndex: 29440,
         tickUpperIndex: 33536,
       },
@@ -604,17 +604,17 @@ describe("swap", () => {
 
     const fundParams: FundedPositionParams[] = [
       {
-        liquidityAmount: new u64(100_000_000),
+        liquidityAmount: new anchor.BN(100_000_000),
         tickLowerIndex: 27456,
         tickUpperIndex: 27840,
       },
       {
-        liquidityAmount: new u64(100_000_000),
+        liquidityAmount: new anchor.BN(100_000_000),
         tickLowerIndex: 28864,
         tickUpperIndex: 28928,
       },
       {
-        liquidityAmount: new u64(100_000_000),
+        liquidityAmount: new anchor.BN(100_000_000),
         tickLowerIndex: 27712,
         tickUpperIndex: 28928,
       },
@@ -786,7 +786,7 @@ describe("swap", () => {
 
     const fundParams: FundedPositionParams[] = [
       {
-        liquidityAmount: new u64(100_000),
+        liquidityAmount: new anchor.BN(100_000),
         tickLowerIndex: 29440,
         tickUpperIndex: 33536,
       },
@@ -838,7 +838,7 @@ describe("swap", () => {
 
     const fundParams: FundedPositionParams[] = [
       {
-        liquidityAmount: new u64(100_000),
+        liquidityAmount: new anchor.BN(100_000),
         tickLowerIndex: 29440,
         tickUpperIndex: 33536,
       },
@@ -890,7 +890,7 @@ describe("swap", () => {
 
     const fundParams: FundedPositionParams[] = [
       {
-        liquidityAmount: new u64(100_000),
+        liquidityAmount: new anchor.BN(100_000),
         tickLowerIndex: 29440,
         tickUpperIndex: 33536,
       },
@@ -942,7 +942,7 @@ describe("swap", () => {
 
     const fundParams: FundedPositionParams[] = [
       {
-        liquidityAmount: new u64(100_000),
+        liquidityAmount: new anchor.BN(100_000),
         tickLowerIndex: 29440,
         tickUpperIndex: 33536,
       },
@@ -1011,42 +1011,42 @@ describe("swap", () => {
 
     const fundParams: FundedPositionParams[] = [
       {
-        liquidityAmount: new u64(10_000_000),
+        liquidityAmount: new anchor.BN(10_000_000),
         tickLowerIndex: 27712,
         tickUpperIndex: 29360,
       },
       {
-        liquidityAmount: new u64(10_000_000),
+        liquidityAmount: new anchor.BN(10_000_000),
         tickLowerIndex: 27736,
         tickUpperIndex: 29240,
       },
       {
-        liquidityAmount: new u64(10_000_000),
+        liquidityAmount: new anchor.BN(10_000_000),
         tickLowerIndex: 27840,
         tickUpperIndex: 29120,
       },
       {
-        liquidityAmount: new u64(10_000_000),
+        liquidityAmount: new anchor.BN(10_000_000),
         tickLowerIndex: 28288,
         tickUpperIndex: 29112,
       },
       {
-        liquidityAmount: new u64(10_000_000),
+        liquidityAmount: new anchor.BN(10_000_000),
         tickLowerIndex: 28416,
         tickUpperIndex: 29112,
       },
       {
-        liquidityAmount: new u64(10_000_000),
+        liquidityAmount: new anchor.BN(10_000_000),
         tickLowerIndex: 28288,
         tickUpperIndex: 28304,
       },
       {
-        liquidityAmount: new u64(10_000_000),
+        liquidityAmount: new anchor.BN(10_000_000),
         tickLowerIndex: 28296,
         tickUpperIndex: 29112,
       },
       {
-        liquidityAmount: new u64(10_000_000),
+        liquidityAmount: new anchor.BN(10_000_000),
         tickLowerIndex: 28576,
         tickUpperIndex: 28736,
       },

--- a/sdk/tests/integration/update_fees_and_rewards.test.ts
+++ b/sdk/tests/integration/update_fees_and_rewards.test.ts
@@ -23,7 +23,7 @@ describe("update_fees_and_rewards", () => {
     const tickSpacing = TickSpacing.Standard;
     const fixture = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing,
-      positions: [{ tickLowerIndex, tickUpperIndex, liquidityAmount: new u64(1_000_000) }],
+      positions: [{ tickLowerIndex, tickUpperIndex, liquidityAmount: new anchor.BN(1_000_000) }],
       rewards: [
         { emissionsPerSecondX64: MathUtil.toX64(new Decimal(2)), vaultAmount: new u64(1_000_000) },
       ],
@@ -137,7 +137,7 @@ describe("update_fees_and_rewards", () => {
 
     const other = await new WhirlpoolTestFixture(ctx).init({
       tickSpacing,
-      positions: [{ tickLowerIndex, tickUpperIndex, liquidityAmount: new u64(1_000_000) }],
+      positions: [{ tickLowerIndex, tickUpperIndex, liquidityAmount: new anchor.BN(1_000_000) }],
     });
     const { positions: otherPositions } = other.getInfos();
 

--- a/sdk/tests/sdk/whirlpools/swap/swap-array.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/swap-array.test.ts
@@ -23,7 +23,7 @@ import {
 } from "../../../utils/swap-test-utils";
 import { getTickArrays } from "../../../utils/testDataTypes";
 
-describe("swap arrays test", async () => {
+describe("swap arrays test", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;

--- a/sdk/tests/sdk/whirlpools/swap/swap-traverse.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/swap-traverse.test.ts
@@ -22,7 +22,7 @@ import {
 } from "../../../utils/swap-test-utils";
 import { getVaultAmounts } from "../../../utils/whirlpools-test-utils";
 
-describe("swap traversal tests", async () => {
+describe("swap traversal tests", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;

--- a/sdk/tests/utils/init-utils.ts
+++ b/sdk/tests/utils/init-utils.ts
@@ -539,7 +539,7 @@ export async function initTestPoolWithLiquidity(ctx: WhirlpoolContext) {
 
   const fundParams: FundedPositionParams[] = [
     {
-      liquidityAmount: new u64(100_000),
+      liquidityAmount: new anchor.BN(100_000),
       tickLowerIndex: 27904,
       tickUpperIndex: 33408,
     },

--- a/sdk/tests/utils/init-utils.ts
+++ b/sdk/tests/utils/init-utils.ts
@@ -32,9 +32,8 @@ import {
 import { u64 } from "@solana/spl-token";
 import { PoolUtil } from "../../src/utils/public/pool-utils";
 import { MathUtil, PDA } from "@orca-so/common-sdk";
-import { BN } from "bn.js";
 
-const defaultInitSqrtPrice = MathUtil.toX64_BN(new u64(5));
+const defaultInitSqrtPrice = MathUtil.toX64_BN(new anchor.BN(5));
 
 /**
  * Initialize a brand new WhirlpoolsConfig account and construct a set of InitPoolParams
@@ -290,7 +289,7 @@ export async function initTestPoolWithTokens(
   ctx: WhirlpoolContext,
   tickSpacing: number,
   initSqrtPrice = defaultInitSqrtPrice,
-  mintAmount = new BN("15000000000")
+  mintAmount = new anchor.BN("15000000000")
 ) {
   const provider = ctx.provider;
 

--- a/sdk/tests/utils/swap-test-utils.ts
+++ b/sdk/tests/utils/swap-test-utils.ts
@@ -39,7 +39,7 @@ export async function setupSwapTest(setup: SwapTestPoolParams) {
 
   const whirlpool = await setup.client.getPool(whirlpoolPda.publicKey, true);
 
-  (await whirlpool.initTickArrayForTicks(setup.initArrayStartTicks))?.buildAndExecute();
+  await (await whirlpool.initTickArrayForTicks(setup.initArrayStartTicks))?.buildAndExecute();
 
   await fundPositions(setup.ctx, poolInitInfo, tokenAccountA, tokenAccountB, setup.fundedPositions);
   return whirlpool;

--- a/sdk/tests/utils/test-consts.ts
+++ b/sdk/tests/utils/test-consts.ts
@@ -7,4 +7,4 @@ export const ZERO_BN = new anchor.BN(0);
 
 export const ONE_SOL = 1000000000;
 
-export const MAX_U64 = new u64(new u64(2).pow(new u64(64).sub(new u64(1))).toString());
+export const MAX_U64 = new u64(new anchor.BN(2).pow(new anchor.BN(64).sub(new anchor.BN(1))).toString());


### PR DESCRIPTION
### liquidity
- Change type of variables handling liquidity from u64 to BN
- Fix: removing "async" keyword from describe. test must be defined synchronously.
- Fix: using BN to calculate the max value of u64 (test-constants.ts)
- Fix: adding "await" to wait transaction completion (swap-test-utils.ts)

### sqrtPrice
- Change type of variables handling sqrtPrice from u64 to BN
- Refactor: changing argument name of getTokenAmountsFromLiquidity
  to clarify required price is sqrtPrice

## Note
anchor test passes all unit-tests