### PR TITLE
expose a lot of internal functionality

### DIFF
--- a/sdk/src/impl/index.ts
+++ b/sdk/src/impl/index.ts
@@ -1,0 +1,4 @@
+export * from "./position-impl";
+export * from "./util";
+export * from "./whirlpool-client-impl";
+export * from "./whirlpool-impl";

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,7 +1,7 @@
 import Decimal from "decimal.js";
 
 export * from "./context";
-export * from "./impl/position-impl";
+export * from "./impl";
 export * from "./ix";
 export * from "./network/public";
 export * from "./quotes/public";

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -5,6 +5,7 @@ export * from "./impl/position-impl";
 export * from "./ix";
 export * from "./network/public";
 export * from "./quotes/public";
+export * from "./quotes/swap";
 export * from "./types/public";
 export * from "./types/public/anchor-types";
 export * from "./utils/public";

--- a/sdk/src/quotes/swap/index.ts
+++ b/sdk/src/quotes/swap/index.ts
@@ -1,0 +1,4 @@
+export * from "./swap-manager"
+export * from "./swap-quote-impl"
+export * from "./tick-array-index"
+export * from "./tick-array-sequence"

--- a/sdk/src/utils/public/tick-utils.ts
+++ b/sdk/src/utils/public/tick-utils.ts
@@ -1,3 +1,4 @@
+import { PDA } from "@orca-so/common-sdk";
 import { PublicKey } from "@solana/web3.js";
 import invariant from "tiny-invariant";
 import { AccountFetcher } from "../../network/public";
@@ -198,14 +199,14 @@ export class TickArrayUtil {
    * @param whirlpoolAddress - Address for the Whirlpool for these tick-arrays
    * @returns TickArray PDAs for the sequence`
    */
-  public static async getTickArrayPDAs(
+  public static getTickArrayPDAs(
     tick: number,
     tickSpacing: number,
     numOfTickArrays: number,
     programId: PublicKey,
     whirlpoolAddress: PublicKey,
     aToB: boolean
-  ) {
+  ): PDA[] {
     let arrayIndexList = [...Array(numOfTickArrays).keys()];
     if (aToB) {
       arrayIndexList = arrayIndexList.map((value) => -value);

--- a/sdk/src/whirlpool-client.ts
+++ b/sdk/src/whirlpool-client.ts
@@ -1,6 +1,6 @@
 import { Percentage, TransactionBuilder } from "@orca-so/common-sdk";
 import { Address } from "@project-serum/anchor";
-import { PublicKey } from "@solana/web3.js";
+import { PublicKey, TransactionInstruction } from "@solana/web3.js";
 import { WhirlpoolContext } from "./context";
 import { WhirlpoolClientImpl } from "./impl/whirlpool-client-impl";
 import { DevFeeSwapInput, SwapInput } from "./instructions";
@@ -271,6 +271,13 @@ export interface Whirlpool {
     wallet?: PublicKey,
     payer?: PublicKey
   ) => Promise<TransactionBuilder>;
+
+  getSwapIx(
+    input: SwapInput,
+    inputAccount: PublicKey,
+    outputAccount: PublicKey,
+    wallet: PublicKey
+  ): Promise<TransactionInstruction>;
 }
 
 /**


### PR DESCRIPTION
It's a bit difficult to build a router based on orca whirpool, because one needs access to a bunch of it's internal methods. This PR makes a bunch of internal modules public and adds a new utility method to create whirpool swap ix without any convenince /magic that could cause a network request.