### PR TITLE
Allow developers to take additional fees from a swap

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -7,7 +7,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@metaplex-foundation/mpl-token-metadata": "1.2.5",
-    "@orca-so/common-sdk": "~0.1.0",
+    "@orca-so/common-sdk": "~0.1.1",
     "@project-serum/anchor": "~0.25.0",
     "@solana/spl-token": "^0.1.8",
     "decimal.js": "^10.3.1",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -14,7 +14,7 @@
     "tiny-invariant": "^1.2.0"
   },
   "devDependencies": {
-    "@types/bn.js": "^5.1.0",
+    "@types/bn.js": "~5.1.0",
     "@types/decimal.js": "^7.4.0",
     "@types/jest": "^26.0.24",
     "@types/mocha": "^9.0.0",

--- a/sdk/src/errors/errors.ts
+++ b/sdk/src/errors/errors.ts
@@ -11,6 +11,7 @@ export enum TokenErrorCode {
 }
 
 export enum SwapErrorCode {
+  InvalidDevFeePercentage = `InvalidDevFeePercentage`,
   InvalidSqrtPriceLimitDirection = `InvalidSqrtPriceLimitDirection`,
   SqrtPriceOutOfBounds = `SqrtPriceOutOfBounds`,
   ZeroTradableAmount = `ZeroTradableAmount`,

--- a/sdk/src/impl/whirlpool-impl.ts
+++ b/sdk/src/impl/whirlpool-impl.ts
@@ -11,6 +11,7 @@ import { Address, BN, translateAddress } from "@project-serum/anchor";
 import { Keypair, PublicKey } from "@solana/web3.js";
 import invariant from "tiny-invariant";
 import { WhirlpoolContext } from "../context";
+import { SwapErrorCode, WhirlpoolsError } from "../errors/errors";
 import {
   closePositionIx,
   decreaseLiquidityIx,
@@ -189,6 +190,13 @@ export class WhirlpoolImpl implements Whirlpool {
       this.ctx.provider.connection,
       this.ctx.provider.wallet
     );
+
+    if (quote.devFeeAmount.gt(quote.amount)) {
+      throw new WhirlpoolsError(
+        "devFeeAmount cannot be more than 100% of the swap amount. ",
+        SwapErrorCode.InvalidDevFeePercentage
+      );
+    }
 
     if (!quote.devFeeAmount.eq(ZERO)) {
       const inputToken =

--- a/sdk/src/impl/whirlpool-impl.ts
+++ b/sdk/src/impl/whirlpool-impl.ts
@@ -190,21 +190,23 @@ export class WhirlpoolImpl implements Whirlpool {
       this.ctx.provider.wallet
     );
 
-    const inputToken =
-      quote.aToB === quote.amountSpecifiedIsInput ? this.getTokenAInfo() : this.getTokenBInfo();
+    if (!quote.devFeeAmount.eq(ZERO)) {
+      const inputToken =
+        quote.aToB === quote.amountSpecifiedIsInput ? this.getTokenAInfo() : this.getTokenBInfo();
 
-    txBuilder.addInstruction(
-      await TokenUtil.createSendTokensToWalletInstruction(
-        this.ctx.connection,
-        sourceWalletKey,
-        devFeeWallet,
-        inputToken.mint,
-        inputToken.decimals,
-        quote.devFeeAmount,
-        this.ctx.fetcher.getAccountRentExempt,
-        payerKey
-      )
-    );
+      txBuilder.addInstruction(
+        await TokenUtil.createSendTokensToWalletInstruction(
+          this.ctx.connection,
+          sourceWalletKey,
+          devFeeWallet,
+          inputToken.mint,
+          inputToken.decimals,
+          quote.devFeeAmount,
+          this.ctx.fetcher.getAccountRentExempt,
+          payerKey
+        )
+      );
+    }
 
     return this.getSwapTx(quote, sourceWalletKey, txBuilder);
   }
@@ -432,6 +434,7 @@ export class WhirlpoolImpl implements Whirlpool {
     wallet: PublicKey,
     initTxBuilder?: TransactionBuilder
   ): Promise<TransactionBuilder> {
+    invariant(input.amount.gt(ZERO), "swap amount must be more than zero.");
     const { amount, aToB } = input;
     const whirlpool = this.data;
     const txBuilder =

--- a/sdk/src/impl/whirlpool-impl.ts
+++ b/sdk/src/impl/whirlpool-impl.ts
@@ -15,6 +15,7 @@ import { SwapErrorCode, WhirlpoolsError } from "../errors/errors";
 import {
   closePositionIx,
   decreaseLiquidityIx,
+  DevFeeSwapInput,
   IncreaseLiquidityInput,
   increaseLiquidityIx,
   initTickArrayIx,
@@ -24,8 +25,7 @@ import {
   swapIx,
 } from "../instructions";
 import { AccountFetcher } from "../network/public";
-import { decreaseLiquidityQuoteByLiquidityWithParams, SwapQuote } from "../quotes/public";
-import { DevFeeSwapQuote } from "../quotes/public/dev-fee-swap-quote";
+import { decreaseLiquidityQuoteByLiquidityWithParams } from "../quotes/public";
 import { TokenAccountInfo, TokenInfo, WhirlpoolData, WhirlpoolRewardInfo } from "../types/public";
 import { PDAUtil, TickArrayUtil, TickUtil } from "../utils/public";
 import { Whirlpool } from "../whirlpool-client";
@@ -171,7 +171,7 @@ export class WhirlpoolImpl implements Whirlpool {
     );
   }
 
-  async swap(quote: SwapQuote, sourceWallet?: Address) {
+  async swap(quote: SwapInput, sourceWallet?: Address) {
     const sourceWalletKey = sourceWallet
       ? AddressUtil.toPubKey(sourceWallet)
       : this.ctx.wallet.publicKey;
@@ -179,7 +179,7 @@ export class WhirlpoolImpl implements Whirlpool {
   }
 
   async swapWithDevFees(
-    quote: DevFeeSwapQuote,
+    quote: DevFeeSwapInput,
     devFeeWallet: PublicKey,
     wallet?: PublicKey | undefined,
     payer?: PublicKey | undefined

--- a/sdk/src/impl/whirlpool-impl.ts
+++ b/sdk/src/impl/whirlpool-impl.ts
@@ -5,13 +5,12 @@ import {
   resolveOrCreateATAs,
   TokenUtil,
   TransactionBuilder,
-  ZERO,
+  ZERO
 } from "@orca-so/common-sdk";
 import { Address, BN, translateAddress } from "@project-serum/anchor";
 import { Keypair, PublicKey } from "@solana/web3.js";
 import invariant from "tiny-invariant";
 import { WhirlpoolContext } from "../context";
-import { SwapErrorCode, WhirlpoolsError } from "../errors/errors";
 import {
   closePositionIx,
   decreaseLiquidityIx,
@@ -22,7 +21,7 @@ import {
   openPositionIx,
   openPositionWithMetadataIx,
   SwapInput,
-  swapIx,
+  swapIx
 } from "../instructions";
 import { AccountFetcher } from "../network/public";
 import { decreaseLiquidityQuoteByLiquidityWithParams } from "../quotes/public";
@@ -191,13 +190,6 @@ export class WhirlpoolImpl implements Whirlpool {
       this.ctx.provider.wallet
     );
 
-    if (quote.devFeeAmount.gt(quote.amount)) {
-      throw new WhirlpoolsError(
-        "devFeeAmount cannot be more than 100% of the swap amount. ",
-        SwapErrorCode.InvalidDevFeePercentage
-      );
-    }
-
     if (!quote.devFeeAmount.eq(ZERO)) {
       const inputToken =
         quote.aToB === quote.amountSpecifiedIsInput ? this.getTokenAInfo() : this.getTokenBInfo();
@@ -210,7 +202,7 @@ export class WhirlpoolImpl implements Whirlpool {
           inputToken.mint,
           inputToken.decimals,
           quote.devFeeAmount,
-          this.ctx.fetcher.getAccountRentExempt,
+          () => this.ctx.fetcher.getAccountRentExempt(),
           payerKey
         )
       );

--- a/sdk/src/instructions/swap-ix.ts
+++ b/sdk/src/instructions/swap-ix.ts
@@ -76,7 +76,7 @@ export type SwapInput = {
  * @param devFeeAmount -  FeeAmount (developer fees) charged on this swap
  */
 export type DevFeeSwapInput = SwapInput & {
-  devFeeAmount: BN;
+  devFeeAmount: u64;
 };
 
 /**

--- a/sdk/src/instructions/swap-ix.ts
+++ b/sdk/src/instructions/swap-ix.ts
@@ -1,9 +1,8 @@
-import { TOKEN_PROGRAM_ID, u64 } from "@solana/spl-token";
-import { Program } from "@project-serum/anchor";
-import { Whirlpool } from "../artifacts/whirlpool";
 import { Instruction } from "@orca-so/common-sdk";
+import { BN, Program } from "@project-serum/anchor";
+import { TOKEN_PROGRAM_ID, u64 } from "@solana/spl-token";
 import { PublicKey } from "@solana/web3.js";
-import { BN } from "@project-serum/anchor";
+import { Whirlpool } from "../artifacts/whirlpool";
 
 /**
  * Parameters and accounts to swap on a Whirlpool
@@ -59,6 +58,25 @@ export type SwapInput = {
   tickArray0: PublicKey;
   tickArray1: PublicKey;
   tickArray2: PublicKey;
+};
+
+/**
+ * Parameters to swap on a Whirlpool with developer fees
+ *
+ * @category Instruction Types
+ * @param aToB - The direction of the swap. True if swapping from A to B. False if swapping from B to A.
+ * @param amountSpecifiedIsInput - Specifies the token the parameter `amount`represents. If true, the amount represents
+ *                                 the input token of the swap.
+ * @param amount - The amount of input or output token to swap from (depending on amountSpecifiedIsInput).
+ * @param otherAmountThreshold - The maximum/minimum of input/output token to swap into (depending on amountSpecifiedIsInput).
+ * @param sqrtPriceLimit - The maximum/minimum price the swap will swap to.
+ * @param tickArray0 - PublicKey of the tick-array where the Whirlpool's currentTickIndex resides in
+ * @param tickArray1 - The next tick-array in the swap direction. If the swap will not reach the next tick-aray, input the same array as tickArray0.
+ * @param tickArray2 - The next tick-array in the swap direction after tickArray2. If the swap will not reach the next tick-aray, input the same array as tickArray1.
+ * @param devFeeAmount -  FeeAmount (developer fees) charged on this swap
+ */
+export type DevFeeSwapInput = SwapInput & {
+  devFeeAmount: BN;
 };
 
 /**

--- a/sdk/src/quotes/public/dev-fee-swap-quote.ts
+++ b/sdk/src/quotes/public/dev-fee-swap-quote.ts
@@ -1,0 +1,137 @@
+import { AddressUtil, Percentage } from "@orca-so/common-sdk";
+import { Address } from "@project-serum/anchor";
+import { u64 } from "@solana/spl-token";
+import invariant from "tiny-invariant";
+import { AccountFetcher } from "../..";
+import { PoolUtil, SwapUtils, TokenType } from "../../utils/public";
+import { Whirlpool } from "../../whirlpool-client";
+import { simulateSwap } from "../swap/swap-quote-impl";
+import { checkIfAllTickArraysInitialized } from "../swap/swap-quote-utils";
+import { BaseSwapQuote, SwapQuoteParam } from "./swap-quote";
+
+/**
+ * @category Quotes
+ *
+ * @param tokenAmount - The amount of input or output token to swap from (depending on amountSpecifiedIsInput).
+ * @param otherAmountThreshold - The maximum/minimum of input/output token to swap into (depending on amountSpecifiedIsInput).
+ * @param sqrtPriceLimit - The maximum/minimum price the swap will swap to.
+ * @param aToB - The direction of the swap. True if swapping from A to B. False if swapping from B to A.
+ * @param amountSpecifiedIsInput - 'true', dev-fee swaps only supports where tokenAmount specified is the input.
+ * @param tickArrays - An sequential array of tick-array objects in the direction of the trade to swap on
+ * @param devFeePercentage - The percentage of fees the developer will collect from this swap. Percentage value has to match the input token decimals.
+ */
+export type DevFeeSwapQuoteParam = SwapQuoteParam & {
+  devFeePercentage: Percentage;
+  amountSpecifiedIsInput: true;
+};
+
+/**
+ * A collection of estimated values from quoting a swap with dev-fee collection.
+ * @category Quotes
+ * @param estimatedAmountIn - Approximate number of input token swapped in the swap
+ * @param estimatedAmountOut - Approximate number of output token swapped in the swap
+ * @param estimatedEndTickIndex - Approximate tick-index the Whirlpool will land on after this swap
+ * @param estimatedEndSqrtPrice - Approximate sqrtPrice the Whirlpool will land on after this swap
+ * @param estimatedFeeAmount - Approximate feeAmount (all fees) charged on this swap
+ * @param estimatedSwapFeeAmount - Approximate feeAmount (LP + protocol fees) charged on this swap
+ * @param devFeeAmount - Approximate feeAmount (developer fees) charged on this swap
+ */
+export type DevFeeSwapQuote = BaseSwapQuote & {
+  estimatedSwapFeeAmount: u64;
+  devFeeAmount: u64;
+  amountSpecifiedIsInput: true;
+};
+
+/**
+ * Get an estimated swap quote using input token amount.
+ *
+ * @category Quotes
+ * @param whirlpool - Whirlpool to perform the swap on
+ * @param inputTokenMint - PublicKey for the input token mint to swap with
+ * @param tokenAmount - The amount of input token to swap from
+ * @param slippageTolerance - The amount of slippage to account for in this quote
+ * @param programId - PublicKey for the Whirlpool ProgramId
+ * @param fetcher - AccountFetcher object to fetch solana accounts
+ * @param refresh - If true, fetcher would default to fetching the latest accounts
+ * @returns a SwapQuote object with slippage adjusted SwapInput parameters & estimates on token amounts, fee & end whirlpool states.
+ */
+export async function swapQuoteByInputTokenWithDevFees(
+  whirlpool: Whirlpool,
+  inputTokenMint: Address,
+  tokenAmount: u64,
+  slippageTolerance: Percentage,
+  programId: Address,
+  fetcher: AccountFetcher,
+  devFeePercentage: Percentage,
+  refresh: boolean
+): Promise<DevFeeSwapQuote> {
+  const whirlpoolData = whirlpool.getData();
+  const swapMintKey = AddressUtil.toPubKey(inputTokenMint);
+  const swapTokenType = PoolUtil.getTokenType(whirlpoolData, swapMintKey);
+  invariant(!!swapTokenType, "swapTokenMint does not match any tokens on this pool");
+  const aToB = swapTokenType === TokenType.TokenA;
+
+  const tickArrays = await SwapUtils.getTickArrays(
+    whirlpoolData.tickCurrentIndex,
+    whirlpoolData.tickSpacing,
+    aToB,
+    AddressUtil.toPubKey(programId),
+    whirlpool.getAddress(),
+    fetcher,
+    refresh
+  );
+
+  return devFeeSwapQuoteWithParams(
+    {
+      whirlpoolData,
+      tokenAmount,
+      aToB,
+      amountSpecifiedIsInput: true,
+      sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
+      otherAmountThreshold: SwapUtils.getDefaultOtherAmountThreshold(true),
+      tickArrays,
+      devFeePercentage,
+    },
+    slippageTolerance
+  );
+}
+
+/**
+ * Perform a sync swap quote based on the basic swap instruction parameters.
+ *
+ * @category Quotes
+ * @param params - SwapQuote parameters
+ * @param slippageTolerance - The amount of slippage to account for when generating the final quote.
+ * @returns a SwapQuote object with slippage adjusted SwapInput parameters & estimates on token amounts, fee & end whirlpool states.
+ */
+export function devFeeSwapQuoteWithParams(
+  params: DevFeeSwapQuoteParam,
+  slippageTolerance: Percentage
+): DevFeeSwapQuote {
+  checkIfAllTickArraysInitialized(params.tickArrays);
+
+  const devFeeRate = params.devFeePercentage;
+  const devFeeAmount = params.tokenAmount.mul(devFeeRate.numerator).div(devFeeRate.denominator);
+  const finalTokenAmount = params.tokenAmount.sub(devFeeAmount);
+
+  const quote = simulateSwap({
+    ...params,
+    tokenAmount: finalTokenAmount,
+  });
+
+  const slippageAdjustedQuote: DevFeeSwapQuote = {
+    ...quote,
+    ...SwapUtils.calculateSwapAmountsFromQuote(
+      params.tokenAmount,
+      quote.estimatedAmountIn,
+      quote.estimatedAmountOut,
+      slippageTolerance,
+      params.amountSpecifiedIsInput
+    ),
+    amountSpecifiedIsInput: true,
+    estimatedSwapFeeAmount: quote.estimatedFeeAmount,
+    devFeeAmount,
+  };
+
+  return slippageAdjustedQuote;
+}

--- a/sdk/src/quotes/public/dev-fee-swap-quote.ts
+++ b/sdk/src/quotes/public/dev-fee-swap-quote.ts
@@ -7,7 +7,7 @@ import { Whirlpool } from "../../whirlpool-client";
 import { BaseSwapQuote, swapQuoteByInputToken } from "./swap-quote";
 
 /**
- * A collection of estimated values from quoting a swap with dev-fee collection.
+ * A collection of estimated values from quoting a swap that collects a developer-fee.
  * @category Quotes
  * @param estimatedAmountIn - Approximate number of input token swapped in the swap
  * @param estimatedAmountOut - Approximate number of output token swapped in the swap
@@ -18,13 +18,17 @@ import { BaseSwapQuote, swapQuoteByInputToken } from "./swap-quote";
  * @param devFeeAmount - Approximate feeAmount (developer fees) charged on this swap
  */
 export type DevFeeSwapQuote = BaseSwapQuote & {
+  // NOTE: DevFeeSwaps supports input-token based swaps only as it is difficult
+  // to collect an exact % amount of dev-fees for output-token based swaps due to slippage.
+  // If there are third party requests in the future for this functionality, we can launch it
+  // but with the caveat that the % collected is only an estimate.
   amountSpecifiedIsInput: true;
   estimatedSwapFeeAmount: u64;
   devFeeAmount: u64;
 };
 
 /**
- * Get an estimated swap quote using input token amount.
+ * Get an estimated swap quote using input token amount and collecting dev-fees.
  *
  * @category Quotes
  * @param whirlpool - Whirlpool to perform the swap on

--- a/sdk/src/quotes/public/dev-fee-swap-quote.ts
+++ b/sdk/src/quotes/public/dev-fee-swap-quote.ts
@@ -4,7 +4,7 @@ import { u64 } from "@solana/spl-token";
 import { AccountFetcher } from "../..";
 import { SwapErrorCode, WhirlpoolsError } from "../../errors/errors";
 import { Whirlpool } from "../../whirlpool-client";
-import { BaseSwapQuote, swapQuoteByInputToken } from "./swap-quote";
+import { NormalSwapQuote, swapQuoteByInputToken } from "./swap-quote";
 
 /**
  * A collection of estimated values from quoting a swap that collects a developer-fee.
@@ -17,7 +17,7 @@ import { BaseSwapQuote, swapQuoteByInputToken } from "./swap-quote";
  * @param estimatedSwapFeeAmount - Approximate feeAmount (LP + protocol fees) charged on this swap
  * @param devFeeAmount - Approximate feeAmount (developer fees) charged on this swap
  */
-export type DevFeeSwapQuote = BaseSwapQuote & {
+export type DevFeeSwapQuote = NormalSwapQuote & {
   // NOTE: DevFeeSwaps supports input-token based swaps only as it is difficult
   // to collect an exact % amount of dev-fees for output-token based swaps due to slippage.
   // If there are third party requests in the future for this functionality, we can launch it
@@ -28,7 +28,7 @@ export type DevFeeSwapQuote = BaseSwapQuote & {
 };
 
 /**
- * Get an estimated swap quote using input token amount and collecting dev-fees.
+ * Get an estimated swap quote using input token amount while collecting dev fees.
  *
  * @category Quotes
  * @param whirlpool - Whirlpool to perform the swap on

--- a/sdk/src/quotes/public/dev-fee-swap-quote.ts
+++ b/sdk/src/quotes/public/dev-fee-swap-quote.ts
@@ -15,7 +15,7 @@ import { NormalSwapQuote, swapQuoteByInputToken } from "./swap-quote";
  * @param estimatedEndSqrtPrice - Approximate sqrtPrice the Whirlpool will land on after this swap
  * @param estimatedFeeAmount - Approximate feeAmount (all fees) charged on this swap
  * @param estimatedSwapFeeAmount - Approximate feeAmount (LP + protocol fees) charged on this swap
- * @param devFeeAmount - Approximate feeAmount (developer fees) charged on this swap
+ * @param devFeeAmount -  FeeAmount (developer fees) charged on this swap
  */
 export type DevFeeSwapQuote = NormalSwapQuote & {
   // NOTE: DevFeeSwaps supports input-token based swaps only as it is difficult

--- a/sdk/src/quotes/public/dev-fee-swap-quote.ts
+++ b/sdk/src/quotes/public/dev-fee-swap-quote.ts
@@ -53,6 +53,7 @@ export type DevFeeSwapQuote = BaseSwapQuote & {
  * @param programId - PublicKey for the Whirlpool ProgramId
  * @param fetcher - AccountFetcher object to fetch solana accounts
  * @param refresh - If true, fetcher would default to fetching the latest accounts
+ * @param devFeePercentage - The percentage amount to send to developer wallet prior to the swap. Percentage num/dem values has to match token decimal.
  * @returns a SwapQuote object with slippage adjusted SwapInput parameters & estimates on token amounts, fee & end whirlpool states.
  */
 export async function swapQuoteByInputTokenWithDevFees(

--- a/sdk/src/quotes/public/swap-quote.ts
+++ b/sdk/src/quotes/public/swap-quote.ts
@@ -151,11 +151,11 @@ export function swapQuoteWithParams(
   const slippageAdjustedQuote: SwapQuote = {
     ...quote,
     ...SwapUtils.calculateSwapAmountsFromQuote(
-      params.tokenAmount,
+      quote.amount,
       quote.estimatedAmountIn,
       quote.estimatedAmountOut,
       slippageTolerance,
-      params.amountSpecifiedIsInput
+      quote.amountSpecifiedIsInput
     ),
   };
 

--- a/sdk/src/quotes/public/swap-quote.ts
+++ b/sdk/src/quotes/public/swap-quote.ts
@@ -39,7 +39,7 @@ export type SwapQuoteParam = {
  * @link {BaseSwapQuote}
  * @link {DevFeeSwapQuote}
  */
-export type SwapQuote = BaseSwapQuote | DevFeeSwapQuote;
+export type SwapQuote = NormalSwapQuote | DevFeeSwapQuote;
 
 /**
  * A collection of estimated values from quoting a swap.
@@ -50,7 +50,7 @@ export type SwapQuote = BaseSwapQuote | DevFeeSwapQuote;
  * @param estimatedEndSqrtPrice - Approximate sqrtPrice the Whirlpool will land on after this swap
  * @param estimatedFeeAmount - Approximate feeAmount (all fees) charged on this swap
  */
-export type BaseSwapQuote = {
+export type NormalSwapQuote = {
   estimatedAmountIn: u64;
   estimatedAmountOut: u64;
   estimatedEndTickIndex: number;

--- a/sdk/src/quotes/swap/swap-quote-utils.ts
+++ b/sdk/src/quotes/swap/swap-quote-utils.ts
@@ -1,0 +1,14 @@
+import { TickArray, TickArrayUtil } from "../..";
+
+export function checkIfAllTickArraysInitialized(tickArrays: TickArray[]) {
+  // Check if all the tick arrays have been initialized.
+  const uninitializedIndices = TickArrayUtil.getUninitializedArrays(
+    tickArrays.map((array) => array.data)
+  );
+  if (uninitializedIndices.length > 0) {
+    const uninitializedArrays = uninitializedIndices
+      .map((index) => tickArrays[index].address.toBase58())
+      .join(", ");
+    throw new Error(`TickArray addresses - [${uninitializedArrays}] need to be initialized.`);
+  }
+}

--- a/sdk/src/whirlpool-client.ts
+++ b/sdk/src/whirlpool-client.ts
@@ -209,7 +209,7 @@ export interface Whirlpool {
   swap: (quote: SwapQuote, wallet?: PublicKey) => Promise<TransactionBuilder>;
 
   /**
-   * Collect a developer fee, then perform a swap between tokenA and tokenB on this pool.
+   * Collect a developer fee and perform a swap between tokenA and tokenB on this pool.
    *
    * @param quote - A quote on the desired tokenIn and tokenOut for this swap. Use @link {swapQuote} to generate this object.
    * @param devFeeWallet - The wallet that developer fees will be deposited into.

--- a/sdk/src/whirlpool-client.ts
+++ b/sdk/src/whirlpool-client.ts
@@ -3,9 +3,8 @@ import { Address } from "@project-serum/anchor";
 import { PublicKey } from "@solana/web3.js";
 import { WhirlpoolContext } from "./context";
 import { WhirlpoolClientImpl } from "./impl/whirlpool-client-impl";
+import { DevFeeSwapInput, SwapInput } from "./instructions";
 import { AccountFetcher } from "./network/public";
-import { SwapQuote } from "./quotes/public";
-import { DevFeeSwapQuote } from "./quotes/public/dev-fee-swap-quote";
 import {
   DecreaseLiquidityInput,
   IncreaseLiquidityInput,
@@ -202,23 +201,23 @@ export interface Whirlpool {
   /**
    * Perform a swap between tokenA and tokenB on this pool.
    *
-   * @param quote - A quote on the desired tokenIn and tokenOut for this swap. Use @link {swapQuote} to generate this object.
+   * @param input - A quote on the desired tokenIn and tokenOut for this swap. Use @link {swapQuote} to generate this object.
    * @param wallet - The wallet that tokens will be withdrawn and deposit into. If null, the WhirlpoolContext wallet is used.
    * @return a transaction that will perform the swap once executed.
    */
-  swap: (quote: SwapQuote, wallet?: PublicKey) => Promise<TransactionBuilder>;
+  swap: (input: SwapInput, wallet?: PublicKey) => Promise<TransactionBuilder>;
 
   /**
    * Collect a developer fee and perform a swap between tokenA and tokenB on this pool.
    *
-   * @param quote - A quote on the desired tokenIn and tokenOut for this swap. Use @link {swapQuote} to generate this object.
+   * @param input - A quote on the desired tokenIn and tokenOut for this swap. Use @link {swapQuote} to generate this object.
    * @param devFeeWallet - The wallet that developer fees will be deposited into.
    * @param wallet - The wallet that swap tokens will be withdrawn and deposit into. If null, the WhirlpoolContext wallet is used.
    * @param payer - The wallet that will fund the cost needed to initialize the dev wallet token ATA accounts. If null, the WhirlpoolContext wallet is used.
    * @return a transaction that will perform the swap once executed.
    */
   swapWithDevFees: (
-    quote: DevFeeSwapQuote,
+    input: DevFeeSwapInput,
     devFeeWallet: PublicKey,
     wallet?: PublicKey,
     payer?: PublicKey

--- a/sdk/src/whirlpool-client.ts
+++ b/sdk/src/whirlpool-client.ts
@@ -5,6 +5,7 @@ import { WhirlpoolContext } from "./context";
 import { WhirlpoolClientImpl } from "./impl/whirlpool-client-impl";
 import { AccountFetcher } from "./network/public";
 import { SwapQuote } from "./quotes/public";
+import { DevFeeSwapQuote } from "./quotes/public/dev-fee-swap-quote";
 import {
   DecreaseLiquidityInput,
   IncreaseLiquidityInput,
@@ -206,6 +207,22 @@ export interface Whirlpool {
    * @return a transaction that will perform the swap once executed.
    */
   swap: (quote: SwapQuote, wallet?: PublicKey) => Promise<TransactionBuilder>;
+
+  /**
+   * Collect a developer fee, then perform a swap between tokenA and tokenB on this pool.
+   *
+   * @param quote - A quote on the desired tokenIn and tokenOut for this swap. Use @link {swapQuote} to generate this object.
+   * @param devFeeWallet - The wallet that developer fees will be deposited into.
+   * @param wallet - The wallet that swap tokens will be withdrawn and deposit into. If null, the WhirlpoolContext wallet is used.
+   * @param payer - The wallet that will fund the cost needed to initialize the dev wallet token ATA accounts. If null, the WhirlpoolContext wallet is used.
+   * @return a transaction that will perform the swap once executed.
+   */
+  swapWithDevFees: (
+    quote: DevFeeSwapQuote,
+    devFeeWallet: PublicKey,
+    wallet?: PublicKey,
+    payer?: PublicKey
+  ) => Promise<TransactionBuilder>;
 }
 
 /**

--- a/sdk/tests/sdk/whirlpools/swap/swap-dev-fee.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/swap-dev-fee.test.ts
@@ -5,11 +5,10 @@ import { u64 } from "@solana/spl-token";
 import { Keypair, PublicKey } from "@solana/web3.js";
 import * as assert from "assert";
 import {
-  buildWhirlpoolClient,
-  PriceMath,
+  buildWhirlpoolClient, PriceMath,
   swapQuoteByInputToken,
   Whirlpool,
-  WhirlpoolContext,
+  WhirlpoolContext
 } from "../../../../src";
 import { SwapErrorCode, WhirlpoolsError } from "../../../../src/errors/errors";
 import { swapQuoteByInputTokenWithDevFees } from "../../../../src/quotes/public/dev-fee-swap-quote";
@@ -17,16 +16,16 @@ import {
   assertDevFeeQuotes,
   assertDevTokenAmount,
   assertQuoteAndResults,
-  TickSpacing,
+  TickSpacing
 } from "../../../utils";
 import {
   arrayTickIndexToTickIndex,
   buildPosition,
-  setupSwapTest,
+  setupSwapTest
 } from "../../../utils/swap-test-utils";
 import { getVaultAmounts } from "../../../utils/whirlpools-test-utils";
 
-describe("whirlpool-dev-fee-swap", () => {
+describe.only("whirlpool-dev-fee-swap", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;
@@ -123,13 +122,13 @@ describe("whirlpool-dev-fee-swap", () => {
     });
 
     const devFeePercentage = Percentage.fromFraction(1, 1000); // 0.1%
-    const inputTokenAmount = new u64(119500000);
+    const inputTokenAmount = new u64(1195000);
     const postFeeTokenAmount = inputTokenAmount.sub(
       inputTokenAmount.mul(devFeePercentage.numerator).div(devFeePercentage.denominator)
     );
 
     const whirlpoolData = await whirlpool.refreshData();
-    const swapToken = whirlpoolData.tokenMintB;
+    const swapToken = aToB ? whirlpoolData.tokenMintA : whirlpoolData.tokenMintB;
     const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
     const { inputTokenQuote, postFeeInputTokenQuote, inputTokenQuoteWithDevFees } = await getQuotes(
       ctx,
@@ -154,13 +153,13 @@ describe("whirlpool-dev-fee-swap", () => {
       beforeVaultAmounts,
       afterVaultAmounts
     );
-    assertDevTokenAmount(ctx, inputTokenQuoteWithDevFees, swapToken, devWallet.publicKey);
+    await assertDevTokenAmount(ctx, inputTokenQuoteWithDevFees, swapToken, devWallet.publicKey);
   });
 
   it("swap with dev-fee 1%", async () => {
-    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -1, offsetIndex: 22 }, tickSpacing);
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 22 }, tickSpacing);
     const devWallet = Keypair.generate();
-    const aToB = false;
+    const aToB = true;
     const whirlpool = await setupSwapTest({
       ctx,
       client,
@@ -178,14 +177,14 @@ describe("whirlpool-dev-fee-swap", () => {
       ],
     });
 
-    const devFeePercentage = Percentage.fromFraction(1, 100); // 0.1%
+    const devFeePercentage = Percentage.fromFraction(1, 100); // 1%
     const inputTokenAmount = new u64(119500000);
     const postFeeTokenAmount = inputTokenAmount.sub(
       inputTokenAmount.mul(devFeePercentage.numerator).div(devFeePercentage.denominator)
     );
 
     const whirlpoolData = await whirlpool.refreshData();
-    const swapToken = whirlpoolData.tokenMintB;
+    const swapToken = aToB ? whirlpoolData.tokenMintA : whirlpoolData.tokenMintB;
     const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
     const { inputTokenQuote, postFeeInputTokenQuote, inputTokenQuoteWithDevFees } = await getQuotes(
       ctx,
@@ -210,7 +209,88 @@ describe("whirlpool-dev-fee-swap", () => {
       beforeVaultAmounts,
       afterVaultAmounts
     );
-    assertDevTokenAmount(ctx, inputTokenQuoteWithDevFees, swapToken, devWallet.publicKey);
+    await assertDevTokenAmount(ctx, inputTokenQuoteWithDevFees, swapToken, devWallet.publicKey);
+  });
+
+  it("swap with input-token as NATIVE_MINT & dev-fee 1%", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 1 }, tickSpacing);
+    const aToB = true;
+    const tokenAIsNative = true;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-16896, -11264, -5632, 0, 5632],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -1, offsetIndex: 10 },
+          { arrayIndex: 1, offsetIndex: 23 },
+          tickSpacing,
+          new anchor.BN(990_000_000)
+        ),
+        buildPosition(
+          // a
+          { arrayIndex: -1, offsetIndex: 10 },
+          { arrayIndex: 0, offsetIndex: 23 },
+          tickSpacing,
+          new anchor.BN(990_000_000)
+        ),
+        buildPosition(
+          // a
+          { arrayIndex: 0, offsetIndex: 22 },
+          { arrayIndex: 1, offsetIndex: 23 },
+          tickSpacing,
+          new anchor.BN(1_990_000_000)
+        ),
+        buildPosition(
+          // a
+          { arrayIndex: 0, offsetIndex: 23 },
+          { arrayIndex: 1, offsetIndex: 23 },
+          tickSpacing,
+          new anchor.BN(990_000_000)
+        ),
+      ],
+    }, tokenAIsNative);
+
+    const { devWallet, balance: preDevWalletBalance } = await setupDevWallet(ctx, 10_000_000)
+
+    const devFeePercentage = Percentage.fromFraction(1, 10000); // 0.01%
+    const inputTokenAmount = new u64(1_000_000_000); // Swap 1SOL
+    const postFeeTokenAmount = inputTokenAmount.sub(
+      inputTokenAmount.mul(devFeePercentage.numerator).div(devFeePercentage.denominator)
+    );
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const swapToken = aToB ? whirlpoolData.tokenMintA : whirlpoolData.tokenMintB;
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+
+    const { inputTokenQuote, postFeeInputTokenQuote, inputTokenQuoteWithDevFees } = await getQuotes(
+      ctx,
+      whirlpool,
+      swapToken,
+      inputTokenAmount,
+      postFeeTokenAmount,
+      slippageTolerance,
+      devFeePercentage
+    );
+
+    assertDevFeeQuotes(inputTokenQuote, postFeeInputTokenQuote, inputTokenQuoteWithDevFees);
+    await (
+      await whirlpool.swapWithDevFees(inputTokenQuoteWithDevFees, devWallet.publicKey)
+    ).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(
+      aToB,
+      postFeeInputTokenQuote,
+      newData,
+      beforeVaultAmounts,
+      afterVaultAmounts
+    );
+    await assertDevTokenAmount(ctx, inputTokenQuoteWithDevFees, swapToken, devWallet.publicKey, preDevWalletBalance);
   });
 
   it("swap with dev-fee 50%", async () => {
@@ -241,7 +321,7 @@ describe("whirlpool-dev-fee-swap", () => {
     );
 
     const whirlpoolData = await whirlpool.refreshData();
-    const swapToken = whirlpoolData.tokenMintB;
+    const swapToken = aToB ? whirlpoolData.tokenMintA : whirlpoolData.tokenMintB;
     const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
     const { inputTokenQuote, postFeeInputTokenQuote, inputTokenQuoteWithDevFees } = await getQuotes(
       ctx,
@@ -266,13 +346,11 @@ describe("whirlpool-dev-fee-swap", () => {
       beforeVaultAmounts,
       afterVaultAmounts
     );
-    assertDevTokenAmount(ctx, inputTokenQuoteWithDevFees, swapToken, devWallet.publicKey);
+    await assertDevTokenAmount(ctx, inputTokenQuoteWithDevFees, swapToken, devWallet.publicKey);
   });
 
   it("swap with dev-fee of 100%", async () => {
     const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -1, offsetIndex: 22 }, tickSpacing);
-    const devWallet = Keypair.generate();
-    const aToB = false;
     const whirlpool = await setupSwapTest({
       ctx,
       client,
@@ -313,8 +391,6 @@ describe("whirlpool-dev-fee-swap", () => {
 
   it("swap with dev-fee of 200%", async () => {
     const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -1, offsetIndex: 22 }, tickSpacing);
-    const devWallet = Keypair.generate();
-    const aToB = false;
     const whirlpool = await setupSwapTest({
       ctx,
       client,
@@ -356,7 +432,6 @@ describe("whirlpool-dev-fee-swap", () => {
   it("swap with a manual quote with dev-fee of 200%", async () => {
     const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -1, offsetIndex: 22 }, tickSpacing);
     const devWallet = Keypair.generate();
-    const aToB = false;
     const whirlpool = await setupSwapTest({
       ctx,
       client,
@@ -441,4 +516,14 @@ async function getQuotes(
   );
 
   return { inputTokenQuote, postFeeInputTokenQuote, inputTokenQuoteWithDevFees };
+}
+
+async function setupDevWallet(ctx: WhirlpoolContext, airdrop: number) {
+  // Setup dev-wallet. Airdrop some tokens in or it'll be difficult to account for
+  // rent-tokens when we do assertion
+  const devWallet = Keypair.generate();
+  const txn = await ctx.provider.connection.requestAirdrop(devWallet.publicKey, airdrop);
+  await ctx.provider.connection.confirmTransaction(txn);
+  const balance = await ctx.provider.connection.getBalance(devWallet.publicKey);
+  return { devWallet, balance }
 }

--- a/sdk/tests/sdk/whirlpools/swap/swap-dev-fee.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/swap-dev-fee.test.ts
@@ -393,12 +393,6 @@ describe("whirlpool-dev-fee-swap", () => {
               tickArray0: PublicKey.default,
               tickArray1: PublicKey.default,
               tickArray2: PublicKey.default,
-              estimatedAmountIn: ZERO,
-              estimatedAmountOut: ZERO,
-              estimatedFeeAmount: ZERO,
-              estimatedEndSqrtPrice: ZERO,
-              estimatedEndTickIndex: 5,
-              estimatedSwapFeeAmount: ZERO,
             },
             devWallet.publicKey
           )

--- a/sdk/tests/sdk/whirlpools/swap/swap-dev-fee.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/swap-dev-fee.test.ts
@@ -25,7 +25,7 @@ import {
 } from "../../../utils/swap-test-utils";
 import { getVaultAmounts } from "../../../utils/whirlpools-test-utils";
 
-describe.only("whirlpool-dev-fee-swap", () => {
+describe("whirlpool-dev-fee-swap", () => {
   const provider = anchor.AnchorProvider.local();
   anchor.setProvider(anchor.AnchorProvider.env());
   const program = anchor.workspace.Whirlpool;

--- a/sdk/tests/sdk/whirlpools/swap/swap-dev-fee.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/swap-dev-fee.test.ts
@@ -1,14 +1,24 @@
 import { Percentage } from "@orca-so/common-sdk";
 import * as anchor from "@project-serum/anchor";
+import { Address } from "@project-serum/anchor";
 import { u64 } from "@solana/spl-token";
+import { Keypair } from "@solana/web3.js";
+import * as assert from "assert";
 import {
   buildWhirlpoolClient,
   PriceMath,
   swapQuoteByInputToken,
+  Whirlpool,
   WhirlpoolContext,
 } from "../../../../src";
+import { SwapErrorCode, WhirlpoolsError } from "../../../../src/errors/errors";
 import { swapQuoteByInputTokenWithDevFees } from "../../../../src/quotes/public/dev-fee-swap-quote";
-import { assertInputOutputQuoteEqual, assertQuoteAndResults, TickSpacing } from "../../../utils";
+import {
+  assertDevFeeQuotes,
+  assertDevTokenAmount,
+  assertQuoteAndResults,
+  TickSpacing,
+} from "../../../utils";
 import {
   arrayTickIndexToTickIndex,
   buildPosition,
@@ -27,6 +37,7 @@ describe.only("whirlpool-dev-fee-swap", () => {
 
   it("swap with dev-fee 0% equals swap", async () => {
     const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -1, offsetIndex: 22 }, tickSpacing);
+    const devWallet = Keypair.generate();
     const aToB = false;
     const whirlpool = await setupSwapTest({
       ctx,
@@ -45,12 +56,26 @@ describe.only("whirlpool-dev-fee-swap", () => {
       ],
     });
 
+    const devFeePercentage = Percentage.fromFraction(0, 1000); // 0%
+    const inputTokenAmount = new u64(119500000);
+    const postFeeTokenAmount = inputTokenAmount.sub(
+      inputTokenAmount.mul(devFeePercentage.numerator).div(devFeePercentage.denominator)
+    );
     const whirlpoolData = await whirlpool.refreshData();
     const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
     const inputTokenQuote = await swapQuoteByInputToken(
       whirlpool,
       whirlpoolData.tokenMintB,
-      new u64(119500000),
+      inputTokenAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      ctx.fetcher,
+      true
+    );
+    const postFeeInputTokenQuote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      postFeeTokenAmount,
       slippageTolerance,
       ctx.program.programId,
       ctx.fetcher,
@@ -58,24 +83,313 @@ describe.only("whirlpool-dev-fee-swap", () => {
     );
     const inputTokenQuoteWithDevFees = await swapQuoteByInputTokenWithDevFees(
       whirlpool,
-      whirlpoolData.tokenMintA,
-      inputTokenQuote.estimatedAmountOut,
+      whirlpoolData.tokenMintB,
+      inputTokenAmount,
       slippageTolerance,
       ctx.program.programId,
       ctx.fetcher,
-      Percentage.fromFraction(0, 1000), // 0%
+      devFeePercentage,
       true
     );
-    assertInputOutputQuoteEqual(inputTokenQuote, inputTokenQuoteWithDevFees);
-    await (await whirlpool.swap(inputTokenQuote)).buildAndExecute();
+    assertDevFeeQuotes(inputTokenQuote, postFeeInputTokenQuote, inputTokenQuoteWithDevFees);
+    await (
+      await whirlpool.swapWithDevFees(inputTokenQuoteWithDevFees, devWallet.publicKey)
+    ).buildAndExecute();
 
     const newData = await whirlpool.refreshData();
     const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
     assertQuoteAndResults(aToB, inputTokenQuote, newData, beforeVaultAmounts, afterVaultAmounts);
   });
 
-  it("swap with dev-fee 0.1%", async () => {});
+  it("swap with dev-fee 0.1%", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -1, offsetIndex: 22 }, tickSpacing);
+    const devWallet = Keypair.generate();
+    const aToB = false;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-5632, 0, 5632],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -1, offsetIndex: 10 },
+          { arrayIndex: 1, offsetIndex: 23 },
+          tickSpacing,
+          new anchor.BN(250_000_000)
+        ),
+      ],
+    });
 
-  it("swap with dev-fee 1%", async () => {});
-  it("swap with dev-fee 10%", async () => {});
+    const devFeePercentage = Percentage.fromFraction(1, 1000); // 0.1%
+    const inputTokenAmount = new u64(119500000);
+    const postFeeTokenAmount = inputTokenAmount.sub(
+      inputTokenAmount.mul(devFeePercentage.numerator).div(devFeePercentage.denominator)
+    );
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const swapToken = whirlpoolData.tokenMintB;
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    const { inputTokenQuote, postFeeInputTokenQuote, inputTokenQuoteWithDevFees } = await getQuotes(
+      ctx,
+      whirlpool,
+      swapToken,
+      inputTokenAmount,
+      postFeeTokenAmount,
+      slippageTolerance,
+      devFeePercentage
+    );
+    assertDevFeeQuotes(inputTokenQuote, postFeeInputTokenQuote, inputTokenQuoteWithDevFees);
+    await (
+      await whirlpool.swapWithDevFees(inputTokenQuoteWithDevFees, devWallet.publicKey)
+    ).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(
+      aToB,
+      postFeeInputTokenQuote,
+      newData,
+      beforeVaultAmounts,
+      afterVaultAmounts
+    );
+    assertDevTokenAmount(ctx, inputTokenQuoteWithDevFees, swapToken, devWallet.publicKey);
+  });
+
+  it("swap with dev-fee 1%", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -1, offsetIndex: 22 }, tickSpacing);
+    const devWallet = Keypair.generate();
+    const aToB = false;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-5632, 0, 5632],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -1, offsetIndex: 10 },
+          { arrayIndex: 1, offsetIndex: 23 },
+          tickSpacing,
+          new anchor.BN(250_000_000)
+        ),
+      ],
+    });
+
+    const devFeePercentage = Percentage.fromFraction(1, 100); // 0.1%
+    const inputTokenAmount = new u64(119500000);
+    const postFeeTokenAmount = inputTokenAmount.sub(
+      inputTokenAmount.mul(devFeePercentage.numerator).div(devFeePercentage.denominator)
+    );
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const swapToken = whirlpoolData.tokenMintB;
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    const { inputTokenQuote, postFeeInputTokenQuote, inputTokenQuoteWithDevFees } = await getQuotes(
+      ctx,
+      whirlpool,
+      swapToken,
+      inputTokenAmount,
+      postFeeTokenAmount,
+      slippageTolerance,
+      devFeePercentage
+    );
+    assertDevFeeQuotes(inputTokenQuote, postFeeInputTokenQuote, inputTokenQuoteWithDevFees);
+    await (
+      await whirlpool.swapWithDevFees(inputTokenQuoteWithDevFees, devWallet.publicKey)
+    ).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(
+      aToB,
+      postFeeInputTokenQuote,
+      newData,
+      beforeVaultAmounts,
+      afterVaultAmounts
+    );
+    assertDevTokenAmount(ctx, inputTokenQuoteWithDevFees, swapToken, devWallet.publicKey);
+  });
+
+  it("swap with dev-fee 50%", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -1, offsetIndex: 22 }, tickSpacing);
+    const devWallet = Keypair.generate();
+    const aToB = false;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-5632, 0, 5632],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -1, offsetIndex: 10 },
+          { arrayIndex: 1, offsetIndex: 23 },
+          tickSpacing,
+          new anchor.BN(250_000_000)
+        ),
+      ],
+    });
+
+    const devFeePercentage = Percentage.fromFraction(500000, 1000000); // 50%
+    const inputTokenAmount = new u64(119500000);
+    const postFeeTokenAmount = inputTokenAmount.sub(
+      inputTokenAmount.mul(devFeePercentage.numerator).div(devFeePercentage.denominator)
+    );
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const swapToken = whirlpoolData.tokenMintB;
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    const { inputTokenQuote, postFeeInputTokenQuote, inputTokenQuoteWithDevFees } = await getQuotes(
+      ctx,
+      whirlpool,
+      swapToken,
+      inputTokenAmount,
+      postFeeTokenAmount,
+      slippageTolerance,
+      devFeePercentage
+    );
+    assertDevFeeQuotes(inputTokenQuote, postFeeInputTokenQuote, inputTokenQuoteWithDevFees);
+    await (
+      await whirlpool.swapWithDevFees(inputTokenQuoteWithDevFees, devWallet.publicKey)
+    ).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(
+      aToB,
+      postFeeInputTokenQuote,
+      newData,
+      beforeVaultAmounts,
+      afterVaultAmounts
+    );
+    assertDevTokenAmount(ctx, inputTokenQuoteWithDevFees, swapToken, devWallet.publicKey);
+  });
+
+  it("swap with dev-fee of 100%", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -1, offsetIndex: 22 }, tickSpacing);
+    const devWallet = Keypair.generate();
+    const aToB = false;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-5632, 0, 5632],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -1, offsetIndex: 10 },
+          { arrayIndex: 1, offsetIndex: 23 },
+          tickSpacing,
+          new anchor.BN(250_000_000)
+        ),
+      ],
+    });
+
+    const devFeePercentage = Percentage.fromFraction(100, 100); // 100%
+    const inputTokenAmount = new u64(119500000);
+    const whirlpoolData = await whirlpool.refreshData();
+    const swapToken = whirlpoolData.tokenMintB;
+
+    assert.rejects(
+      () =>
+        swapQuoteByInputTokenWithDevFees(
+          whirlpool,
+          swapToken,
+          inputTokenAmount,
+          slippageTolerance,
+          ctx.program.programId,
+          ctx.fetcher,
+          devFeePercentage,
+          true
+        ),
+      (err) => (err as WhirlpoolsError).errorCode === SwapErrorCode.InvalidDevFeePercentage
+    );
+  });
+  it("swap with dev-fee of 200%", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -1, offsetIndex: 22 }, tickSpacing);
+    const devWallet = Keypair.generate();
+    const aToB = false;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-5632, 0, 5632],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -1, offsetIndex: 10 },
+          { arrayIndex: 1, offsetIndex: 23 },
+          tickSpacing,
+          new anchor.BN(250_000_000)
+        ),
+      ],
+    });
+
+    const devFeePercentage = Percentage.fromFraction(200, 100); // 200%
+    const inputTokenAmount = new u64(119500000);
+    const whirlpoolData = await whirlpool.refreshData();
+    const swapToken = whirlpoolData.tokenMintB;
+
+    assert.rejects(
+      () =>
+        swapQuoteByInputTokenWithDevFees(
+          whirlpool,
+          swapToken,
+          inputTokenAmount,
+          slippageTolerance,
+          ctx.program.programId,
+          ctx.fetcher,
+          devFeePercentage,
+          true
+        ),
+      (err) => (err as WhirlpoolsError).errorCode === SwapErrorCode.InvalidDevFeePercentage
+    );
+  });
 });
+
+async function getQuotes(
+  ctx: WhirlpoolContext,
+  whirlpool: Whirlpool,
+  swapToken: Address,
+  inputTokenAmount: u64,
+  postFeeTokenAmount: u64,
+  slippageTolerance: Percentage,
+  devFeePercentage: Percentage
+) {
+  const inputTokenQuote = await swapQuoteByInputToken(
+    whirlpool,
+    swapToken,
+    inputTokenAmount,
+    slippageTolerance,
+    ctx.program.programId,
+    ctx.fetcher,
+    true
+  );
+  const postFeeInputTokenQuote = await swapQuoteByInputToken(
+    whirlpool,
+    swapToken,
+    postFeeTokenAmount,
+    slippageTolerance,
+    ctx.program.programId,
+    ctx.fetcher,
+    true
+  );
+  const inputTokenQuoteWithDevFees = await swapQuoteByInputTokenWithDevFees(
+    whirlpool,
+    swapToken,
+    inputTokenAmount,
+    slippageTolerance,
+    ctx.program.programId,
+    ctx.fetcher,
+    devFeePercentage,
+    true
+  );
+
+  return { inputTokenQuote, postFeeInputTokenQuote, inputTokenQuoteWithDevFees };
+}

--- a/sdk/tests/sdk/whirlpools/swap/swap-dev-fee.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/swap-dev-fee.test.ts
@@ -1,0 +1,81 @@
+import { Percentage } from "@orca-so/common-sdk";
+import * as anchor from "@project-serum/anchor";
+import { u64 } from "@solana/spl-token";
+import {
+  buildWhirlpoolClient,
+  PriceMath,
+  swapQuoteByInputToken,
+  WhirlpoolContext,
+} from "../../../../src";
+import { swapQuoteByInputTokenWithDevFees } from "../../../../src/quotes/public/dev-fee-swap-quote";
+import { assertInputOutputQuoteEqual, assertQuoteAndResults, TickSpacing } from "../../../utils";
+import {
+  arrayTickIndexToTickIndex,
+  buildPosition,
+  setupSwapTest,
+} from "../../../utils/swap-test-utils";
+import { getVaultAmounts } from "../../../utils/whirlpools-test-utils";
+
+describe.only("whirlpool-dev-fee-swap", () => {
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
+  const program = anchor.workspace.Whirlpool;
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
+  const client = buildWhirlpoolClient(ctx);
+  const tickSpacing = TickSpacing.SixtyFour;
+  const slippageTolerance = Percentage.fromFraction(0, 100);
+
+  it("swap with dev-fee 0% equals swap", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -1, offsetIndex: 22 }, tickSpacing);
+    const aToB = false;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-5632, 0, 5632],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -1, offsetIndex: 10 },
+          { arrayIndex: 1, offsetIndex: 23 },
+          tickSpacing,
+          new anchor.BN(250_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    const inputTokenQuote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      new u64(119500000),
+      slippageTolerance,
+      ctx.program.programId,
+      ctx.fetcher,
+      true
+    );
+    const inputTokenQuoteWithDevFees = await swapQuoteByInputTokenWithDevFees(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      inputTokenQuote.estimatedAmountOut,
+      slippageTolerance,
+      ctx.program.programId,
+      ctx.fetcher,
+      Percentage.fromFraction(0, 1000), // 0%
+      true
+    );
+    assertInputOutputQuoteEqual(inputTokenQuote, inputTokenQuoteWithDevFees);
+    await (await whirlpool.swap(inputTokenQuote)).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(aToB, inputTokenQuote, newData, beforeVaultAmounts, afterVaultAmounts);
+  });
+
+  it("swap with dev-fee 0.1%", async () => {});
+
+  it("swap with dev-fee 1%", async () => {});
+  it("swap with dev-fee 10%", async () => {});
+});

--- a/sdk/tests/utils/assert.ts
+++ b/sdk/tests/utils/assert.ts
@@ -88,17 +88,19 @@ export async function assertDevTokenAmount(
   ctx: WhirlpoolContext,
   expectationQuote: DevFeeSwapQuote,
   swapToken: PublicKey,
-  devWallet: PublicKey
+  devWallet: PublicKey,
+  preDevWalletLamport = 0
 ) {
 
   if (swapToken.equals(NATIVE_MINT)) {
     const walletAmount = await ctx.provider.connection.getBalance(devWallet);
-    assert.equal(expectationQuote.devFeeAmount.toNumber(), walletAmount)
+    assert.equal(expectationQuote.devFeeAmount.toNumber() + preDevWalletLamport, walletAmount)
     return;
   }
 
   const tokenDevWalletAta = await deriveATA(devWallet, swapToken);
   const afterDevWalletAmount = await getTokenBalance(ctx.provider, tokenDevWalletAta);
+  console.log(`hello`)
   assert.equal(
     expectationQuote.devFeeAmount,
     afterDevWalletAmount,

--- a/sdk/tests/utils/assert.ts
+++ b/sdk/tests/utils/assert.ts
@@ -1,6 +1,6 @@
 import { deriveATA, ONE } from "@orca-so/common-sdk";
 import { BN, Program, web3 } from "@project-serum/anchor";
-import { AccountLayout } from "@solana/spl-token";
+import { AccountLayout, NATIVE_MINT } from "@solana/spl-token";
 import { PublicKey } from "@solana/web3.js";
 import * as assert from "assert";
 import { SwapQuote, WhirlpoolContext } from "../../src";
@@ -90,6 +90,13 @@ export async function assertDevTokenAmount(
   swapToken: PublicKey,
   devWallet: PublicKey
 ) {
+
+  if (swapToken.equals(NATIVE_MINT)) {
+    const walletAmount = await ctx.provider.connection.getBalance(devWallet);
+    assert.equal(expectationQuote.devFeeAmount.toNumber(), walletAmount)
+    return;
+  }
+
   const tokenDevWalletAta = await deriveATA(devWallet, swapToken);
   const afterDevWalletAmount = await getTokenBalance(ctx.provider, tokenDevWalletAta);
   assert.equal(

--- a/sdk/tests/utils/assert.ts
+++ b/sdk/tests/utils/assert.ts
@@ -100,7 +100,6 @@ export async function assertDevTokenAmount(
 
   const tokenDevWalletAta = await deriveATA(devWallet, swapToken);
   const afterDevWalletAmount = await getTokenBalance(ctx.provider, tokenDevWalletAta);
-  console.log(`hello`)
   assert.equal(
     expectationQuote.devFeeAmount,
     afterDevWalletAmount,

--- a/sdk/tests/utils/init-utils.ts
+++ b/sdk/tests/utils/init-utils.ts
@@ -298,7 +298,8 @@ export async function initTestPoolWithTokens(
   const { tokenMintA, tokenMintB, whirlpoolPda } = poolInitInfo;
 
   // Airdrop SOL into provider's wallet for SOL native token testing.
-  await ctx.provider.connection.requestAirdrop(ctx.provider.wallet.publicKey, 100_000_000_000_000);
+  const connection = ctx.provider.connection;
+  await connection.requestAirdrop(ctx.provider.wallet.publicKey, 100_000_000_000_000)
 
   const tokenAccountA = await createAndMintToAssociatedTokenAccount(
     provider,

--- a/sdk/tests/utils/test-builders.ts
+++ b/sdk/tests/utils/test-builders.ts
@@ -1,6 +1,6 @@
 import { MathUtil, PDA, Percentage } from "@orca-so/common-sdk";
 import { AnchorProvider } from "@project-serum/anchor";
-import { ASSOCIATED_TOKEN_PROGRAM_ID, Token, TOKEN_PROGRAM_ID } from "@solana/spl-token";
+import { ASSOCIATED_TOKEN_PROGRAM_ID, NATIVE_MINT, Token, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { Keypair, PublicKey } from "@solana/web3.js";
 import Decimal from "decimal.js";
 import { createAndMintToAssociatedTokenAccount, createMint } from ".";
@@ -13,7 +13,7 @@ import {
   OpenPositionParams,
   PDAUtil,
   PriceMath,
-  Whirlpool,
+  Whirlpool
 } from "../../src";
 import { WhirlpoolContext } from "../../src/context";
 
@@ -46,9 +46,9 @@ export const generateDefaultConfigParams = (
   return { configInitInfo, configKeypairs };
 };
 
-export const createInOrderMints = async (context: WhirlpoolContext) => {
+export const createInOrderMints = async (context: WhirlpoolContext, tokenAIsNative = false) => {
   const provider = context.provider;
-  const tokenXMintPubKey = await createMint(provider);
+  const tokenXMintPubKey = tokenAIsNative ? NATIVE_MINT : await createMint(provider);
   const tokenYMintPubKey = await createMint(provider);
 
   let tokenAMintPubKey, tokenBMintPubKey;
@@ -69,9 +69,10 @@ export const generateDefaultInitPoolParams = async (
   feeTierKey: PublicKey,
   tickSpacing: number,
   initSqrtPrice = MathUtil.toX64(new Decimal(5)),
-  funder?: PublicKey
+  funder?: PublicKey,
+  tokenAIsNative = false
 ): Promise<InitPoolParams> => {
-  const [tokenAMintPubKey, tokenBMintPubKey] = await createInOrderMints(context);
+  const [tokenAMintPubKey, tokenBMintPubKey] = await createInOrderMints(context, tokenAIsNative);
 
   const whirlpoolPda = PDAUtil.getWhirlpool(
     context.program.programId,

--- a/yarn.lock
+++ b/yarn.lock
@@ -565,14 +565,15 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@orca-so/common-sdk@~0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@orca-so/common-sdk/-/common-sdk-0.1.0.tgz#25050f18e95bab6a7ef9b10e2d3bd44699ce9836"
-  integrity sha512-WH6mjrrJyuUMq0DC41jWW6opEIq5Ip/UOf8h7z/gM9Zx+9156JwP/dm8N5GJTNnIG6GYFfhemyNNPj1y3U5LIw==
+"@orca-so/common-sdk@~0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@orca-so/common-sdk/-/common-sdk-0.1.1.tgz#18a3a562f1b57f970f2115f453c7e00aa05034cf"
+  integrity sha512-OKFwr5VgzLKmM/C6xQom4y1jxrihuhKXhDwYMbgPLJW4SllePOfS6SG5fp9/17SvyuWL/zna8Z6ZW2QHpX1Yxw==
   dependencies:
     "@project-serum/anchor" "~0.25.0"
     "@solana/spl-token" "0.1.8"
     decimal.js "^10.3.1"
+    tiny-invariant "^1.2.0"
 
 "@orca-so/whirlpool-client-sdk@0.0.7":
   version "0.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -747,10 +747,10 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/bn.js@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-5.1.0.tgz#32c5d271503a12653c62cf4d2b45e6eab8cebc68"
-  integrity sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==
+"@types/bn.js@~5.1.0":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-5.1.1.tgz#b51e1b55920a4ca26e9285ff79936bbdec910682"
+  integrity sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
- Add a new `swapWithDevFees` function in the `Whirlpool` client class
- Add new `swapQuoteByInputTokenWithDevFees` quote function

Allow developers to take a percentage of a swap prior to executing the swap instruction.

### Dependency CRs
https://github.com/orca-so/orca-sdks/pull/10


### Note
- Not a smart-contract integration
- Pending testing