### PR TITLE
Add swap with dev fee to typedocs

### DIFF
--- a/sdk/src/quotes/public/index.ts
+++ b/sdk/src/quotes/public/index.ts
@@ -3,3 +3,4 @@ export * from "./decrease-liquidity-quote";
 export * from "./collect-fees-quote";
 export * from "./collect-rewards-quote";
 export * from "./swap-quote";
+export * from "./dev-fee-swap-quote";


### PR DESCRIPTION
I noticed that the dev fee related functions aren't showing up in the typedocs. I think this will fix it.