### PR TITLE
fix testing two hop swaps

### DIFF
--- a/sdk/tests/utils/token.ts
+++ b/sdk/tests/utils/token.ts
@@ -175,12 +175,25 @@ export async function createAndMintToAssociatedTokenAccount(
     return tokenAccount;
   }
 
-  const tokenAccount = await createAssociatedTokenAccount(
-    provider,
-    mint,
-    destinationWalletKey,
-    payerKey
-  );
+  const tokenAccounts = await provider.connection.getParsedTokenAccountsByOwner(destinationWalletKey, {
+    programId: TOKEN_PROGRAM_ID,
+  });
+
+  let tokenAccount = tokenAccounts.value.map((account) => {
+    if(account.account.data.parsed.info.mint === mint.toString()) {
+      return account.pubkey
+    }
+  }).filter(Boolean)[0];
+
+  if(!tokenAccount) {
+    tokenAccount = await createAssociatedTokenAccount(
+      provider,
+      mint,
+      destinationWalletKey,
+      payerKey
+    );
+  }
+
   await mintToByAuthority(provider, mint, tokenAccount, new u64(amount.toString()));
   return tokenAccount;
 }


### PR DESCRIPTION
If two pools are initialized in order to test two hop swaps it fails upon initializing the second pool using `initTestPool` because the token account for the reused token account A has already been created for pool one.

This pull requests reuses an already existing token account thereby enabling testing two pool swaps and initializing two pools in the same test that share the same tokenA. 

Context:
We are submoduling the whirlpools repo to test an integration, reusing provided test initialisers.