### PR TITLE
Reduced close position transaction builder to a single transaction

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/whirlpools-sdk",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "Typescript SDK to interact with Orca's Whirlpool program.",
   "license": "Apache-2.0",
   "main": "dist/index.js",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -7,7 +7,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@coral-xyz/anchor": "~0.27.0",
-    "@orca-so/common-sdk": "^0.3.3",
+    "@orca-so/common-sdk": "^0.3.6",
     "@solana/spl-token": "^0.3.8",
     "@solana/web3.js": "^1.75.0",
     "decimal.js": "^10.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,10 +133,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@orca-so/common-sdk@^0.3.6-beta.4":
-  version "0.3.6-beta.4"
-  resolved "https://registry.yarnpkg.com/@orca-so/common-sdk/-/common-sdk-0.3.6-beta.4.tgz#6c043732380f74c632c0b37b48935495dfa03917"
-  integrity sha512-AdKcytBlDCkYiqyfpSPMzM+UxX+enCayn3UlLN5bspWiU3OCBajO8aN/SKRoVTiFwu8+TSCB9qNckVsBbXfScQ==
+"@orca-so/common-sdk@^0.3.6":
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/@orca-so/common-sdk/-/common-sdk-0.3.6.tgz#18ce8176118bdf3dba276e0d5fb8cf9d79aacffa"
+  integrity sha512-Yf4AZqnJI881SmDn2tf/KL0KOcXVuwHsP1pF4O28UyoSgQG1hBHfhNExd6Bn0K3ocv/pIbi215U4zlydtPTJDw==
   dependencies:
     "@solana/spl-token" "^0.3.8"
     "@solana/web3.js" "^1.75.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,10 +133,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@orca-so/common-sdk@^0.3.3":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@orca-so/common-sdk/-/common-sdk-0.3.3.tgz#d208c9a3a77c91f057519dc590c4725b60de5b39"
-  integrity sha512-g4LSOkSjq9IwXgeVB5pV5bbB9DBX8MBJyE2dpv7KE/B2jyFe8yEqjCOk9aTwbM2ftVDLJRH0jBP4z0rKz6oFCQ==
+"@orca-so/common-sdk@^0.3.6-beta.4":
+  version "0.3.6-beta.4"
+  resolved "https://registry.yarnpkg.com/@orca-so/common-sdk/-/common-sdk-0.3.6-beta.4.tgz#6c043732380f74c632c0b37b48935495dfa03917"
+  integrity sha512-AdKcytBlDCkYiqyfpSPMzM+UxX+enCayn3UlLN5bspWiU3OCBajO8aN/SKRoVTiFwu8+TSCB9qNckVsBbXfScQ==
   dependencies:
     "@solana/spl-token" "^0.3.8"
     "@solana/web3.js" "^1.75.0"


### PR DESCRIPTION
Right now the closePosition transaction builder potentially creates two transactions if ATAs need to be created. Tx one contains the CreateATA instructions and tx two contains the instructions related to closing the position.

This PR changes this logic and puts all instructions for closePosition in a single transaction (like we were already doing for collectFees and collectRewards).

@yugure-orca opted for not changing the instruction to CreateATAIdempotent because the logic is fetching the accounts either way. If we want that improvement there is a bigger change needed in `common-sdk`.