### PR TITLE
Remove async from TickUtil.getTickArrayPDAs

### DIFF
--- a/sdk/src/quotes/public/collect-rewards-quote.ts
+++ b/sdk/src/quotes/public/collect-rewards-quote.ts
@@ -81,9 +81,9 @@ export function collectRewardsQuote(param: CollectRewardsQuoteParam): CollectRew
       rewardGrowthsBelowX64 =
         tickCurrentIndex < tickLowerIndex
           ? MathUtil.subUnderflowU128(
-            adjustedRewardGrowthGlobalX64,
-            tickLowerRewardGrowthsOutsideX64
-          )
+              adjustedRewardGrowthGlobalX64,
+              tickLowerRewardGrowthsOutsideX64
+            )
           : tickLowerRewardGrowthsOutsideX64;
     }
 
@@ -93,9 +93,9 @@ export function collectRewardsQuote(param: CollectRewardsQuoteParam): CollectRew
         tickCurrentIndex < tickUpperIndex
           ? tickUpperRewardGrowthsOutsideX64
           : MathUtil.subUnderflowU128(
-            adjustedRewardGrowthGlobalX64,
-            tickUpperRewardGrowthsOutsideX64
-          );
+              adjustedRewardGrowthGlobalX64,
+              tickUpperRewardGrowthsOutsideX64
+            );
     }
 
     const rewardGrowthInsideX64 = MathUtil.subUnderflowU128(

--- a/sdk/src/utils/public/tick-utils.ts
+++ b/sdk/src/utils/public/tick-utils.ts
@@ -7,7 +7,7 @@ import {
   MIN_TICK_INDEX,
   TickArrayData,
   TickData,
-  TICK_ARRAY_SIZE
+  TICK_ARRAY_SIZE,
 } from "../../types/public";
 import { PDAUtil } from "./pda-utils";
 
@@ -21,7 +21,7 @@ enum TickSearchDirection {
  * @category Whirlpool Utils
  */
 export class TickUtil {
-  private constructor() { }
+  private constructor() {}
 
   /**
    * Get the offset index to access a tick at a given tick-index in a tick-array


### PR DESCRIPTION
TickUtil.getTickArrayPDAs to be a sync method and should not be async

This is a follow up to max's comment here - https://github.com/orca-so/whirlpools/pull/74
