### PR TITLE
Get anchor account sizes by name instead of IDL index

### DIFF
--- a/sdk/src/network/public/fetcher.ts
+++ b/sdk/src/network/public/fetcher.ts
@@ -10,10 +10,9 @@ import {
   TickArrayData,
   WhirlpoolData,
   WhirlpoolsConfigData,
-  WHIRLPOOL_ACCOUNT_SIZE,
   WHIRLPOOL_CODER,
 } from "../..";
-import { FeeTierData } from "../../types/public";
+import { FeeTierData, getAccountSize } from "../../types/public";
 import {
   ParsableEntity,
   ParsableFeeTier,
@@ -221,7 +220,7 @@ export class AccountFetcher {
     configId,
   }: ListWhirlpoolParams): Promise<WhirlpoolAccount[]> {
     const filters = [
-      { dataSize: WHIRLPOOL_ACCOUNT_SIZE },
+      { dataSize: getAccountSize(AccountName.Whirlpool) },
       {
         memcmp: WHIRLPOOL_CODER.memcmp(
           AccountName.Whirlpool,

--- a/sdk/src/types/public/anchor-types.ts
+++ b/sdk/src/types/public/anchor-types.ts
@@ -32,10 +32,13 @@ const IDL = WhirlpoolIDL as Idl;
 export const WHIRLPOOL_CODER = new BorshAccountsCoder(IDL);
 
 /**
- * Size of the Whirlpool account in bytes.
- * @category Solana Accounts
+ * Get the size of an account owned by the Whirlpool program in bytes.
+ * @param accountName Whirlpool account name
+ * @returns Size in bytes of the account
  */
-export const WHIRLPOOL_ACCOUNT_SIZE = WHIRLPOOL_CODER.size(IDL.accounts![4]);
+export function getAccountSize(accountName: AccountName) {
+  return WHIRLPOOL_CODER.size(IDL.accounts!.find((account) => account.name === accountName)!);
+}
 
 /**
  * @category Solana Accounts

--- a/sdk/src/types/public/anchor-types.ts
+++ b/sdk/src/types/public/anchor-types.ts
@@ -37,8 +37,32 @@ export const WHIRLPOOL_CODER = new BorshAccountsCoder(IDL);
  * @returns Size in bytes of the account
  */
 export function getAccountSize(accountName: AccountName) {
-  return WHIRLPOOL_CODER.size(IDL.accounts!.find((account) => account.name === accountName)!);
+  const size = WHIRLPOOL_CODER.size(IDL.accounts!.find((account) => account.name === accountName)!);
+  return size + RESERVED_BYTES[accountName];
 }
+
+/**
+ * Reserved bytes for each account used for calculating the account size.
+ */
+const RESERVED_BYTES: ReservedBytes = {
+  [AccountName.WhirlpoolsConfig]: 2,
+  [AccountName.Position]: 0,
+  [AccountName.TickArray]: 0,
+  [AccountName.Whirlpool]: 0,
+  [AccountName.FeeTier]: 0,
+  [AccountName.PositionBundle]: 64,
+};
+
+type ReservedBytes = {
+  [name in AccountName]: number;
+};
+
+/**
+ * Size of the Whirlpool account in bytes.
+ * @deprecated Please use {@link getAccountSize} instead.
+ * @category Solana Accounts
+ */
+export const WHIRLPOOL_ACCOUNT_SIZE = getAccountSize(AccountName.Whirlpool);
 
 /**
  * @category Solana Accounts

--- a/sdk/tests/sdk/types/anchor-types.test.ts
+++ b/sdk/tests/sdk/types/anchor-types.test.ts
@@ -3,12 +3,26 @@ import { AccountName, getAccountSize } from "../../../src";
 
 describe("anchor-types", () => {
   it("all whirlpool account names exist in IDL", async () => {
-    try {
-      for (const name of Object.values(AccountName)) {
-        getAccountSize(name);
+    type ExpectedSize = { [a in AccountName]: number };
+    const expectedSizes: ExpectedSize = {
+      [AccountName.WhirlpoolsConfig]: 108,
+      [AccountName.Position]: 216,
+      [AccountName.TickArray]: 9988,
+      [AccountName.Whirlpool]: 653,
+      [AccountName.FeeTier]: 44,
+      [AccountName.PositionBundle]: 136,
+    };
+    Object.values(AccountName).forEach((name) => {
+      let actualSize;
+      try {
+        assert.equal(
+          getAccountSize(name),
+          expectedSizes[name],
+          `For ${name} expected ${expectedSizes[name]} but got ${actualSize}`
+        );
+      } catch (e) {
+        assert.fail(`Error fetching size for ${name}: ${e}`);
       }
-    } catch (e) {
-      assert.fail(`Account name ${e} does not exist in IDL`);
-    }
+    });
   });
 });

--- a/sdk/tests/sdk/types/anchor-types.test.ts
+++ b/sdk/tests/sdk/types/anchor-types.test.ts
@@ -1,0 +1,14 @@
+import * as assert from "assert";
+import { AccountName, getAccountSize } from "../../../src";
+
+describe("anchor-types", () => {
+  it("all whirlpool account names exist in IDL", async () => {
+    try {
+      for (const name of Object.values(AccountName)) {
+        getAccountSize(name);
+      }
+    } catch (e) {
+      assert.fail(`Account name ${e} does not exist in IDL`);
+    }
+  });
+});


### PR DESCRIPTION
Previously whirlpool account size was hardcoded to be an IDL index with the assumption that we would not add more account types. With `PositionBundle` added, the ordering of accounts on the IDL changed.

This patch fetches account sizes by the `AccountName` instead and adds a test to verify all `AccountName` enums have an IDL account entry.