### PR TITLE
Implement batch getPools method

### DIFF
--- a/sdk/src/impl/util.ts
+++ b/sdk/src/impl/util.ts
@@ -57,6 +57,8 @@ async function getRewardInfo(
   return rewardInfo;
 }
 
+// Uninitialized pubkeys onchain default to this value.
+// If the mint equal to this value, then we assume the field was never initialized.
 const EMPTY_MINT = "11111111111111111111111111111111";
 export function isInitialized(rewardInfo: WhirlpoolRewardInfoData): boolean {
   return rewardInfo.vault.toBase58() !== EMPTY_MINT;

--- a/sdk/src/impl/util.ts
+++ b/sdk/src/impl/util.ts
@@ -1,5 +1,5 @@
 import BN from "bn.js";
-import { AccountFetcher, TokenInfo } from "..";
+import { AccountFetcher, PoolUtil, TokenInfo } from "..";
 import {
   WhirlpoolData,
   WhirlpoolRewardInfo,
@@ -46,7 +46,7 @@ async function getRewardInfo(
   refresh: boolean
 ): Promise<WhirlpoolRewardInfo> {
   const rewardInfo = { ...data, initialized: false, vaultAmount: new BN(0) };
-  if (isInitialized(data)) {
+  if (PoolUtil.isRewardInitialized(data)) {
     const vaultInfo = await fetcher.getTokenInfo(data.vault, refresh);
     if (!vaultInfo) {
       throw new Error(`Unable to fetch TokenAccountInfo for vault - ${data.vault}`);
@@ -55,13 +55,6 @@ async function getRewardInfo(
     rewardInfo.vaultAmount = vaultInfo.amount;
   }
   return rewardInfo;
-}
-
-// Uninitialized pubkeys onchain default to this value.
-// If the mint equal to this value, then we assume the field was never initialized.
-const EMPTY_MINT = "11111111111111111111111111111111";
-export function isInitialized(rewardInfo: WhirlpoolRewardInfoData): boolean {
-  return rewardInfo.vault.toBase58() !== EMPTY_MINT;
 }
 
 export async function getTokenVaultAccountInfos(

--- a/sdk/src/impl/util.ts
+++ b/sdk/src/impl/util.ts
@@ -1,0 +1,81 @@
+import BN from "bn.js";
+import { AccountFetcher, TokenInfo } from "..";
+import {
+  WhirlpoolData,
+  WhirlpoolRewardInfo,
+  WhirlpoolRewardInfoData,
+  TokenAccountInfo,
+} from "../types/public";
+
+export async function getTokenMintInfos(
+  fetcher: AccountFetcher,
+  data: WhirlpoolData,
+  refresh: boolean
+): Promise<TokenInfo[]> {
+  const mintA = data.tokenMintA;
+  const infoA = await fetcher.getMintInfo(mintA, refresh);
+  if (!infoA) {
+    throw new Error(`Unable to fetch MintInfo for mint - ${mintA}`);
+  }
+  const mintB = data.tokenMintB;
+  const infoB = await fetcher.getMintInfo(mintB, refresh);
+  if (!infoB) {
+    throw new Error(`Unable to fetch MintInfo for mint - ${mintB}`);
+  }
+  return [
+    { mint: mintA, ...infoA },
+    { mint: mintB, ...infoB },
+  ];
+}
+
+export async function getRewardInfos(
+  fetcher: AccountFetcher,
+  data: WhirlpoolData,
+  refresh: boolean
+): Promise<WhirlpoolRewardInfo[]> {
+  const rewardInfos: WhirlpoolRewardInfo[] = [];
+  for (const rewardInfo of data.rewardInfos) {
+    rewardInfos.push(await getRewardInfo(fetcher, rewardInfo, refresh));
+  }
+  return rewardInfos;
+}
+
+async function getRewardInfo(
+  fetcher: AccountFetcher,
+  data: WhirlpoolRewardInfoData,
+  refresh: boolean
+): Promise<WhirlpoolRewardInfo> {
+  const rewardInfo = { ...data, initialized: false, vaultAmount: new BN(0) };
+  if (isInitialized(data)) {
+    const vaultInfo = await fetcher.getTokenInfo(data.vault, refresh);
+    if (!vaultInfo) {
+      throw new Error(`Unable to fetch TokenAccountInfo for vault - ${data.vault}`);
+    }
+    rewardInfo.initialized = true;
+    rewardInfo.vaultAmount = vaultInfo.amount;
+  }
+  return rewardInfo;
+}
+
+const EMPTY_MINT = "11111111111111111111111111111111";
+export function isInitialized(rewardInfo: WhirlpoolRewardInfoData): boolean {
+  return rewardInfo.vault.toBase58() !== EMPTY_MINT;
+}
+
+export async function getTokenVaultAccountInfos(
+  fetcher: AccountFetcher,
+  data: WhirlpoolData,
+  refresh: boolean
+): Promise<TokenAccountInfo[]> {
+  const vaultA = data.tokenVaultA;
+  const vaultInfoA = await fetcher.getTokenInfo(vaultA, refresh);
+  if (!vaultInfoA) {
+    throw new Error(`Unable to fetch TokenAccountInfo for vault - ${vaultA}`);
+  }
+  const vaultB = data.tokenVaultB;
+  const vaultInfoB = await fetcher.getTokenInfo(vaultB, refresh);
+  if (!vaultInfoB) {
+    throw new Error(`Unable to fetch TokenAccountInfo for vault - ${vaultB}`);
+  }
+  return [vaultInfoA, vaultInfoB];
+}

--- a/sdk/src/impl/whirlpool-client-impl.ts
+++ b/sdk/src/impl/whirlpool-client-impl.ts
@@ -1,17 +1,12 @@
 import { AddressUtil } from "@orca-so/common-sdk";
 import { Address } from "@project-serum/anchor";
-import { BN } from "bn.js";
 import { WhirlpoolContext } from "../context";
 import { AccountFetcher } from "../network/public";
 import { WhirlpoolData } from "../types/public";
+import { PoolUtil } from "../utils/public";
 import { WhirlpoolClient, Whirlpool, Position } from "../whirlpool-client";
 import { PositionImpl } from "./position-impl";
-import {
-  getRewardInfos,
-  getTokenMintInfos,
-  getTokenVaultAccountInfos,
-  isInitialized,
-} from "./util";
+import { getRewardInfos, getTokenMintInfos, getTokenVaultAccountInfos } from "./util";
 import { WhirlpoolImpl } from "./whirlpool-impl";
 
 export class WhirlpoolClientImpl implements WhirlpoolClient {
@@ -61,7 +56,7 @@ export class WhirlpoolClientImpl implements WhirlpoolClient {
       tokenAccounts.add(account.tokenVaultA.toBase58());
       tokenAccounts.add(account.tokenVaultB.toBase58());
       account.rewardInfos.forEach((rewardInfo) => {
-        if (isInitialized(rewardInfo)) {
+        if (PoolUtil.isRewardInitialized(rewardInfo)) {
           tokenAccounts.add(rewardInfo.vault.toBase58());
         }
       });

--- a/sdk/src/impl/whirlpool-impl.ts
+++ b/sdk/src/impl/whirlpool-impl.ts
@@ -19,7 +19,7 @@ import {
   swapIx,
   SwapInput,
 } from "../instructions";
-import { TokenInfo, WhirlpoolData } from "../types/public";
+import { TokenAccountInfo, TokenInfo, WhirlpoolData } from "../types/public";
 import { Whirlpool } from "../whirlpool-client";
 import { PublicKey, Keypair } from "@solana/web3.js";
 import { AccountFetcher } from "../network/public";
@@ -35,6 +35,8 @@ export class WhirlpoolImpl implements Whirlpool {
     readonly address: PublicKey,
     readonly tokenAInfo: TokenInfo,
     readonly tokenBInfo: TokenInfo,
+    readonly tokenVaultAInfo: TokenAccountInfo,
+    readonly tokenVaultBInfo: TokenAccountInfo,
     data: WhirlpoolData
   ) {
     this.data = data;
@@ -54,6 +56,14 @@ export class WhirlpoolImpl implements Whirlpool {
 
   getTokenBInfo(): TokenInfo {
     return this.tokenBInfo;
+  }
+
+  getTokenVaultAInfo(): TokenAccountInfo {
+    return this.tokenVaultAInfo;
+  }
+
+  getTokenVaultBInfo(): TokenAccountInfo {
+    return this.tokenVaultBInfo;
   }
 
   async refreshData() {

--- a/sdk/src/types/public/client-types.ts
+++ b/sdk/src/types/public/client-types.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from "@solana/web3.js";
-import { MintInfo } from "@solana/spl-token";
+import { AccountInfo, MintInfo } from "@solana/spl-token";
 import { TickArrayData } from "./anchor-types";
 
 /**
@@ -7,6 +7,8 @@ import { TickArrayData } from "./anchor-types";
  * @category WhirlpoolClient
  */
 export type TokenInfo = MintInfo & { mint: PublicKey };
+
+export type TokenAccountInfo = AccountInfo;
 
 /**
  * A wrapper class of a TickArray on a Whirlpool

--- a/sdk/src/types/public/client-types.ts
+++ b/sdk/src/types/public/client-types.ts
@@ -1,6 +1,6 @@
 import { PublicKey } from "@solana/web3.js";
-import { AccountInfo, MintInfo } from "@solana/spl-token";
-import { TickArrayData } from "./anchor-types";
+import { AccountInfo, MintInfo, u64 } from "@solana/spl-token";
+import { TickArrayData, WhirlpoolRewardInfoData } from "./anchor-types";
 
 /**
  * Extended MintInfo class to host token info.
@@ -9,6 +9,11 @@ import { TickArrayData } from "./anchor-types";
 export type TokenInfo = MintInfo & { mint: PublicKey };
 
 export type TokenAccountInfo = AccountInfo;
+
+export type WhirlpoolRewardInfo = WhirlpoolRewardInfoData & {
+  initialized: boolean;
+  vaultAmount: u64;
+};
 
 /**
  * A wrapper class of a TickArray on a Whirlpool

--- a/sdk/src/whirlpool-client.ts
+++ b/sdk/src/whirlpool-client.ts
@@ -113,9 +113,7 @@ export interface Whirlpool {
 
   /**
    * Get the WhirlpoolRewardInfos for this pool.
-   * An array of 3 reward vaults are always returned. However, not all of them may be initialized.
-   * Use the initialized field on WhirlpoolRewardInfo to determine whether the reward is active.
-   * @return TokenAccountInfo for initialized reward vaults
+   * @return Array of 3 WhirlpoolRewardInfos. However, not all of them may be initialized. Use the initialized field on WhirlpoolRewardInfo to check if the reward is active.
    */
   getRewardInfos: () => WhirlpoolRewardInfo[];
 

--- a/sdk/src/whirlpool-client.ts
+++ b/sdk/src/whirlpool-client.ts
@@ -11,7 +11,7 @@ import {
   PositionData,
   WhirlpoolData,
 } from "./types/public";
-import { TokenAccountInfo, TokenInfo } from "./types/public/client-types";
+import { TokenAccountInfo, TokenInfo, WhirlpoolRewardInfo } from "./types/public/client-types";
 
 /**
  * Helper class to help interact with Whirlpool Accounts with a simpler interface.
@@ -37,6 +37,13 @@ export interface WhirlpoolClient {
    * @return a Whirlpool object to interact with
    */
   getPool: (poolAddress: Address, refresh?: boolean) => Promise<Whirlpool>;
+
+  /**
+   * Get a list of Whirlpool objects matching the provided list of addresses.
+   * @param poolAddresses the addresses of the Whirlpool accounts
+   * @return a list of Whirlpool objects to interact with
+   */
+  getPools: (poolAddresses: Address[], refresh?: boolean) => Promise<Whirlpool[]>;
 
   /**
    * Get a Position object to interact with the Position account at the given address.
@@ -103,6 +110,14 @@ export interface Whirlpool {
    * @return TokenAccountInfo for token vault B
    */
   getTokenVaultBInfo: () => TokenAccountInfo;
+
+  /**
+   * Get a WhirlpoolRewardInfo for initialized rewards of this pool.
+   * A maximum of 3 reward vaults are supported.
+   * Uninitialized reward vaults are excluded.
+   * @return TokenAccountInfo for initialized reward vaults
+   */
+  getRewardInfos: () => WhirlpoolRewardInfo[];
 
   /**
    * Initialize a set of tick-arrays that encompasses the provided ticks.

--- a/sdk/src/whirlpool-client.ts
+++ b/sdk/src/whirlpool-client.ts
@@ -11,7 +11,7 @@ import {
   PositionData,
   WhirlpoolData,
 } from "./types/public";
-import { TokenInfo } from "./types/public/client-types";
+import { TokenAccountInfo, TokenInfo } from "./types/public/client-types";
 
 /**
  * Helper class to help interact with Whirlpool Accounts with a simpler interface.
@@ -91,6 +91,18 @@ export interface Whirlpool {
    * @return TokenInfo for token B
    */
   getTokenBInfo: () => TokenInfo;
+
+  /**
+   * Get the TokenAccountInfo for token vault A of this pool.
+   * @return TokenAccountInfo for token vault A
+   */
+  getTokenVaultAInfo: () => TokenAccountInfo;
+
+  /**
+   * Get the TokenAccountInfo for token vault B of this pool.
+   * @return TokenAccountInfo for token vault B
+   */
+  getTokenVaultBInfo: () => TokenAccountInfo;
 
   /**
    * Initialize a set of tick-arrays that encompasses the provided ticks.

--- a/sdk/src/whirlpool-client.ts
+++ b/sdk/src/whirlpool-client.ts
@@ -112,9 +112,9 @@ export interface Whirlpool {
   getTokenVaultBInfo: () => TokenAccountInfo;
 
   /**
-   * Get a WhirlpoolRewardInfo for initialized rewards of this pool.
-   * A maximum of 3 reward vaults are supported.
-   * Uninitialized reward vaults are excluded.
+   * Get the WhirlpoolRewardInfos for this pool.
+   * An array of 3 reward vaults are always returned. However, not all of them may be initialized.
+   * Use the initialized field on WhirlpoolRewardInfo to determine whether the reward is active.
    * @return TokenAccountInfo for initialized reward vaults
    */
   getRewardInfos: () => WhirlpoolRewardInfo[];


### PR DESCRIPTION
Implementing a `getPools` method on the WhirlpoolClient for batch fetching pools.

This change also adds fetching onchain data for token accounts for vaults (including reward vaults).

These fields were provided by the old SDK, and it feels like they also belong in the new SDK rather than interacting with the web3.js client after retrieving whirlpools.