### PR TITLE
optimize price module perf

### DIFF
--- a/sdk/src/prices/calculate-pool-prices.ts
+++ b/sdk/src/prices/calculate-pool-prices.ts
@@ -1,5 +1,5 @@
 import { AddressUtil, DecimalUtil, Percentage } from "@orca-so/common-sdk";
-import { Address, translateAddress } from "@project-serum/anchor";
+import { Address } from "@project-serum/anchor";
 import { u64 } from "@solana/spl-token";
 import { PublicKey } from "@solana/web3.js";
 import Decimal from "decimal.js";
@@ -119,10 +119,10 @@ export function calculatePricesForQuoteToken(
 
       // The quote token is the output token.
       // Therefore, if the quote token is mintB, then we are swapping from mintA to mintB.
-      const aToB = translateAddress(mintB).equals(quoteTokenMint);
+      const aToB = AddressUtil.toPubKey(mintB).equals(quoteTokenMint);
 
       const baseTokenMint = aToB ? mintA : mintB;
-      const poolCandidate = mostLiquidPools[translateAddress(baseTokenMint).toBase58()];
+      const poolCandidate = mostLiquidPools[AddressUtil.toString(baseTokenMint)];
       if (poolCandidate === undefined) {
         return [mint.toBase58(), null];
       }

--- a/sdk/src/prices/price-module.ts
+++ b/sdk/src/prices/price-module.ts
@@ -295,7 +295,7 @@ export class PriceModuleUtils {
       const orderB = getQuoteTokenOrder(pool.tokenMintB);
 
       if (orderA === orderB) {
-        // neigher tokenMintA nor tokenMintB is a quote token
+        // neither tokenMintA nor tokenMintB is a quote token
         return;
       }
 

--- a/sdk/tests/integration/get_pool_prices.test.ts
+++ b/sdk/tests/integration/get_pool_prices.test.ts
@@ -24,7 +24,7 @@ describe("get_pool_prices", () => {
 
   async function fetchMaps(context: WhirlpoolContext, mints: PublicKey[], config: GetPricesConfig) {
     const poolMap = await PriceModuleUtils.fetchPoolDataFromMints(context, mints, config);
-    const tickArrayMap = await PriceModuleUtils.fetchTickArraysForPools(context, poolMap);
+    const tickArrayMap = await PriceModuleUtils.fetchTickArraysForPools(context, poolMap, config);
     const decimalsMap = await PriceModuleUtils.fetchDecimalsForMints(context, mints);
 
     return { poolMap, tickArrayMap, decimalsMap };
@@ -86,7 +86,7 @@ describe("get_pool_prices", () => {
     );
 
     assert.equal(Object.keys(poolMap).length, 1);
-    assert.equal(Object.keys(tickArrayMap).length, 3);
+    assert.equal(Object.keys(tickArrayMap).length, 1); // mintA to mintB direction
 
     assert.equal(Object.keys(priceMap).length, 2);
   });
@@ -143,8 +143,12 @@ describe("get_pool_prices", () => {
       thresholdConfig
     );
 
+    // mints are sorted (mintKeys[0] < mintKeys[1] < mintKeys[2])
+    const fetchedTickArrayForPool0 = 1; // A to B direction (mintKeys[0] to mintKeys[1])
+    const fetchedTickArrayForPool1 = 3; // B to A direction (mintKeys[2] to mintKeys[1])
+
     assert.equal(Object.keys(poolMap).length, 2);
-    assert.equal(Object.keys(tickArrayMap).length, 6);
+    assert.equal(Object.keys(tickArrayMap).length, fetchedTickArrayForPool0 + fetchedTickArrayForPool1);
     assert.equal(Object.keys(priceMap).length, 3);
   });
 
@@ -261,9 +265,12 @@ describe("get_pool_prices", () => {
       thresholdConfig
     );
 
+    // mints are sorted (mintKeys[0] < mintKeys[1] < mintKeys[2])
+    const fetchedTickArrayForPool0 = 1; // A to B direction (mintKeys[0] to mintKeys[1])
+    const fetchedTickArrayForPool1 = 1; // A to B direction (mintKeys[1] to mintKeys[2])
+    
     assert.equal(Object.keys(poolMap).length, 2);
-    assert.equal(Object.keys(tickArrayMap).length, 6);
-
+    assert.equal(Object.keys(tickArrayMap).length, fetchedTickArrayForPool0 + fetchedTickArrayForPool1);
     assert.equal(Object.keys(priceMap).length, 3);
   });
 });


### PR DESCRIPTION
Reflect performance-enhancing changes that were necessary to integrate into the UI.

### optimize getMostLiquidPool
Eliminate PDA calculations by first calculating the most liquid pool for each pair with quoteToken, rather than checking for its existence in the poolMap while generating PDAs.

### optimize fetchTickArraysForPools
Only fetch TickArrays in the necessary direction, since swap is only attempted in the direction of the quoteToken with the higher priority.

Although the fetching of TickArray can be done in parallel, we want to minimize the number of account fetched because it takes time to decode and parse a 10KB account.