### PR TITLE
Handle liquidity swapping edge case across initialized tick boundary

### DIFF
--- a/programs/whirlpool/src/manager/swap_manager.rs
+++ b/programs/whirlpool/src/manager/swap_manager.rs
@@ -172,7 +172,7 @@ pub fn swap(
             } else {
                 next_tick_index
             };
-        } else {
+        } else if swap_computation.next_price != curr_sqrt_price {
             curr_tick_index = tick_index_from_sqrt_price(&swap_computation.next_price);
         }
 


### PR DESCRIPTION
- Addresses edge case where swapping liquidity across an initialized tick boundary could cross the tick boundary but remain on the initialized tick.
- These edge cases could cause the fees and rewards in some pools to be calculated incorrectly due to actual liquidity diverging from calculated liquidity. As part of this fix, all pools were audited to ensure each pool contained appropriate liquidity and no user deposits were lost.
- This update was deployed to mainnet on [[Block #168,120,167](https://explorer.solana.com/block/168120167)](https://explorer.solana.com/block/168120167).