### PR TITLE
Fix a div by zero bug in increaseLiquidityQuoteByInputToken calculations

### DIFF
--- a/sdk/src/utils/position-util.ts
+++ b/sdk/src/utils/position-util.ts
@@ -31,7 +31,7 @@ export class PositionUtil {
     tickLowerIndex: number,
     tickUpperIndex: number
   ): PositionStatus {
-    if (tickCurrentIndex < tickLowerIndex) {
+    if (tickCurrentIndex <= tickLowerIndex) {
       return PositionStatus.BelowRange;
     } else if (tickCurrentIndex < tickUpperIndex) {
       return PositionStatus.InRange;


### PR DESCRIPTION
There is currently an edge case in the `increaseLiquidityQuoteByInputToken` function that could create a div-by-zero error. This specific case happens when (1) specifying tokenB input, and (2) the `tickLowerIndex` is equal to `tickCurrentIndex`.

Basically what happens in this case is that this quote is calculated as being in-range which then calls `getLiquidityFromTokenB` with  `sqrtPriceLowerX64` and `sqrtPriceX64` that are equal to each other.

https://github.com/orca-so/whirlpools/blob/61b262de70a68cc2169fcdd1916fc6f9c484b25c/sdk/src/quotes/public/increase-liquidity-quote.ts#L197

This then causes the denominator (diff between the two sqrtPrices) to be zero which then causes a div-by-zero a few lines later:

https://github.com/orca-so/whirlpools/blob/61b262de70a68cc2169fcdd1916fc6f9c484b25c/sdk/src/utils/position-util.ts#L93

This PR fixes the bug by handling this specific case as a belowRange position preventing the div-by-zero.

Below is a minimal example to reproduce the bug
```ts
import { increaseLiquidityQuoteByInputTokenWithParams, PriceMath } from "@orca-so/whirlpools-sdk"
import { PublicKey } from "@solana/web3.js";
import BN from "bn.js";
import { Percentage } from "@orca-so/common-sdk";

increaseLiquidityQuoteByInputTokenWithParams({
  inputTokenAmount: new BN(1000),
  inputTokenMint: new PublicKey("J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn"),
  sqrtPrice: PriceMath.tickIndexToSqrtPriceX64(0),
  tokenMintA: new PublicKey("So11111111111111111111111111111111111111112"),
  tokenMintB: new PublicKey("J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn"),
  tickLowerIndex: 0,
  tickUpperIndex: 64,
  tickCurrentIndex: 0,
  slippageTolerance: Percentage.fromFraction(0, 1000),
});
```