### PR TITLE
Close intermediate token accounts of 2-hop swap

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/whirlpools-sdk",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Typescript SDK to interact with Orca's Whirlpool program.",
   "license": "Apache-2.0",
   "main": "dist/index.js",


### PR DESCRIPTION
During a two-hop swap an intermediate token account needs to be created if it does not exist already. If this account did not exist before the amount in this token account will be 0 after the swap. The user did however pay rent for this account in the transaction and needs to manually reclaim this rent by closing the account.

This PR closes any intermediate token accounts that are created during a two-hop swap. Token accounts that were already created before a two-hop swap will be left intact (so they are only closed if they are created in the same transaction). This way the user never has to pay rent to create an intermediate token account during a two-hop swap.

Verified all tests still pass