### PR TITLE
fix sdk test MAX_U64 definition 

### DIFF
--- a/sdk/tests/utils/test-consts.ts
+++ b/sdk/tests/utils/test-consts.ts
@@ -7,4 +7,4 @@ export const ZERO_BN = new anchor.BN(0);
 
 export const ONE_SOL = 1000000000;
 
-export const MAX_U64 = new u64(new anchor.BN(2).pow(new anchor.BN(64).sub(new anchor.BN(1))).toString());
+export const MAX_U64 = new u64(new anchor.BN(2).pow(new anchor.BN(64)).sub(new anchor.BN(1)).toString());


### PR DESCRIPTION
there's is a small typo in the definition of the `MAX_U64` constant, instead of `2^(64-1)` it should be `2^64-1`

https://github.com/orca-so/whirlpools/blob/8fc92ea1afe6b46404a3d1097525a5c92933211d/sdk/tests/utils/test-consts.ts#L10

probably not a big issue, but running some numbers I couldn't reproduce some of your test results and it took me some time until i realize this was the cause