### PR TITLE
protocol_fee_rate comment

### DIFF
--- a/programs/whirlpool/src/state/whirlpool.rs
+++ b/programs/whirlpool/src/state/whirlpool.rs
@@ -22,7 +22,7 @@ pub struct Whirlpool {
     // u16::MAX corresponds to ~6.5%
     pub fee_rate: u16, // 2
 
-    // Denominator for portion of fee rate taken (1/x)%
+    // Portion of fee rate taken stored as basis points
     pub protocol_fee_rate: u16, // 2
 
     // Maximum amount that can be held by Solana account


### PR DESCRIPTION
The comment is incorrect. This is described correctly in the Developer Portal, so this will sync up with the documentation.