### PR TITLE
add optional position mint params

### DIFF
--- a/sdk/src/impl/whirlpool-impl.ts
+++ b/sdk/src/impl/whirlpool-impl.ts
@@ -281,7 +281,7 @@ export class WhirlpoolImpl implements Whirlpool {
       `upper tick ${tickUpper} is not an initializable tick for tick-spacing ${whirlpool.tickSpacing}`
     );
 
-    const positionMintKeypair =  Keypair.generate();
+    const positionMintKeypair = Keypair.generate();
     const positionMintPubkey = positionMint ?? positionMintKeypair.publicKey;
     const positionPda = PDAUtil.getPosition(
       this.ctx.program.programId,

--- a/sdk/src/impl/whirlpool-impl.ts
+++ b/sdk/src/impl/whirlpool-impl.ts
@@ -94,7 +94,8 @@ export class WhirlpoolImpl implements Whirlpool {
     tickUpper: number,
     liquidityInput: IncreaseLiquidityInput,
     wallet?: Address,
-    funder?: Address
+    funder?: Address,
+    positionMint?: Keypair
   ) {
     await this.refresh();
     return this.getOpenPositionWithOptMetadataTx(
@@ -111,8 +112,8 @@ export class WhirlpoolImpl implements Whirlpool {
     tickUpper: number,
     liquidityInput: IncreaseLiquidityInput,
     sourceWallet?: Address,
-    positionWallet?: Address,
-    funder?: Address
+    funder?: Address,
+    positionMint?: Keypair
   ) {
     await this.refresh();
     return this.getOpenPositionWithOptMetadataTx(
@@ -121,7 +122,8 @@ export class WhirlpoolImpl implements Whirlpool {
       liquidityInput,
       !!sourceWallet ? AddressUtil.toPubKey(sourceWallet) : this.ctx.wallet.publicKey,
       !!funder ? AddressUtil.toPubKey(funder) : this.ctx.wallet.publicKey,
-      true
+      true,
+      positionMint
     );
   }
 
@@ -253,7 +255,8 @@ export class WhirlpoolImpl implements Whirlpool {
     liquidityInput: IncreaseLiquidityInput,
     wallet: PublicKey,
     funder: PublicKey,
-    withMetadata: boolean = false
+    withMetadata: boolean = false,
+    positionMint?: Keypair
   ): Promise<{ positionMint: PublicKey; tx: TransactionBuilder }> {
     invariant(TickUtil.checkTickInBounds(tickLower), "tickLower is out of bounds.");
     invariant(TickUtil.checkTickInBounds(tickUpper), "tickUpper is out of bounds.");
@@ -276,7 +279,7 @@ export class WhirlpoolImpl implements Whirlpool {
       `upper tick ${tickUpper} is not an initializable tick for tick-spacing ${whirlpool.tickSpacing}`
     );
 
-    const positionMintKeypair = Keypair.generate();
+    const positionMintKeypair = positionMint ?? Keypair.generate();
     const positionPda = PDAUtil.getPosition(
       this.ctx.program.programId,
       positionMintKeypair.publicKey

--- a/sdk/src/whirlpool-client.ts
+++ b/sdk/src/whirlpool-client.ts
@@ -220,7 +220,7 @@ export interface Whirlpool {
     liquidityInput: IncreaseLiquidityInput,
     wallet?: Address,
     funder?: Address,
-    positionMint?: Keypair
+    positionMint?: PublicKey
   ) => Promise<{ positionMint: PublicKey; tx: TransactionBuilder }>;
 
   /**
@@ -244,7 +244,7 @@ export interface Whirlpool {
     liquidityInput: IncreaseLiquidityInput,
     wallet?: Address,
     funder?: Address,
-    positionMint?: Keypair
+    positionMint?: PublicKey
   ) => Promise<{ positionMint: PublicKey; tx: TransactionBuilder }>;
 
   /**

--- a/sdk/src/whirlpool-client.ts
+++ b/sdk/src/whirlpool-client.ts
@@ -1,6 +1,6 @@
 import { Address } from "@coral-xyz/anchor";
 import { Percentage, TransactionBuilder } from "@orca-so/common-sdk";
-import {Keypair, PublicKey } from "@solana/web3.js";
+import { PublicKey } from "@solana/web3.js";
 import { WhirlpoolContext } from "./context";
 import { WhirlpoolClientImpl } from "./impl/whirlpool-client-impl";
 import { DevFeeSwapInput, SwapInput } from "./instructions";

--- a/sdk/src/whirlpool-client.ts
+++ b/sdk/src/whirlpool-client.ts
@@ -1,6 +1,6 @@
 import { Address } from "@coral-xyz/anchor";
 import { Percentage, TransactionBuilder } from "@orca-so/common-sdk";
-import { PublicKey } from "@solana/web3.js";
+import {Keypair, PublicKey } from "@solana/web3.js";
 import { WhirlpoolContext } from "./context";
 import { WhirlpoolClientImpl } from "./impl/whirlpool-client-impl";
 import { DevFeeSwapInput, SwapInput } from "./instructions";
@@ -211,6 +211,7 @@ export interface Whirlpool {
    * @param liquidityInput - an InputLiquidityInput type to define the desired liquidity amount to deposit
    * @param wallet - the wallet to withdraw tokens to deposit into the position and house the position token. If null, the WhirlpoolContext wallet is used.
    * @param funder - the wallet that will fund the cost needed to initialize the position. If null, the WhirlpoolContext wallet is used.
+   * @param positionMint - the mint address of the position token to be created. If null, a new mint address will be created.
    * @return `positionMint` - the position to be created. `tx` - The transaction containing the instructions to perform the operation on chain.
    */
   openPosition: (
@@ -218,7 +219,8 @@ export interface Whirlpool {
     tickUpper: number,
     liquidityInput: IncreaseLiquidityInput,
     wallet?: Address,
-    funder?: Address
+    funder?: Address,
+    positionMint?: Keypair
   ) => Promise<{ positionMint: PublicKey; tx: TransactionBuilder }>;
 
   /**
@@ -233,6 +235,7 @@ export interface Whirlpool {
    * @param liquidityInput - input that defines the desired liquidity amount and maximum tokens willing to be to deposited.
    * @param wallet - the wallet to withdraw tokens to deposit into the position and house the position token. If null, the WhirlpoolContext wallet is used.
    * @param funder - the wallet that will fund the cost needed to initialize the position. If null, the WhirlpoolContext wallet is used.
+   * @param positionMint - the mint address of the position token to be created. If null, a new mint address will be created.
    * @return `positionMint` - the position to be created. `tx` - The transaction containing the instructions to perform the operation on chain.
    */
   openPositionWithMetadata: (
@@ -240,7 +243,8 @@ export interface Whirlpool {
     tickUpper: number,
     liquidityInput: IncreaseLiquidityInput,
     wallet?: Address,
-    funder?: Address
+    funder?: Address,
+    positionMint?: Keypair
   ) => Promise<{ positionMint: PublicKey; tx: TransactionBuilder }>;
 
   /**


### PR DESCRIPTION
Add an optional parameter to specify the positionMint instead of generating it internally. This allows the ability to assign an ephemeral keypair that can be saved for later execution in the case of a multi-sig wallet.