### PR TITLE
fix: test cases (tokenAIsNative related)

### DIFF
--- a/sdk/tests/utils/fixture.ts
+++ b/sdk/tests/utils/fixture.ts
@@ -1,5 +1,5 @@
 import { PublicKey, Keypair } from "@solana/web3.js";
-import { u64 } from "@solana/spl-token";
+import { NATIVE_MINT, u64 } from "@solana/spl-token";
 import { InitConfigParams, InitPoolParams, TickUtil, WhirlpoolContext } from "../../src";
 import {
   FundedPositionInfo,
@@ -54,7 +54,7 @@ export class WhirlpoolTestFixture {
         tickSpacing,
         initialSqrtPrice,
         undefined,
-        tokenAIsNative
+        tokenAIsNative ? NATIVE_MINT : undefined
       );
 
     this.poolInitInfo = poolInitInfo;

--- a/sdk/tests/utils/swap-test-utils.ts
+++ b/sdk/tests/utils/swap-test-utils.ts
@@ -39,7 +39,7 @@ export async function setupSwapTest(setup: SwapTestPoolParams, tokenAIsNative = 
     setup.tickSpacing,
     setup.initSqrtPrice,
     setup.tokenMintAmount,
-    NATIVE_MINT
+    tokenAIsNative ? NATIVE_MINT : undefined
   );
 
   const whirlpool = await setup.client.getPool(whirlpoolPda.publicKey, true);

--- a/sdk/tests/utils/test-builders.ts
+++ b/sdk/tests/utils/test-builders.ts
@@ -59,13 +59,12 @@ export const createInOrderMints = async (context: WhirlpoolContext, reuseTokenA?
   const tokenXMintPubKey = reuseTokenA ?? (await createMint(provider));
 
   // ensure reuseTokenA is the first mint if reuseTokenA is provided
-  while (true) {
+  let ordered;
+  do {
     const tokenYMintPubKey = await createMint(provider);
-    const ordered = PoolUtil.orderMints(tokenXMintPubKey, tokenYMintPubKey).map(AddressUtil.toPubKey);
-    if (!reuseTokenA || ordered[0].equals(reuseTokenA)) {
-      return ordered;
-    }
-  }
+    ordered = PoolUtil.orderMints(tokenXMintPubKey, tokenYMintPubKey).map(AddressUtil.toPubKey);
+  } while (!!reuseTokenA && !ordered[0].equals(reuseTokenA));
+  return ordered;
 };
 
 export const generateDefaultInitPoolParams = async (

--- a/sdk/tests/utils/test-builders.ts
+++ b/sdk/tests/utils/test-builders.ts
@@ -56,9 +56,16 @@ export const generateDefaultConfigParams = (
 
 export const createInOrderMints = async (context: WhirlpoolContext, reuseTokenA?: PublicKey) => {
   const provider = context.provider;
-  const tokenXMintPubKey = reuseTokenA || (await createMint(provider));
-  const tokenYMintPubKey = await createMint(provider);
-  return PoolUtil.orderMints(tokenXMintPubKey, tokenYMintPubKey).map(AddressUtil.toPubKey);
+  const tokenXMintPubKey = reuseTokenA ?? (await createMint(provider));
+
+  // ensure reuseTokenA is the first mint if reuseTokenA is provided
+  while (true) {
+    const tokenYMintPubKey = await createMint(provider);
+    const ordered = PoolUtil.orderMints(tokenXMintPubKey, tokenYMintPubKey).map(AddressUtil.toPubKey);
+    if (!reuseTokenA || ordered[0].equals(reuseTokenA)) {
+      return ordered;
+    }
+  }
 };
 
 export const generateDefaultInitPoolParams = async (


### PR DESCRIPTION
- tokenAIsNative was extended to reuseTokenA, but there was a bug that was fixed.
- Change the generation logic so that the mint specified in reuseTokenA is always tokenA (first mint). 
  Removed cause of accidental SOL-SPL pool test failures.
