### PR TITLE
bump to v0.8.2

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@orca-so/whirlpools-sdk",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Typescript SDK to interact with Orca's Whirlpool program.",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
     "@metaplex-foundation/mpl-token-metadata": "1.2.5",
-    "@orca-so/common-sdk": "^0.1.9",
+    "@orca-so/common-sdk": "^0.1.10",
     "@project-serum/anchor": "~0.25.0",
     "@solana/spl-token": "^0.1.8",
     "@solana/web3.js": "1.66.0",

--- a/sdk/tests/integration/open_position_with_metadata.test.ts
+++ b/sdk/tests/integration/open_position_with_metadata.test.ts
@@ -68,7 +68,7 @@ describe("open_position_with_metadata", () => {
     assert.ok(metadata.data.updateAuthority === "3axbTs2z5GBy6usVbNVoqEgZMng3vZvMnAoX29BFfwhr");
     assert.ok(metadata.data.mint === positionMint.toString());
     assert.ok(
-      metadata.data.data.uri === `https://arweave.net/KZlsubXZyzeSYi2wJhyL7SY-DAot_OXhfWSYQGLmmOc`
+      metadata.data.data.uri === `https://arweave.net/E19ZNY2sqMqddm1Wx7mrXPUZ0ZZ5ISizhebb0UsVEws`
     );
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -593,10 +593,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@orca-so/common-sdk@^0.1.9":
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/@orca-so/common-sdk/-/common-sdk-0.1.9.tgz#d55d843e5a5c2b2a21ea22a1bdb2c0d2f24524e3"
-  integrity sha512-p/qpUy4coo1lXShyBVEACcRk63tw48iAJBjEvCdjQm0fRJqN3EID17wSWZ1JpR/Op4UoYUYPMTYPi7oDRA3EJg==
+"@orca-so/common-sdk@^0.1.10":
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/@orca-so/common-sdk/-/common-sdk-0.1.10.tgz#c5c926ba81bbb3d6eab96e58353873f1c1989b26"
+  integrity sha512-0rFFt0hAuA+ucWSNpxKUJ2oKduhtlUnE/S0xiOC1uBj5Ngw0ka90i/fjJ8Lz4SxjxSUQkr+Eqic8eOY13qB7mQ==
   dependencies:
     "@project-serum/anchor" "~0.25.0"
     "@solana/spl-token" "0.1.8"


### PR DESCRIPTION
- use common-sdk v0.1.10
- fix: open_position_with_metadata integration test (update URI of the metadata of position NFTs)
  related: https://github.com/orca-so/whirlpools/pull/83
- ```anchor test``` passed