### PR TITLE
Fix usage of actual size variable in test used for logging

### DIFF
--- a/sdk/tests/sdk/types/anchor-types.test.ts
+++ b/sdk/tests/sdk/types/anchor-types.test.ts
@@ -13,10 +13,10 @@ describe("anchor-types", () => {
       [AccountName.PositionBundle]: 136,
     };
     Object.values(AccountName).forEach((name) => {
-      let actualSize;
       try {
+        const actualSize = getAccountSize(name);
         assert.equal(
-          getAccountSize(name),
+          actualSize,
           expectedSizes[name],
           `For ${name} expected ${expectedSizes[name]} but got ${actualSize}`
         );


### PR DESCRIPTION
Fixing small issue in the test where `actualSize` variable wasn't being populated.