### PR TITLE
Proposal - Comments for closePosition patch

### DIFF
--- a/sdk/src/instructions/composites/collect-all-txn.ts
+++ b/sdk/src/instructions/composites/collect-all-txn.ts
@@ -107,7 +107,7 @@ export async function collectAllForPositionsTxns(
 
   const accountExemption = await ctx.fetcher.getAccountRentExempt();
   const { ataTokenAddresses: affliatedTokenAtaMap, resolveAtaIxs } = await resolveAtaForMints(ctx, {
-    mints: getTokenMintsFromWhirlpools(whirlpoolDatas),
+    mints: getTokenMintsFromWhirlpools(whirlpoolDatas).mintMap,
     accountExemption,
     receiver: receiverKey,
     payer: payerKey,

--- a/sdk/src/utils/spl-token-utils.ts
+++ b/sdk/src/utils/spl-token-utils.ts
@@ -1,11 +1,10 @@
 import { Instruction } from "@orca-so/common-sdk";
-import { createWSOLAccountInstructions } from "@orca-so/common-sdk/dist/helpers/token-instructions";
 import {
   AccountLayout,
   ASSOCIATED_TOKEN_PROGRAM_ID,
   NATIVE_MINT,
   Token,
-  TOKEN_PROGRAM_ID,
+  TOKEN_PROGRAM_ID
 } from "@solana/spl-token";
 import { Keypair, PublicKey, SystemProgram } from "@solana/web3.js";
 import BN from "bn.js";
@@ -29,18 +28,15 @@ export function getAssociatedTokenAddressSync(
   return address;
 }
 
-// TODO: Move this to common-sdk and use that in this SDK later
-export function wrapSOL(
+// TODO: This is a temp fn to help add payer / differing destination params to the original method
+// Deprecate this as soon as we move to sync-native. Can consider moving to common-sdk for posterity.
+export function createWSOLAccountInstructions(
   owner: PublicKey,
   amountToWrap: BN,
   accountExemption: number,
   payer?: PublicKey,
   unwrapDestination?: PublicKey
-): {
-  wSolAccount: PublicKey;
-  wrapIx: Instruction;
-  unwrapIx: Instruction;
-} {
+): { address: PublicKey } & Instruction {
   const payerKey = payer ?? owner;
   const unwrapDestinationKey = unwrapDestination ?? payer ?? owner;
   const tempAccount = new Keypair();
@@ -68,21 +64,10 @@ export function wrapSOL(
     []
   );
 
-  const wrapIx: Instruction = {
-    instructions: [createIx, initIx],
-    cleanupInstructions: [],
-    signers: [tempAccount],
-  };
-
-  const unwrapIx: Instruction = {
-    instructions: [closeIx],
-    cleanupInstructions: [],
-    signers: [],
-  };
-
   return {
-    wSolAccount: tempAccount.publicKey,
-    wrapIx,
-    unwrapIx,
+    address: tempAccount.publicKey,
+    instructions: [createIx, initIx],
+    cleanupInstructions: [closeIx],
+    signers: [tempAccount],
   };
 }

--- a/sdk/src/whirlpool-client.ts
+++ b/sdk/src/whirlpool-client.ts
@@ -10,7 +10,7 @@ import {
   IncreaseLiquidityInput,
   PositionData,
   TickData,
-  WhirlpoolData,
+  WhirlpoolData
 } from "./types/public";
 import { TokenAccountInfo, TokenInfo, WhirlpoolRewardInfo } from "./types/public/client-types";
 
@@ -360,7 +360,7 @@ export interface Position {
    * If `positionWallet` is provided, the wallet owners have to sign this transaction.
    *
    * @param updateFeesAndRewards -  if true, add instructions to refresh the accumulated fees and rewards data (default to true unless you know that the collect fees quote and on-chain data match for the "feeOwedA" and "feeOwedB" fields in the Position account)
-   * @param ownerTokenAccountsRecord - A record that maps a given mint to the owner's token account for that mint (if an entry doesn't exist, it will be automatically resolved)
+   * @param ownerTokenAccountMap - A record that maps a given mint to the owner's token account for that mint (if an entry doesn't exist, it will be automatically resolved)
    * @param destinationWallet - the wallet to deposit tokens into when withdrawing from the position. If null, the WhirlpoolContext wallet is used.
    * @param positionWallet - the wallet to that houses the position token. If null, the WhirlpoolContext wallet is used.
    * @param ataPayer - wallet that will fund the creation of the new associated token accounts
@@ -369,7 +369,7 @@ export interface Position {
    */
   collectFees: (
     updateFeesAndRewards?: boolean,
-    ownerTokenAccountsRecord?: Partial<Record<string, Address>>,
+    ownerTokenAccountMap?: Partial<Record<string, Address>>,
     destinationWallet?: Address,
     positionWallet?: Address,
     ataPayer?: Address,
@@ -383,7 +383,7 @@ export interface Position {
    *
    * @param rewardsToCollect - reward mints to collect (omitting this parameter means all rewards will be collected)
    * @param updateFeesAndRewards -  if true, add instructions to refresh the accumulated fees and rewards data (default to true unless you know that the collect fees quote and on-chain data match for the "feeOwedA" and "feeOwedB" fields in the Position account)
-   * @param ownerTokenAccountsRecord - A record that maps a given mint to the owner's token account for that mint (if an entry doesn't exist, it will be automatically resolved)
+   * @param ownerTokenAccountMap - A record that maps a given mint to the owner's token account for that mint (if an entry doesn't exist, it will be automatically resolved)
    * @param destinationWallet - the wallet to deposit tokens into when withdrawing from the position. If null, the WhirlpoolContext wallet is used.
    * @param positionWallet - the wallet to that houses the position token. If null, the WhirlpoolContext wallet is used.
    * @param ataPayer - wallet that will fund the creation of the new associated token accounts
@@ -393,7 +393,7 @@ export interface Position {
   collectRewards: (
     rewardsToCollect?: Address[],
     updateFeesAndRewards?: boolean,
-    ownerTokenAccountsRecord?: Partial<Record<string, Address>>,
+    ownerTokenAccountMap?: Partial<Record<string, Address>>,
     destinationWallet?: Address,
     positionWallet?: Address,
     ataPayer?: Address,


### PR DESCRIPTION
- Added a flag to getTokenMintsFromWhirlpools to reuse mint detection for different usecases
- Tested and confirmed that wSOL wrapping fits in the max filled close-position txbuilder
- Removed tokenaccount check for collectRewards

Next steps:
We are using existing tests to verify whirlpool.closePosition. However, the test coverage is not complete. We still need the following:

1. ClosePosition with decreaseL only
2. ClosePosition with collectFees only
3. ClosePosition with collectRewards only
4. ClosePosition with no collection/decreaseL, only close_position
5. Position.collectReward - verify the plumbing is correct with all param options turned on (payer, other wallet, SOL handling)
6. Position.collectFees - verify the plumbing is correct with all param options turned on (payer, other wallet, SOL handling)