### PR TITLE
Expose more data on PositionUtil for easier quote generation

### DIFF
--- a/sdk/src/impl/position-impl.ts
+++ b/sdk/src/impl/position-impl.ts
@@ -2,27 +2,20 @@ import {
   AddressUtil,
   deriveATA,
   resolveOrCreateATAs,
-  TransactionBuilder,
+  TransactionBuilder
 } from "@orca-so/common-sdk";
 import { Address } from "@project-serum/anchor";
 import { PublicKey } from "@solana/web3.js";
-import invariant from "tiny-invariant";
 import { WhirlpoolContext } from "../context";
 import {
   DecreaseLiquidityInput,
   decreaseLiquidityIx,
   IncreaseLiquidityInput,
-  increaseLiquidityIx,
+  increaseLiquidityIx
 } from "../instructions";
-import {
-  PositionData,
-  TickArrayData,
-  TickData,
-  TICK_ARRAY_SIZE,
-  WhirlpoolData,
-} from "../types/public";
+import { PositionData, TickArrayData, TickData, WhirlpoolData } from "../types/public";
 import { getTickArrayDataForPosition } from "../utils/builder/position-builder-util";
-import { PDAUtil, TickUtil } from "../utils/public";
+import { PDAUtil, TickArrayUtil, TickUtil } from "../utils/public";
 import { Position } from "../whirlpool-client";
 
 export class PositionImpl implements Position {
@@ -57,29 +50,19 @@ export class PositionImpl implements Position {
   }
 
   getLowerTickData(): TickData {
-    const offsetIndex = TickUtil.getOffsetIndex(
+    return TickArrayUtil.getTickFromArray(
+      this.lowerTickArrayData,
       this.data.tickLowerIndex,
-      this.lowerTickArrayData.startTickIndex,
       this.whirlpoolData.tickSpacing
     );
-    invariant(
-      offsetIndex > 0 && offsetIndex < TICK_ARRAY_SIZE,
-      "getLowerTickData - tick index does not exist in provided tick-array"
-    );
-    return this.lowerTickArrayData.ticks[offsetIndex];
   }
 
   getUpperTickData(): TickData {
-    const offsetIndex = TickUtil.getOffsetIndex(
+    return TickArrayUtil.getTickFromArray(
+      this.upperTickArrayData,
       this.data.tickUpperIndex,
-      this.upperTickArrayData.startTickIndex,
       this.whirlpoolData.tickSpacing
     );
-    invariant(
-      offsetIndex > 0 && offsetIndex < TICK_ARRAY_SIZE,
-      "getUpperTickData - tick index does not exist in provided tick-array"
-    );
-    return this.upperTickArrayData.ticks[offsetIndex];
   }
 
   async refreshData() {
@@ -247,7 +230,8 @@ export class PositionImpl implements Position {
     const [lowerTickArray, upperTickArray] = await getTickArrayDataForPosition(
       this.ctx,
       this.data,
-      this.whirlpoolData
+      this.whirlpoolData,
+      true
     );
     if (lowerTickArray) {
       this.lowerTickArrayData = lowerTickArray;

--- a/sdk/src/impl/whirlpool-client-impl.ts
+++ b/sdk/src/impl/whirlpool-client-impl.ts
@@ -16,7 +16,7 @@ import { getRewardInfos, getTokenMintInfos, getTokenVaultAccountInfos } from "./
 import { WhirlpoolImpl } from "./whirlpool-impl";
 
 export class WhirlpoolClientImpl implements WhirlpoolClient {
-  constructor(readonly ctx: WhirlpoolContext) {}
+  constructor(readonly ctx: WhirlpoolContext) { }
 
   public getContext(): WhirlpoolContext {
     return this.ctx;
@@ -127,10 +127,10 @@ export class WhirlpoolClientImpl implements WhirlpoolClient {
   ): Promise<Record<string, Position | null>> {
     // TODO: Prefetch and use fetcher as a cache - Think of a cleaner way to prefetch
     const positions = await this.ctx.fetcher.listPositions(positionAddresses, refresh);
-    const whirlpoolAddr = positions
+    const whirlpoolAddrs = positions
       .map((position) => position?.whirlpool.toBase58())
       .flatMap((x) => (!!x ? x : []));
-    await this.ctx.fetcher.listPools(whirlpoolAddr, refresh);
+    await this.ctx.fetcher.listPools(whirlpoolAddrs, refresh);
     const tickArrayAddresses: Set<PublicKey> = new Set();
     await Promise.all(
       positions.map(async (pos) => {

--- a/sdk/src/impl/whirlpool-impl.ts
+++ b/sdk/src/impl/whirlpool-impl.ts
@@ -5,7 +5,7 @@ import {
   resolveOrCreateATAs,
   TokenUtil,
   TransactionBuilder,
-  ZERO
+  ZERO,
 } from "@orca-so/common-sdk";
 import { Address, BN, translateAddress } from "@project-serum/anchor";
 import { Keypair, PublicKey } from "@solana/web3.js";
@@ -21,7 +21,7 @@ import {
   openPositionIx,
   openPositionWithMetadataIx,
   SwapInput,
-  swapIx
+  swapIx,
 } from "../instructions";
 import { decreaseLiquidityQuoteByLiquidityWithParams } from "../quotes/public";
 import { TokenAccountInfo, TokenInfo, WhirlpoolData, WhirlpoolRewardInfo } from "../types/public";

--- a/sdk/src/quotes/swap/tick-array-sequence.ts
+++ b/sdk/src/quotes/swap/tick-array-sequence.ts
@@ -36,12 +36,12 @@ export class TickArraySequence {
     // If an uninitialized TickArray appears, truncate all TickArrays after it (inclusive).
     this.sequence = [];
     for (const tickArray of tickArrays) {
-      if ( !tickArray || !tickArray.data ) {
+      if (!tickArray || !tickArray.data) {
         break;
       }
       this.sequence.push({
         address: tickArray.address,
-        data: tickArray.data
+        data: tickArray.data,
       });
     }
 

--- a/sdk/src/utils/builder/position-builder-util.ts
+++ b/sdk/src/utils/builder/position-builder-util.ts
@@ -1,0 +1,24 @@
+import { WhirlpoolContext } from "../..";
+import { PositionData, WhirlpoolData } from "../../types/public";
+import { PDAUtil } from "../public";
+
+export async function getTickArrayDataForPosition(
+  ctx: WhirlpoolContext,
+  position: PositionData,
+  whirlpool: WhirlpoolData
+) {
+  const lowerTickArrayPda = PDAUtil.getTickArrayFromTickIndex(
+    position.tickLowerIndex,
+    whirlpool.tickSpacing,
+    position.whirlpool,
+    ctx.program.programId
+  ).publicKey;
+  const upperTickArrayPda = PDAUtil.getTickArrayFromTickIndex(
+    position.tickUpperIndex,
+    whirlpool.tickSpacing,
+    position.whirlpool,
+    ctx.program.programId
+  ).publicKey;
+
+  return await ctx.fetcher.listTickArrays([lowerTickArrayPda, upperTickArrayPda], true);
+}

--- a/sdk/src/utils/builder/position-builder-util.ts
+++ b/sdk/src/utils/builder/position-builder-util.ts
@@ -5,20 +5,21 @@ import { PDAUtil } from "../public";
 export async function getTickArrayDataForPosition(
   ctx: WhirlpoolContext,
   position: PositionData,
-  whirlpool: WhirlpoolData
+  whirlpool: WhirlpoolData,
+  refresh: boolean
 ) {
-  const lowerTickArrayPda = PDAUtil.getTickArrayFromTickIndex(
+  const lowerTickArrayKey = PDAUtil.getTickArrayFromTickIndex(
     position.tickLowerIndex,
     whirlpool.tickSpacing,
     position.whirlpool,
     ctx.program.programId
   ).publicKey;
-  const upperTickArrayPda = PDAUtil.getTickArrayFromTickIndex(
+  const upperTickArrayKey = PDAUtil.getTickArrayFromTickIndex(
     position.tickUpperIndex,
     whirlpool.tickSpacing,
     position.whirlpool,
     ctx.program.programId
   ).publicKey;
 
-  return await ctx.fetcher.listTickArrays([lowerTickArrayPda, upperTickArrayPda], true);
+  return await ctx.fetcher.listTickArrays([lowerTickArrayKey, upperTickArrayKey], refresh);
 }

--- a/sdk/src/utils/public/tick-utils.ts
+++ b/sdk/src/utils/public/tick-utils.ts
@@ -1,6 +1,6 @@
-import invariant from "tiny-invariant";
-import { Address, BN } from "@project-serum/anchor";
 import { PublicKey } from "@solana/web3.js";
+import invariant from "tiny-invariant";
+import { AccountFetcher } from "../../network/public";
 import {
   MAX_TICK_INDEX,
   MIN_TICK_INDEX,
@@ -9,7 +9,6 @@ import {
   TICK_ARRAY_SIZE,
 } from "../../types/public";
 import { PDAUtil } from "./pda-utils";
-import { AccountFetcher } from "../../network/public";
 
 enum TickSearchDirection {
   Left,
@@ -22,6 +21,18 @@ enum TickSearchDirection {
  */
 export class TickUtil {
   private constructor() {}
+
+  /**
+   * Get the offset index to access a tick at a given tick-index in a tick-array
+   *
+   * @param tickIndex The tick index for the tick that this offset would access
+   * @param arrayStartIndex The starting tick for the array that this tick-index resides in
+   * @param tickSpacing The tickSpacing for the Whirlpool that this tickArray belongs to
+   * @returns The offset index that can access the desired tick at the given tick-array
+   */
+  public static getOffsetIndex(tickIndex: number, arrayStartIndex: number, tickSpacing: number) {
+    return Math.floor((tickIndex - arrayStartIndex) / tickSpacing);
+  }
 
   /**
    * Get the startIndex of the tick array containing tickIndex.

--- a/sdk/src/utils/whirlpool-ata-utils.ts
+++ b/sdk/src/utils/whirlpool-ata-utils.ts
@@ -6,7 +6,7 @@ import { convertListToMap } from "./txn-utils";
 
 /**
  * Fetch a list of affliated tokens from a list of whirlpools
- * 
+ *
  * SOL tokens does not use the ATA program and therefore not handled.
  * @param whirlpoolDatas An array of whirlpoolData (from fetcher.listPools)
  * @returns All the whirlpool, reward token mints in the given set of whirlpools
@@ -108,11 +108,12 @@ export async function resolveAtaForMints(
     { resolvedAtas: [], resolveAtaIxs: [] }
   );
 
-  const affliatedTokenAtaMap = convertListToMap(resolvedAtas, mints.map((mint) => mint.toBase58()));
+  const affliatedTokenAtaMap = convertListToMap(
+    resolvedAtas,
+    mints.map((mint) => mint.toBase58())
+  );
   return {
     ataTokenAddresses: affliatedTokenAtaMap,
     resolveAtaIxs,
   };
 }
-
-

--- a/sdk/src/whirlpool-client.ts
+++ b/sdk/src/whirlpool-client.ts
@@ -9,6 +9,7 @@ import {
   DecreaseLiquidityInput,
   IncreaseLiquidityInput,
   PositionData,
+  TickData,
   WhirlpoolData
 } from "./types/public";
 import { TokenAccountInfo, TokenInfo, WhirlpoolRewardInfo } from "./types/public/client-types";
@@ -288,6 +289,24 @@ export interface Position {
    * @return most recently fetched PositionData for this address.
    */
   getData: () => PositionData;
+
+  /**
+   * Return the most recently fetched Whirlpool account data for this position.
+   * @return most recently fetched WhirlpoolData for this position.
+   */
+  getWhirlpoolData: () => WhirlpoolData;
+
+  /**
+   * Return the most recently fetched TickData account data for this position's lower tick.
+   * @return most recently fetched TickData for this position's lower tick.
+   */
+  getLowerTickData: () => TickData;
+
+  /**
+   * Return the most recently fetched TickData account data for this position's upper tick.
+   * @return most recently fetched TickData for this position's upper tick.
+   */
+  getUpperTickData: () => TickData;
 
   /**
    * Fetch and return the most recently fetched Position account data.

--- a/sdk/src/whirlpool-client.ts
+++ b/sdk/src/whirlpool-client.ts
@@ -10,7 +10,7 @@ import {
   IncreaseLiquidityInput,
   PositionData,
   TickData,
-  WhirlpoolData
+  WhirlpoolData,
 } from "./types/public";
 import { TokenAccountInfo, TokenInfo, WhirlpoolRewardInfo } from "./types/public/client-types";
 


### PR DESCRIPTION
- Add WhirlpoolData, TickArrayData to Position (client object) to allow for an easier time to generate quotes
- Change collect fee to user PositionData instead of client Position since it doesn't need that much info
- Add new TickUtil.getOffsetIndex to calculate array offset index for a position's tick

### Testing
- The `client.getPositions` is used by Orca UI
- Confirmed that it successfully fetches all positions and have identical data to live (test case had 7 positions, SOL & nonSOL pairs)
- The UX performance is actually faster because the old version does not do batch RPC

https://app.asana.com/0/0/1203431351729803/f
