### PR TITLE
fix: getTickArrayPublicKeys edge case

### DIFF
--- a/sdk/jest.config.js
+++ b/sdk/jest.config.js
@@ -1,7 +1,8 @@
 module.exports = {
   "roots": [
     "<rootDir>/src",
-    "<rootDir>/tests/sdk"
+    "<rootDir>/tests/sdk",
+    "<rootDir>/tests/integration"
   ],
   "testMatch": [
     "**/__tests__/**/*.+(ts|tsx|js)",
@@ -14,5 +15,6 @@ module.exports = {
     "ts-jest": {
       tsconfig: "./tests/tsconfig.json"
     }
-  }
+  },
+  testTimeout: 30 * 1000
 }

--- a/sdk/src/quotes/swap/swap-quote-impl.ts
+++ b/sdk/src/quotes/swap/swap-quote-impl.ts
@@ -47,7 +47,7 @@ export function simulateSwap(params: SwapQuoteParam): SwapQuote {
   const tickSequence = new TickArraySequence(tickArrays, whirlpoolData.tickSpacing, aToB);
 
   // Ensure 1st search-index resides on the 1st array in the sequence to match smart contract expectation.
-  if (!tickSequence.checkArrayContainsTickIndex(0, whirlpoolData.tickCurrentIndex)) {
+  if (!tickSequence.isValidTickArray0(whirlpoolData.tickCurrentIndex)) {
     throw new WhirlpoolsError(
       "TickArray at index 0 does not contain the Whirlpool current tick index.",
       SwapErrorCode.TickArraySequenceInvalid

--- a/sdk/src/quotes/swap/tick-array-sequence.ts
+++ b/sdk/src/quotes/swap/tick-array-sequence.ts
@@ -52,12 +52,10 @@ export class TickArraySequence {
     ).arrayIndex;
   }
 
-  checkArrayContainsTickIndex(sequenceIndex: number, tickIndex: number) {
-    const tickArray = this.sequence[sequenceIndex]?.data;
-    if (!tickArray) {
-      return false;
-    }
-    return this.checkIfIndexIsInTickArrayRange(tickArray.startTickIndex, tickIndex);
+  isValidTickArray0(tickCurrentIndex: number) {
+    const shift = this.aToB ? 0 : this.tickSpacing;
+    const tickArray = this.sequence[0].data;
+    return this.checkIfIndexIsInTickArrayRange(tickArray.startTickIndex, tickCurrentIndex + shift);
   }
 
   getNumOfTouchedArrays() {
@@ -173,6 +171,6 @@ export class TickArraySequence {
 
   private checkIfIndexIsInTickArrayRange(startTick: number, tickIndex: number) {
     const upperBound = startTick + this.tickSpacing * TICK_ARRAY_SIZE;
-    return !(tickIndex < startTick || tickIndex > upperBound);
+    return tickIndex >= startTick && tickIndex < upperBound;
   }
 }

--- a/sdk/src/utils/public/swap-utils.ts
+++ b/sdk/src/utils/public/swap-utils.ts
@@ -79,12 +79,14 @@ export class SwapUtils {
     programId: PublicKey,
     whirlpoolAddress: PublicKey
   ) {
+    const shift = aToB ? 0 : tickSpacing;
+
     let offset = 0;
     let tickArrayAddresses: PublicKey[] = [];
     for (let i = 0; i < MAX_SWAP_TICK_ARRAYS; i++) {
       let startIndex: number;
       try {
-        startIndex = TickUtil.getStartTickIndex(tickCurrentIndex, tickSpacing, offset);
+        startIndex = TickUtil.getStartTickIndex(tickCurrentIndex + shift, tickSpacing, offset);
       } catch {
         return tickArrayAddresses;
       }

--- a/sdk/tests/integration/open_position.test.ts
+++ b/sdk/tests/integration/open_position.test.ts
@@ -42,7 +42,7 @@ describe("open_position", () => {
   let whirlpoolPda: PDA;
   const funderKeypair = anchor.web3.Keypair.generate();
 
-  before(async () => {
+  beforeAll(async () => {
     poolInitInfo = (await initTestPool(ctx, TickSpacing.Standard)).poolInitInfo;
     whirlpoolPda = poolInitInfo.whirlpoolPda;
 

--- a/sdk/tests/integration/open_position_with_metadata.test.ts
+++ b/sdk/tests/integration/open_position_with_metadata.test.ts
@@ -46,7 +46,7 @@ describe("open_position_with_metadata", () => {
   let whirlpoolPda: PDA;
   const funderKeypair = anchor.web3.Keypair.generate();
 
-  before(async () => {
+  beforeAll(async () => {
     poolInitInfo = (await initTestPool(ctx, TickSpacing.Standard)).poolInitInfo;
     whirlpoolPda = poolInitInfo.whirlpoolPda;
 

--- a/sdk/tests/sdk/whirlpools/position-impl.test.ts
+++ b/sdk/tests/sdk/whirlpools/position-impl.test.ts
@@ -66,7 +66,7 @@ describe("position-impl", () => {
     );
 
     // [Action] Increase liquidity by 70 tokens of tokenB
-    const position = await client.getPosition(positionAddress.publicKey);
+    const position = await client.getPosition(positionAddress.publicKey, true);
     const preIncreaseData = position.getData();
     const increase_quote = increaseLiquidityQuoteByInputToken(
       poolInitInfo.tokenMintB,
@@ -150,7 +150,7 @@ describe("position-impl", () => {
     );
 
     // [Action] Increase liquidity by 70 tokens of tokenB & create the ATA in the new source Wallet
-    const position = await client.getPosition(positionAddress.publicKey);
+    const position = await client.getPosition(positionAddress.publicKey, true);
     const preIncreaseData = position.getData();
     const increase_quote = increaseLiquidityQuoteByInputToken(
       poolInitInfo.tokenMintB,

--- a/sdk/tests/sdk/whirlpools/swap/swap-traverse.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/swap-traverse.test.ts
@@ -1171,6 +1171,174 @@ describe("swap traversal tests", () => {
   });
 
   /**
+   *          -5632        0         5632      11264
+   * |-a--------|-------x1-|----------|----------|-x2-----a-|
+   *                            ta0        ta1        ta2
+   */
+  it("b->a, tickCurrentIndex = -tickSpacing, shifted", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -1, offsetIndex: 87 }, tickSpacing);
+    const aToB = false;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 10 },
+          { arrayIndex: 2, offsetIndex: 80 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    const inputTokenQuote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      new u64(200000000),
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      true
+    );
+    const ta2StartTickIndex = 11264
+    assert.ok(inputTokenQuote.estimatedEndTickIndex > ta2StartTickIndex); // traverse ta0, ta1, and ta2
+
+    const outputTokenQuote = await swapQuoteByOutputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      inputTokenQuote.estimatedAmountOut,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      true
+    );
+    assertInputOutputQuoteEqual(inputTokenQuote, outputTokenQuote);
+    await (await whirlpool.swap(inputTokenQuote)).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(aToB, inputTokenQuote, newData, beforeVaultAmounts, afterVaultAmounts);
+  });
+
+  /**
+   *          -5632        0         5632      11264
+   * |-a--------|--------x1|----------|----------|-x2-----a-|
+   *                            ta0        ta1        ta2
+   */
+  it("b->a, tickCurrentIndex = -1, shifted", async () => {
+    const currIndex = -1;
+    const aToB = false;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 10 },
+          { arrayIndex: 2, offsetIndex: 80 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    const inputTokenQuote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      new u64(200000000),
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      true
+    );
+    const ta2StartTickIndex = 11264
+    assert.ok(inputTokenQuote.estimatedEndTickIndex > ta2StartTickIndex); // traverse ta0, ta1, and ta2
+
+    const outputTokenQuote = await swapQuoteByOutputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      inputTokenQuote.estimatedAmountOut,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      true
+    );
+    assertInputOutputQuoteEqual(inputTokenQuote, outputTokenQuote);
+    await (await whirlpool.swap(inputTokenQuote)).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(aToB, inputTokenQuote, newData, beforeVaultAmounts, afterVaultAmounts);
+  });
+
+  /**
+   *          -5632        0         5632      11264
+   * |-a--------|XXXXXXXXx1|----------|----------|-x2-----a-|
+   *                            ta0        ta1        ta2
+   */
+  it("b->a, tickCurrentIndex = -1, tickCurrentIndex on uninitialized TickArray, shifted", async () => {
+    const currIndex = -1;
+    const aToB = false;
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 10 },
+          { arrayIndex: 2, offsetIndex: 80 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const beforeVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    const inputTokenQuote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      new u64(200000000),
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      true
+    );
+    const ta2StartTickIndex = 11264
+    assert.ok(inputTokenQuote.estimatedEndTickIndex > ta2StartTickIndex); // traverse ta0, ta1, and ta2
+
+    const outputTokenQuote = await swapQuoteByOutputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      inputTokenQuote.estimatedAmountOut,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      true
+    );
+    assertInputOutputQuoteEqual(inputTokenQuote, outputTokenQuote);
+    await (await whirlpool.swap(inputTokenQuote)).buildAndExecute();
+
+    const newData = await whirlpool.refreshData();
+    const afterVaultAmounts = await getVaultAmounts(ctx, whirlpoolData);
+    assertQuoteAndResults(aToB, inputTokenQuote, newData, beforeVaultAmounts, afterVaultAmounts);
+  });
+
+  /**
    * sqrtPriceLimit < MIN_SQRT_PRICE
    * |--------------------|-----------------|---------x1----------|
    */

--- a/sdk/tests/sdk/whirlpools/utils/swap-utils.test.ts
+++ b/sdk/tests/sdk/whirlpools/utils/swap-utils.test.ts
@@ -1,9 +1,16 @@
 import * as assert from "assert";
-import { SwapUtils, SwapDirection } from "../../../../src";
+import * as anchor from "@project-serum/anchor";
+import { WhirlpoolContext } from "../../../../src/context";
+import { SwapUtils, SwapDirection, PDAUtil, TICK_ARRAY_SIZE } from "../../../../src";
 import { testWhirlpoolData } from "../../../utils/testDataTypes";
 import { Keypair } from "@solana/web3.js";
 
 describe("SwapUtils tests", () => {
+  const provider = anchor.AnchorProvider.local();
+  anchor.setProvider(anchor.AnchorProvider.env());
+  const program = anchor.workspace.Whirlpool;
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
+
   describe("getSwapDirection", () => {
     it("SwapToken is tokenA and is an input", async () => {
       const whirlpoolData = testWhirlpoolData;
@@ -41,4 +48,175 @@ describe("SwapUtils tests", () => {
       assert.equal(result, undefined);
     });
   });
+
+  describe("getTickArrayPublicKeys", () => {
+    it("a->b, ts = 64, tickCurrentIndex = 0", () => {
+      const programId = ctx.program.programId;
+      const whirlpoolPubkey = Keypair.generate().publicKey;
+      const tickSpacing = 64;
+      const ticksInArray = tickSpacing * TICK_ARRAY_SIZE;
+      const aToB = true;
+      const tickCurrentIndex = 0;
+
+      const result = SwapUtils.getTickArrayPublicKeys(
+        tickCurrentIndex,
+        tickSpacing,
+        aToB,
+        ctx.program.programId,
+        whirlpoolPubkey,
+      );
+
+      const expected = [
+        PDAUtil.getTickArray(programId, whirlpoolPubkey, ticksInArray*0).publicKey,
+        PDAUtil.getTickArray(programId, whirlpoolPubkey, ticksInArray*-1).publicKey,
+        PDAUtil.getTickArray(programId, whirlpoolPubkey, ticksInArray*-2).publicKey,
+      ];
+      result.forEach((k, i) => assert.equal(k.toBase58(), expected[i].toBase58()));
+    });
+
+    it("a->b, ts = 64, tickCurrentIndex = 64*TICK_ARRAY_SIZE - 64", () => {
+      const programId = ctx.program.programId;
+      const whirlpoolPubkey = Keypair.generate().publicKey;
+      const tickSpacing = 64;
+      const ticksInArray = tickSpacing * TICK_ARRAY_SIZE;
+      const aToB = true;
+      const tickCurrentIndex = tickSpacing * TICK_ARRAY_SIZE - tickSpacing;
+
+      const result = SwapUtils.getTickArrayPublicKeys(
+        tickCurrentIndex,
+        tickSpacing,
+        aToB,
+        ctx.program.programId,
+        whirlpoolPubkey,
+      );
+
+      const expected = [
+        PDAUtil.getTickArray(programId, whirlpoolPubkey, ticksInArray*0).publicKey,
+        PDAUtil.getTickArray(programId, whirlpoolPubkey, ticksInArray*-1).publicKey,
+        PDAUtil.getTickArray(programId, whirlpoolPubkey, ticksInArray*-2).publicKey,
+      ];
+      result.forEach((k, i) => assert.equal(k.toBase58(), expected[i].toBase58()));
+    });
+
+    it("a->b, ts = 64, tickCurrentIndex = 64*TICK_ARRAY_SIZE - 1", () => {
+      const programId = ctx.program.programId;
+      const whirlpoolPubkey = Keypair.generate().publicKey;
+      const tickSpacing = 64;
+      const ticksInArray = tickSpacing * TICK_ARRAY_SIZE;
+      const aToB = true;
+      const tickCurrentIndex = tickSpacing * TICK_ARRAY_SIZE - 1;
+
+      const result = SwapUtils.getTickArrayPublicKeys(
+        tickCurrentIndex,
+        tickSpacing,
+        aToB,
+        ctx.program.programId,
+        whirlpoolPubkey,
+      );
+
+      const expected = [
+        PDAUtil.getTickArray(programId, whirlpoolPubkey, ticksInArray*0).publicKey,
+        PDAUtil.getTickArray(programId, whirlpoolPubkey, ticksInArray*-1).publicKey,
+        PDAUtil.getTickArray(programId, whirlpoolPubkey, ticksInArray*-2).publicKey,
+      ];
+      result.forEach((k, i) => assert.equal(k.toBase58(), expected[i].toBase58()));
+    });
+
+    it("b->a, shifted, ts = 64, tickCurrentIndex = 0", () => {
+      const programId = ctx.program.programId;
+      const whirlpoolPubkey = Keypair.generate().publicKey;
+      const tickSpacing = 64;
+      const ticksInArray = tickSpacing * TICK_ARRAY_SIZE;
+      const aToB = false;
+      const tickCurrentIndex = 0;
+
+      const result = SwapUtils.getTickArrayPublicKeys(
+        tickCurrentIndex,
+        tickSpacing,
+        aToB,
+        ctx.program.programId,
+        whirlpoolPubkey,
+      );
+
+      const expected = [
+        PDAUtil.getTickArray(programId, whirlpoolPubkey, ticksInArray*0).publicKey,
+        PDAUtil.getTickArray(programId, whirlpoolPubkey, ticksInArray*1).publicKey,
+        PDAUtil.getTickArray(programId, whirlpoolPubkey, ticksInArray*2).publicKey,
+      ];
+      result.forEach((k, i) => assert.equal(k.toBase58(), expected[i].toBase58()));
+    });
+
+    it("b->a, shifted, ts = 64, tickCurrentIndex = 64*TICK_ARRAY_SIZE - 64 - 1", () => {
+      const programId = ctx.program.programId;
+      const whirlpoolPubkey = Keypair.generate().publicKey;
+      const tickSpacing = 64;
+      const ticksInArray = tickSpacing * TICK_ARRAY_SIZE;
+      const aToB = false;
+      const tickCurrentIndex = tickSpacing * TICK_ARRAY_SIZE - tickSpacing - 1;
+
+      const result = SwapUtils.getTickArrayPublicKeys(
+        tickCurrentIndex,
+        tickSpacing,
+        aToB,
+        ctx.program.programId,
+        whirlpoolPubkey,
+      );
+
+      const expected = [
+        PDAUtil.getTickArray(programId, whirlpoolPubkey, ticksInArray*0).publicKey,
+        PDAUtil.getTickArray(programId, whirlpoolPubkey, ticksInArray*1).publicKey,
+        PDAUtil.getTickArray(programId, whirlpoolPubkey, ticksInArray*2).publicKey,
+      ];
+      result.forEach((k, i) => assert.equal(k.toBase58(), expected[i].toBase58()));
+    });
+
+    it("b->a, shifted, ts = 64, tickCurrentIndex = 64*TICK_ARRAY_SIZE - 64", () => {
+      const programId = ctx.program.programId;
+      const whirlpoolPubkey = Keypair.generate().publicKey;
+      const tickSpacing = 64;
+      const ticksInArray = tickSpacing * TICK_ARRAY_SIZE;
+      const aToB = false;
+      const tickCurrentIndex = tickSpacing * TICK_ARRAY_SIZE - tickSpacing;
+
+      const result = SwapUtils.getTickArrayPublicKeys(
+        tickCurrentIndex,
+        tickSpacing,
+        aToB,
+        ctx.program.programId,
+        whirlpoolPubkey,
+      );
+
+      const expected = [
+        PDAUtil.getTickArray(programId, whirlpoolPubkey, ticksInArray*1).publicKey,
+        PDAUtil.getTickArray(programId, whirlpoolPubkey, ticksInArray*2).publicKey,
+        PDAUtil.getTickArray(programId, whirlpoolPubkey, ticksInArray*3).publicKey,
+      ];
+      result.forEach((k, i) => assert.equal(k.toBase58(), expected[i].toBase58()));
+    });
+
+    it("b->a, shifted, ts = 64, tickCurrentIndex = 64*TICK_ARRAY_SIZE - 1", () => {
+      const programId = ctx.program.programId;
+      const whirlpoolPubkey = Keypair.generate().publicKey;
+      const tickSpacing = 64;
+      const ticksInArray = tickSpacing * TICK_ARRAY_SIZE;
+      const aToB = false;
+      const tickCurrentIndex = tickSpacing * TICK_ARRAY_SIZE - 1;
+
+      const result = SwapUtils.getTickArrayPublicKeys(
+        tickCurrentIndex,
+        tickSpacing,
+        aToB,
+        ctx.program.programId,
+        whirlpoolPubkey,
+      );
+
+      const expected = [
+        PDAUtil.getTickArray(programId, whirlpoolPubkey, ticksInArray*1).publicKey,
+        PDAUtil.getTickArray(programId, whirlpoolPubkey, ticksInArray*2).publicKey,
+        PDAUtil.getTickArray(programId, whirlpoolPubkey, ticksInArray*3).publicKey,
+      ];
+      result.forEach((k, i) => assert.equal(k.toBase58(), expected[i].toBase58()));
+    });
+  });
+
 });

--- a/sdk/tests/sdk/whirlpools/utils/tick-array-sequence.test.ts
+++ b/sdk/tests/sdk/whirlpools/utils/tick-array-sequence.test.ts
@@ -10,34 +10,103 @@ describe("TickArray Sequence tests", () => {
   const ts64 = 64;
   const ts128 = 128;
 
-  describe("checkArrayContainsTickIndex tests", () => {
+  describe("isValidTickArray0 tests", () => {
     const ta0 = buildTickArrayData(0, [0, 32, 63]);
     const ta1 = buildTickArrayData(ts64 * TICK_ARRAY_SIZE * -1, [0, 50]);
     const ta2 = buildTickArrayData(ts64 * TICK_ARRAY_SIZE * -2, [25, 50]);
 
-    it("a->b, arrayIndex 0 contains index", () => {
+    it("a->b, |--------ta2--------|--------ta1------i-|--------ta0--------|", () => {
       const seq = new TickArraySequence([ta0, ta1, ta2], ts64, true);
-      assert.ok(seq.checkArrayContainsTickIndex(0, 250));
+      assert.ok(!seq.isValidTickArray0(-1 * ts64));
     });
 
-    it("a->b, arrayIndex 0 does not contain index", () => {
+    it("a->b, |--------ta2--------|--------ta1-------i|--------ta0--------|", () => {
       const seq = new TickArraySequence([ta0, ta1, ta2], ts64, true);
-      assert.ok(!seq.checkArrayContainsTickIndex(0, -64));
+      assert.ok(!seq.isValidTickArray0(-1));
     });
 
-    it("b->a, arrayIndex 0 contains index", () => {
+    it("a->b, |--------ta2--------|--------ta1--------|i-------ta0--------|", () => {
+      const seq = new TickArraySequence([ta0, ta1, ta2], ts64, true);
+      assert.ok(seq.isValidTickArray0(0));
+    });
+
+    it("a->b, |--------ta2--------|--------ta1--------|-i------ta0--------|", () => {
+      const seq = new TickArraySequence([ta0, ta1, ta2], ts64, true);
+      assert.ok(seq.isValidTickArray0(ts64));
+    });
+
+    it("a->b, |--------ta2--------|--------ta1--------|--------ta0-----i--|", () => {
+      const seq = new TickArraySequence([ta0, ta1, ta2], ts64, true);
+      assert.ok(seq.isValidTickArray0(ts64 * TICK_ARRAY_SIZE - ts64 - 1));
+    });
+
+    it("a->b, |--------ta2--------|--------ta1--------|--------ta0------i-|", () => {
+      const seq = new TickArraySequence([ta0, ta1, ta2], ts64, true);
+      assert.ok(seq.isValidTickArray0(ts64 * TICK_ARRAY_SIZE - ts64));
+    });
+
+    it("a->b, |--------ta2--------|--------ta1--------|--------ta0-------i|", () => {
+      const seq = new TickArraySequence([ta0, ta1, ta2], ts64, true);
+      assert.ok(seq.isValidTickArray0(ts64 * TICK_ARRAY_SIZE - 1));
+    });
+
+    it("a->b, |--------ta2--------|--------ta1--------|--------ta0--------|i", () => {
+      const seq = new TickArraySequence([ta0, ta1, ta2], ts64, true);
+      assert.ok(!seq.isValidTickArray0(ts64 * TICK_ARRAY_SIZE));
+    });
+
+    it("b->a, i--|--------ta2--------|--------ta1--------|--------ta0--------|", () => {
       const seq = new TickArraySequence([ta2, ta1, ta0], ts64, false);
-      assert.ok(seq.checkArrayContainsTickIndex(0, -10000));
+      const ta2StartTickIndex = ts64 * TICK_ARRAY_SIZE * -2;
+      assert.ok(!seq.isValidTickArray0(ta2StartTickIndex - ts64 - 1));
     });
 
-    it("a->b, arrayIndex 0 does not contain index", () => {
+    it("b->a, -i-|--------ta2--------|--------ta1--------|--------ta0--------|", () => {
       const seq = new TickArraySequence([ta2, ta1, ta0], ts64, false);
-      assert.ok(!seq.checkArrayContainsTickIndex(0, -64));
+      const ta2StartTickIndex = ts64 * TICK_ARRAY_SIZE * -2;
+      assert.ok(seq.isValidTickArray0(ta2StartTickIndex - ts64));
     });
 
-    it("check null does not contain index", () => {
-      const seq = new TickArraySequence([ta2, testEmptyTickArrray, ta0], ts64, false);
-      assert.ok(!seq.checkArrayContainsTickIndex(1, -64));
+    it("b->a, --i|--------ta2--------|--------ta1--------|--------ta0--------|", () => {
+      const seq = new TickArraySequence([ta2, ta1, ta0], ts64, false);
+      const ta2StartTickIndex = ts64 * TICK_ARRAY_SIZE * -2;
+      assert.ok(seq.isValidTickArray0(ta2StartTickIndex - 1));
+    });
+
+    it("b->a, ---|i-------ta2--------|--------ta1--------|--------ta0--------|", () => {
+      const seq = new TickArraySequence([ta2, ta1, ta0], ts64, false);
+      const ta2StartTickIndex = ts64 * TICK_ARRAY_SIZE * -2;
+      assert.ok(seq.isValidTickArray0(ta2StartTickIndex));
+    });
+
+    it("b->a, ---|-i------ta2--------|--------ta1--------|--------ta0--------|", () => {
+      const seq = new TickArraySequence([ta2, ta1, ta0], ts64, false);
+      const ta2StartTickIndex = ts64 * TICK_ARRAY_SIZE * -2;
+      assert.ok(seq.isValidTickArray0(ta2StartTickIndex + ts64));
+    });
+
+    it("b->a, ---|--------ta2-----i--|--------ta1--------|--------ta0--------|", () => {
+      const seq = new TickArraySequence([ta2, ta1, ta0], ts64, false);
+      const ta1StartTickIndex = ts64 * TICK_ARRAY_SIZE * -1;
+      assert.ok(seq.isValidTickArray0(ta1StartTickIndex - ts64 - 1));
+    });
+
+    it("b->a, ---|--------ta2------i-|--------ta1--------|--------ta0--------|", () => {
+      const seq = new TickArraySequence([ta2, ta1, ta0], ts64, false);
+      const ta1StartTickIndex = ts64 * TICK_ARRAY_SIZE * -1;
+      assert.ok(!seq.isValidTickArray0(ta1StartTickIndex - ts64));
+    });
+
+    it("b->a, ---|--------ta2-------i|--------ta1--------|--------ta0--------|", () => {
+      const seq = new TickArraySequence([ta2, ta1, ta0], ts64, false);
+      const ta1StartTickIndex = ts64 * TICK_ARRAY_SIZE * -1;
+      assert.ok(!seq.isValidTickArray0(ta1StartTickIndex - 1));
+    });
+
+    it("b->a, ---|--------ta2--------|i-------ta1--------|--------ta0--------|", () => {
+      const seq = new TickArraySequence([ta2, ta1, ta0], ts64, false);
+      const ta1StartTickIndex = ts64 * TICK_ARRAY_SIZE * -1;
+      assert.ok(!seq.isValidTickArray0(ta1StartTickIndex));
     });
   });
 
@@ -184,6 +253,68 @@ describe("TickArray Sequence tests", () => {
       let i = 0;
       let searchIndex = new TickArrayIndex(0, 25, ts64).toTickIndex();
       const expectedIndicies = [
+        new TickArrayIndex(0, 32, ts64).toTickIndex(),
+        new TickArrayIndex(0, 63, ts64).toTickIndex(),
+        new TickArrayIndex(1, 0, ts64).toTickIndex(),
+        new TickArrayIndex(1, 50, ts64).toTickIndex(),
+        new TickArrayIndex(2, 25, ts64).toTickIndex(),
+        new TickArrayIndex(2, 50, ts64).toTickIndex(),
+        ta2.data!.startTickIndex + TICK_ARRAY_SIZE * ts64 - 1, // Last index in array 3
+      ];
+
+      expectedIndicies.forEach((expectedIndex, expectedResultIndex) => {
+        const { nextIndex, nextTickData } = seq.findNextInitializedTickIndex(searchIndex)!;
+        if (expectedResultIndex === expectedIndicies.length - 1) {
+          assert.equal(nextIndex, expectedIndex);
+          assert.ok(nextTickData === null);
+        } else {
+          assert.equal(nextIndex, expectedIndex);
+          assert.ok(nextTickData!.initialized);
+        }
+        searchIndex = nextIndex;
+      });
+    });
+
+    it("b->a, on initializable index, ts = 64, currentTickIndex = -64, shifted", async () => {
+      const ta0 = buildTickArrayData(0, [0, 32, 63]);
+      const ta1 = buildTickArrayData(ts64 * TICK_ARRAY_SIZE, [0, 50]);
+      const ta2 = buildTickArrayData(ts64 * TICK_ARRAY_SIZE * 2, [25, 50]);
+      const seq = new TickArraySequence([ta0, ta1, ta2], ts64, false);
+      let i = 0;
+      let searchIndex = -1 * ts64;
+      const expectedIndicies = [
+        new TickArrayIndex(0, 0, ts64).toTickIndex(),
+        new TickArrayIndex(0, 32, ts64).toTickIndex(),
+        new TickArrayIndex(0, 63, ts64).toTickIndex(),
+        new TickArrayIndex(1, 0, ts64).toTickIndex(),
+        new TickArrayIndex(1, 50, ts64).toTickIndex(),
+        new TickArrayIndex(2, 25, ts64).toTickIndex(),
+        new TickArrayIndex(2, 50, ts64).toTickIndex(),
+        ta2.data!.startTickIndex + TICK_ARRAY_SIZE * ts64 - 1, // Last index in array 3
+      ];
+
+      expectedIndicies.forEach((expectedIndex, expectedResultIndex) => {
+        const { nextIndex, nextTickData } = seq.findNextInitializedTickIndex(searchIndex)!;
+        if (expectedResultIndex === expectedIndicies.length - 1) {
+          assert.equal(nextIndex, expectedIndex);
+          assert.ok(nextTickData === null);
+        } else {
+          assert.equal(nextIndex, expectedIndex);
+          assert.ok(nextTickData!.initialized);
+        }
+        searchIndex = nextIndex;
+      });
+    });
+
+    it("b->a, on initializable index, ts = 64, currentTickIndex = -1, shifted", async () => {
+      const ta0 = buildTickArrayData(0, [0, 32, 63]);
+      const ta1 = buildTickArrayData(ts64 * TICK_ARRAY_SIZE, [0, 50]);
+      const ta2 = buildTickArrayData(ts64 * TICK_ARRAY_SIZE * 2, [25, 50]);
+      const seq = new TickArraySequence([ta0, ta1, ta2], ts64, false);
+      let i = 0;
+      let searchIndex = -1;
+      const expectedIndicies = [
+        new TickArrayIndex(0, 0, ts64).toTickIndex(),
         new TickArrayIndex(0, 32, ts64).toTickIndex(),
         new TickArrayIndex(0, 63, ts64).toTickIndex(),
         new TickArrayIndex(1, 0, ts64).toTickIndex(),


### PR DESCRIPTION
Issue: https://app.asana.com/0/1202413563699470/1203471728007402/f

## fix: getTickArrayPublicKeys edge case
porting "shifted" in in_search_range of on-chain programs.
https://github.com/orca-so/whirlpools/blob/main/programs/whirlpool/src/state/tick.rs#L299

- getTickArrayPublicKeys: if the swap direction is B to A and tickCurrentIndex is greater than or equal to the last initializable tick in the TickArray, the TickArray adjacent to the swap direction is TickArray0
- TickArraySequence: Change the logic to determine whether TickArray0 contains tickCurrentIndex

## fix: test case & setting
- set jest timeout to 30 sec (default timeout (5 sec) is too short)
- add "integration" test to jest.config.js
- change "before" to "beforeAll"
  In jest there is no before, use beforeAll for one-time setups
    https://jestjs.io/docs/setup-teardown
- add refresh=true on getPosition
  When checking TickArrays that needs to be initialized, a "null" cache remains in the fetcher, and listing TickArrays for the position fails.

**passed all tests (integration & sdk)**