### PR TITLE
Fix understated collectRewardsQuote and unit-tests for new collect functions

### DIFF
--- a/sdk/src/impl/position-impl.ts
+++ b/sdk/src/impl/position-impl.ts
@@ -299,7 +299,7 @@ export class PositionImpl implements Position {
 
     const positionTokenAccount = await deriveATA(positionWalletKey, this.data.positionMint);
 
-    if (updateFeesAndRewards) {
+    if (updateFeesAndRewards && !this.data.liquidity.isZero()) {
       const updateIx = await this.updateFeesAndRewards();
       txBuilder.addInstruction(updateIx);
     }
@@ -382,7 +382,7 @@ export class PositionImpl implements Position {
     }
 
     const positionTokenAccount = await deriveATA(positionWalletKey, this.data.positionMint);
-    if (updateFeesAndRewards) {
+    if (updateFeesAndRewards && !this.data.liquidity.isZero()) {
       const updateIx = await this.updateFeesAndRewards();
       txBuilder.addInstruction(updateIx);
     }

--- a/sdk/src/impl/whirlpool-impl.ts
+++ b/sdk/src/impl/whirlpool-impl.ts
@@ -485,9 +485,7 @@ export class WhirlpoolImpl implements Whirlpool {
       });
 
       const liquidityIx = decreaseLiquidityIx(this.ctx.program, {
-        liquidityAmount: decreaseLiqQuote.liquidityAmount,
-        tokenMinA: decreaseLiqQuote.tokenMinA,
-        tokenMinB: decreaseLiqQuote.tokenMinB,
+        ...decreaseLiqQuote,
         whirlpool: positionData.whirlpool,
         positionAuthority: positionWallet,
         position: positionAddress,

--- a/sdk/src/quotes/public/collect-rewards-quote.ts
+++ b/sdk/src/quotes/public/collect-rewards-quote.ts
@@ -6,7 +6,13 @@ import { BitMath } from "../../utils/math/bit-math";
 import { PoolUtil } from "../../utils/public/pool-utils";
 
 /**
+ * Parameters needed to generate a quote on collectible rewards on a position.
  * @category Quotes
+ * @param whirlpool - the account data for the whirlpool this position belongs to
+ * @param position - the account data for the position
+ * @param tickLower - the TickData account for the lower bound of this position
+ * @param tickUpper - the TickData account for the upper bound of this position
+ * @param timeStampInSeconds - optional parameter to generate this quote to a unix time stamp.
  */
 export type CollectRewardsQuoteParam = {
   whirlpool: WhirlpoolData;
@@ -17,6 +23,7 @@ export type CollectRewardsQuoteParam = {
 };
 
 /**
+ * An array of reward amounts that is collectible on a position.
  * @category Quotes
  */
 export type CollectRewardsQuote = [BN | undefined, BN | undefined, BN | undefined];
@@ -74,9 +81,9 @@ export function collectRewardsQuote(param: CollectRewardsQuoteParam): CollectRew
       rewardGrowthsBelowX64 =
         tickCurrentIndex < tickLowerIndex
           ? MathUtil.subUnderflowU128(
-              adjustedRewardGrowthGlobalX64,
-              tickLowerRewardGrowthsOutsideX64
-            )
+            adjustedRewardGrowthGlobalX64,
+            tickLowerRewardGrowthsOutsideX64
+          )
           : tickLowerRewardGrowthsOutsideX64;
     }
 
@@ -86,9 +93,9 @@ export function collectRewardsQuote(param: CollectRewardsQuoteParam): CollectRew
         tickCurrentIndex < tickUpperIndex
           ? tickUpperRewardGrowthsOutsideX64
           : MathUtil.subUnderflowU128(
-              adjustedRewardGrowthGlobalX64,
-              tickUpperRewardGrowthsOutsideX64
-            );
+            adjustedRewardGrowthGlobalX64,
+            tickUpperRewardGrowthsOutsideX64
+          );
     }
 
     const rewardGrowthInsideX64 = MathUtil.subUnderflowU128(

--- a/sdk/tests/integration/open_position.test.ts
+++ b/sdk/tests/integration/open_position.test.ts
@@ -13,7 +13,7 @@ import {
   PositionData,
   toTx,
   WhirlpoolContext,
-  WhirlpoolIx,
+  WhirlpoolIx
 } from "../../src";
 import {
   createMint,
@@ -22,7 +22,7 @@ import {
   ONE_SOL,
   systemTransferTx,
   TickSpacing,
-  ZERO_BN,
+  ZERO_BN
 } from "../utils";
 import { initTestPool, openPosition } from "../utils/init-utils";
 import { generateDefaultOpenPositionParams } from "../utils/test-builders";
@@ -42,7 +42,7 @@ describe("open_position", () => {
   let whirlpoolPda: PDA;
   const funderKeypair = anchor.web3.Keypair.generate();
 
-  beforeAll(async () => {
+  before(async () => {
     poolInitInfo = (await initTestPool(ctx, TickSpacing.Standard)).poolInitInfo;
     whirlpoolPda = poolInitInfo.whirlpoolPda;
 

--- a/sdk/tests/integration/open_position_with_metadata.test.ts
+++ b/sdk/tests/integration/open_position_with_metadata.test.ts
@@ -16,7 +16,7 @@ import {
   PositionData,
   toTx,
   WhirlpoolContext,
-  WhirlpoolIx,
+  WhirlpoolIx
 } from "../../src";
 import { openPositionAccounts } from "../../src/utils/instructions-util";
 import {
@@ -26,7 +26,7 @@ import {
   ONE_SOL,
   systemTransferTx,
   TickSpacing,
-  ZERO_BN,
+  ZERO_BN
 } from "../utils";
 import { initTestPool, openPositionWithMetadata } from "../utils/init-utils";
 import { generateDefaultOpenPositionParams } from "../utils/test-builders";
@@ -46,7 +46,7 @@ describe("open_position_with_metadata", () => {
   let whirlpoolPda: PDA;
   const funderKeypair = anchor.web3.Keypair.generate();
 
-  beforeAll(async () => {
+  before(async () => {
     poolInitInfo = (await initTestPool(ctx, TickSpacing.Standard)).poolInitInfo;
     whirlpoolPda = poolInitInfo.whirlpoolPda;
 

--- a/sdk/tests/sdk/whirlpools/position-impl#collectRewards.test.ts
+++ b/sdk/tests/sdk/whirlpools/position-impl#collectRewards.test.ts
@@ -1,15 +1,15 @@
-import { deriveATA, MathUtil, Percentage } from "@orca-so/common-sdk";
+import { deriveATA, MathUtil } from "@orca-so/common-sdk";
 import * as anchor from "@project-serum/anchor";
-import * as assert from "assert";
 import { u64 } from "@solana/spl-token";
+import * as assert from "assert";
 import Decimal from "decimal.js";
 import {
   buildWhirlpoolClient,
   collectRewardsQuote,
-  TickArrayUtil,
+  NUM_REWARDS,
   Whirlpool,
   WhirlpoolClient,
-  WhirlpoolContext,
+  WhirlpoolContext
 } from "../../../src";
 import { TickSpacing } from "../../utils";
 import { WhirlpoolTestFixture } from "../../utils/fixture";
@@ -21,7 +21,6 @@ interface SharedTestContext {
   whirlpoolClient: WhirlpoolClient;
 }
 
-// TODO(meep): These tests are kind of flaky, I think this also has to do with the rewards quote bug.
 describe("PositionImpl#collectRewards()", () => {
   let testCtx: SharedTestContext;
   const tickLowerIndex = 29440;
@@ -29,12 +28,6 @@ describe("PositionImpl#collectRewards()", () => {
   const vaultStartBalance = 1_000_000;
   const tickSpacing = TickSpacing.Standard;
   const liquidityAmount = new u64(10_000_000);
-
-  async function delay(ms: number) {
-    return new Promise((resolve) => {
-      setTimeout(resolve, ms);
-    });
-  }
 
   before(() => {
     const provider = anchor.AnchorProvider.local(undefined, {
@@ -54,46 +47,6 @@ describe("PositionImpl#collectRewards()", () => {
       whirlpoolClient,
     };
   });
-
-  async function accrueRewards(fixture: WhirlpoolTestFixture) {
-    const ctx = testCtx.whirlpoolCtx;
-
-    const {
-      positions: [positionInfo],
-      poolInitInfo,
-    } = fixture.getInfos();
-
-    const position = await testCtx.whirlpoolClient.getPosition(positionInfo.publicKey);
-    const pool = await testCtx.whirlpoolClient.getPool(poolInitInfo.whirlpoolPda.publicKey);
-
-    const tickLowerArrayData = await ctx.fetcher.getTickArray(positionInfo.tickArrayLower, true);
-
-    const tickUpperArrayData = await ctx.fetcher.getTickArray(positionInfo.tickArrayUpper, true);
-
-    const tickLower = TickArrayUtil.getTickFromArray(
-      tickLowerArrayData!,
-      tickLowerIndex,
-      tickSpacing
-    );
-
-    const tickUpper = TickArrayUtil.getTickFromArray(
-      tickUpperArrayData!,
-      tickUpperIndex,
-      tickSpacing
-    );
-
-    const rewardsQuote = collectRewardsQuote({
-      whirlpool: await pool.refreshData(),
-      position: await position.refreshData(),
-      tickLower,
-      tickUpper,
-    });
-
-    assert.ok(
-      rewardsQuote.some((quote) => quote && quote.gtn(0)),
-      "Rewards haven't accrued"
-    );
-  }
 
   context("when the whirlpool is SPL-only", () => {
     it("should collect rewards", async () => {
@@ -118,64 +71,41 @@ describe("PositionImpl#collectRewards()", () => {
         ],
       });
 
-      await accrueRewards(fixture);
-
       const { positions, poolInitInfo, rewards } = fixture.getInfos();
 
-      const pool = await testCtx.whirlpoolClient.getPool(poolInitInfo.whirlpoolPda.publicKey);
-      const position = await testCtx.whirlpoolClient.getPosition(positions[0].publicKey);
-
-      const positionDataBefore = await testCtx.whirlpoolCtx.fetcher.getPosition(
-        position.getAddress(),
-        true
-      );
+      const pool = await testCtx.whirlpoolClient.getPool(poolInitInfo.whirlpoolPda.publicKey, true);
+      const position = await testCtx.whirlpoolClient.getPosition(positions[0].publicKey, true);
 
       const otherWallet = anchor.web3.Keypair.generate();
+      const preCollectPoolData = pool.getData();
 
-      const poolData = await pool.refreshData();
-      const positionData = await position.refreshData();
-      const tickLowerData = position.getLowerTickData();
-      const tickUpperData = position.getLowerTickData();
+      await (
+        await position.collectRewards(
+          rewards.map((r) => r.rewardMint),
+          true,
+          undefined,
+          otherWallet.publicKey,
+          testCtx.provider.wallet.publicKey,
+          testCtx.provider.wallet.publicKey,
+          true
+        )
+      ).buildAndExecute();
 
+      // Verify the results fetched is the same as SDK estimate if the timestamp is the same
+      const postCollectPoolData = await pool.refreshData();
       const quote = collectRewardsQuote({
-        whirlpool: poolData,
-        position: positionData,
-        tickLower: tickLowerData,
-        tickUpper: tickUpperData,
+        whirlpool: preCollectPoolData,
+        position: position.getData(),
+        tickLower: position.getLowerTickData(),
+        tickUpper: position.getUpperTickData(),
+        timeStampInSeconds: postCollectPoolData.rewardLastUpdatedTimestamp,
       });
 
-      assert.notEqual(positionDataBefore, null);
-
-      const tx = await position.collectRewards(
-        rewards.map((r) => r.rewardMint),
-        true,
-        undefined,
-        otherWallet.publicKey,
-        testCtx.provider.wallet.publicKey,
-        testCtx.provider.wallet.publicKey,
-        true
-      );
-
-      await tx.buildAndExecute();
-
-      const positionDataAfter = await testCtx.whirlpoolCtx.fetcher.getPosition(
-        position.getAddress(),
-        true
-      );
-
-      assert.notEqual(positionDataAfter, null);
-
-      const r0Pubkey = await deriveATA(otherWallet.publicKey, rewards[0].rewardMint);
-      const r0Account = await testCtx.whirlpoolCtx.fetcher.getTokenInfo(r0Pubkey, true);
-      assert.ok(quote[0] && r0Account && r0Account.amount.eq(quote[0]));
-
-      const r1Pubkey = await deriveATA(otherWallet.publicKey, rewards[1].rewardMint);
-      const r1Account = await testCtx.whirlpoolCtx.fetcher.getTokenInfo(r1Pubkey, true);
-      assert.ok(quote[1] && r1Account && r1Account.amount.eq(quote[1]));
-
-      const r2Pubkey = await deriveATA(otherWallet.publicKey, rewards[2].rewardMint);
-      const r2Account = await testCtx.whirlpoolCtx.fetcher.getTokenInfo(r2Pubkey, true);
-      assert.ok(quote[2] && r2Account && r2Account.amount.eq(quote[2]));
+      for (let i = 0; i < NUM_REWARDS; i++) {
+        const rewardATA = await deriveATA(otherWallet.publicKey, rewards[i].rewardMint);
+        const rewardTokenAccount = await testCtx.whirlpoolCtx.fetcher.getTokenInfo(rewardATA, true);
+        assert.equal(rewardTokenAccount?.amount.toString(), quote[i]?.toString());
+      }
     });
   });
 
@@ -203,64 +133,40 @@ describe("PositionImpl#collectRewards()", () => {
         tokenAIsNative: true,
       });
 
-      await accrueRewards(fixture);
-
       const { positions, poolInitInfo, rewards } = fixture.getInfos();
 
-      const pool = await testCtx.whirlpoolClient.getPool(poolInitInfo.whirlpoolPda.publicKey);
-      const position = await testCtx.whirlpoolClient.getPosition(positions[0].publicKey);
-
-      const positionDataBefore = await testCtx.whirlpoolCtx.fetcher.getPosition(
-        position.getAddress(),
-        true
-      );
-
+      const pool = await testCtx.whirlpoolClient.getPool(poolInitInfo.whirlpoolPda.publicKey, true);
+      const position = await testCtx.whirlpoolClient.getPosition(positions[0].publicKey, true);
       const otherWallet = anchor.web3.Keypair.generate();
+      const preCollectPoolData = pool.getData();
 
-      const poolData = await pool.refreshData();
-      const positionData = await position.refreshData();
-      const tickLowerData = position.getLowerTickData();
-      const tickUpperData = position.getLowerTickData();
+      await (
+        await position.collectRewards(
+          rewards.map((r) => r.rewardMint),
+          true,
+          undefined,
+          otherWallet.publicKey,
+          testCtx.provider.wallet.publicKey,
+          testCtx.provider.wallet.publicKey,
+          true
+        )
+      ).buildAndExecute();
 
+      // Verify the results fetched is the same as SDK estimate if the timestamp is the same
+      const postCollectPoolData = await pool.refreshData();
       const quote = collectRewardsQuote({
-        whirlpool: poolData,
-        position: positionData,
-        tickLower: tickLowerData,
-        tickUpper: tickUpperData,
+        whirlpool: preCollectPoolData,
+        position: position.getData(),
+        tickLower: position.getLowerTickData(),
+        tickUpper: position.getUpperTickData(),
+        timeStampInSeconds: postCollectPoolData.rewardLastUpdatedTimestamp,
       });
 
-      assert.notEqual(positionDataBefore, null);
-
-      const tx = await position.collectRewards(
-        rewards.map((r) => r.rewardMint),
-        true,
-        undefined,
-        otherWallet.publicKey,
-        testCtx.provider.wallet.publicKey,
-        testCtx.provider.wallet.publicKey,
-        true
-      );
-
-      await tx.buildAndExecute();
-
-      const positionDataAfter = await testCtx.whirlpoolCtx.fetcher.getPosition(
-        position.getAddress(),
-        true
-      );
-
-      assert.notEqual(positionDataAfter, null);
-
-      const r0Pubkey = await deriveATA(otherWallet.publicKey, rewards[0].rewardMint);
-      const r0Account = await testCtx.whirlpoolCtx.fetcher.getTokenInfo(r0Pubkey, true);
-      assert.ok(quote[0] && r0Account && r0Account.amount.eq(quote[0]));
-
-      const r1Pubkey = await deriveATA(otherWallet.publicKey, rewards[1].rewardMint);
-      const r1Account = await testCtx.whirlpoolCtx.fetcher.getTokenInfo(r1Pubkey, true);
-      assert.ok(quote[1] && r1Account && r1Account.amount.eq(quote[1]));
-
-      const r2Pubkey = await deriveATA(otherWallet.publicKey, rewards[2].rewardMint);
-      const r2Account = await testCtx.whirlpoolCtx.fetcher.getTokenInfo(r2Pubkey, true);
-      assert.ok(quote[2] && r2Account && r2Account.amount.eq(quote[2]));
+      for (let i = 0; i < NUM_REWARDS; i++) {
+        const rewardATA = await deriveATA(otherWallet.publicKey, rewards[i].rewardMint);
+        const rewardTokenAccount = await testCtx.whirlpoolCtx.fetcher.getTokenInfo(rewardATA, true);
+        assert.equal(rewardTokenAccount?.amount.toString(), quote[i]?.toString());
+      }
     });
   });
 });


### PR DESCRIPTION
- Do not append updateFee ix if liquidity is zero in collectFee & collectReward util fn
- Fix collectRewardQuote use an estimated rewardGlobal accrued till the current timestamp
- Prior to this patch, collectRewardQuote is understating amount collected from call
- Fix unit-tests to strictly verify amount collected from collectFee, collectReward and closePosition

## Testing
- Verified using refactored / new unit-tests that compares the collectRewardsQuote value to the actual collected amount . The quote is generated using the same timestamp as the one executed on-chain in the test case to ensure the clock values are the same.
- Verified that Position.collectReward & collectFees will not fail on-chain if position liquidity is zero & updateFeesAndRewards is enabled
- Ran all the other tests, all pass.