### PR TITLE
Lock decimal version to 10.4.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
     "sdk",
     "scripts"
   ],
+  "resolutions": {
+    "decimal.js": "^10.4.0"
+  },
   "scripts": {
     "idl": "anchor build -i $INIT_CWD/sdk/src/artifacts -t $INIT_CWD/sdk/src/artifacts"
   }

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
     "sdk",
     "scripts"
   ],
-  "resolutions": {
-    "decimal.js": "^10.4.0"
-  },
   "scripts": {
     "idl": "anchor build -i $INIT_CWD/sdk/src/artifacts -t $INIT_CWD/sdk/src/artifacts"
   }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -7,15 +7,14 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@metaplex-foundation/mpl-token-metadata": "1.2.5",
-    "@orca-so/common-sdk": "~0.1.1",
+    "@orca-so/common-sdk": "~0.1.2",
     "@project-serum/anchor": "~0.25.0",
     "@solana/spl-token": "^0.1.8",
-    "decimal.js": "10.3.1",
+    "decimal.js": "^10.4.0",
     "tiny-invariant": "^1.2.0"
   },
   "devDependencies": {
     "@types/bn.js": "~5.1.0",
-    "@types/decimal.js": "^7.4.0",
     "@types/jest": "^26.0.24",
     "@types/mocha": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "^4.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1550,10 +1550,15 @@ decamelize@^4.0.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
   integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
-decimal.js@^10.2.1, decimal.js@^10.3.1, decimal.js@^10.4.0, decimal.js@~10.3.1:
+decimal.js@^10.2.1, decimal.js@^10.3.1, decimal.js@^10.4.0:
   version "10.4.2"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.2.tgz#0341651d1d997d86065a2ce3a441fbd0d8e8b98e"
   integrity sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==
+
+decimal.js@~10.3.1:
+  version "10.3.1"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.3.1.tgz#d8c3a444a9c6774ba60ca6ad7261c3a94fd5e783"
+  integrity sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==
 
 dedent@^0.7.0:
   version "0.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -580,14 +580,14 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@orca-so/common-sdk@~0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@orca-so/common-sdk/-/common-sdk-0.1.1.tgz#18a3a562f1b57f970f2115f453c7e00aa05034cf"
-  integrity sha512-OKFwr5VgzLKmM/C6xQom4y1jxrihuhKXhDwYMbgPLJW4SllePOfS6SG5fp9/17SvyuWL/zna8Z6ZW2QHpX1Yxw==
+"@orca-so/common-sdk@~0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@orca-so/common-sdk/-/common-sdk-0.1.2.tgz#b4e83bcbd01253473ab71e436c868e38170e71fd"
+  integrity sha512-gVjEKQFN2e3TJlSSJ7/AQ6xd7+bzxHP1o8B9EVX9177fGigsiGskVU5Y/BUVyWRy4AFJvr5qUWVmO5mFdqqx8A==
   dependencies:
     "@project-serum/anchor" "~0.25.0"
     "@solana/spl-token" "0.1.8"
-    decimal.js "^10.3.1"
+    decimal.js "~10.3.1"
     tiny-invariant "^1.2.0"
 
 "@orca-so/whirlpool-client-sdk@0.0.7":
@@ -797,13 +797,6 @@
   integrity sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
   dependencies:
     "@types/node" "*"
-
-"@types/decimal.js@^7.4.0":
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/@types/decimal.js/-/decimal.js-7.4.0.tgz#0289c1903c31a4e9b94caa741916a9bc64d1c585"
-  integrity sha512-TiP45voN8GdDib9QkkdMprTfs86xxHInqTxNPSGbF0m6X0LXVBjkFEKbbL9fqm4ZPoVFkG1p4F26on2MWGvW5w==
-  dependencies:
-    decimal.js "*"
 
 "@types/express-serve-static-core@^4.17.9":
   version "4.17.28"
@@ -1557,15 +1550,10 @@ decamelize@^4.0.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
   integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
-decimal.js@*, decimal.js@^10.2.1, decimal.js@^10.3.1:
-  version "10.3.1"
-  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.3.1.tgz#d8c3a444a9c6774ba60ca6ad7261c3a94fd5e783"
-  integrity sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==
-
-decimal.js@10.3.1:
-  version "10.3.1"
-  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.3.1.tgz#d8c3a444a9c6774ba60ca6ad7261c3a94fd5e783"
-  integrity sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==
+decimal.js@^10.2.1, decimal.js@^10.3.1, decimal.js@^10.4.0, decimal.js@~10.3.1:
+  version "10.4.2"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.2.tgz#0341651d1d997d86065a2ce3a441fbd0d8e8b98e"
+  integrity sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==
 
 dedent@^0.7.0:
   version "0.7.0"


### PR DESCRIPTION
- Consolidating decimal.js versions across all public orca repos