### PR TITLE
Fix PositionUtil.getPositionStatus bug

### DIFF
--- a/sdk/src/quotes/public/decrease-liquidity-quote.ts
+++ b/sdk/src/quotes/public/decrease-liquidity-quote.ts
@@ -87,8 +87,8 @@ export function decreaseLiquidityQuoteByLiquidityWithParams(
     "tickCurrentIndex is out of bounds."
   );
 
-  const positionStatus = PositionUtil.getPositionStatus(
-    param.tickCurrentIndex,
+  const positionStatus = PositionUtil.getStrictPositionStatus(
+    param.sqrtPrice,
     param.tickLowerIndex,
     param.tickUpperIndex
   );

--- a/sdk/src/quotes/public/increase-liquidity-quote.ts
+++ b/sdk/src/quotes/public/increase-liquidity-quote.ts
@@ -101,8 +101,8 @@ export function increaseLiquidityQuoteByInputTokenWithParams(
     `input token mint ${param.inputTokenMint.toBase58()} does not match any tokens in the provided pool.`
   );
 
-  const positionStatus = PositionUtil.getPositionStatus(
-    param.tickCurrentIndex,
+  const positionStatus = PositionUtil.getStrictPositionStatus(
+    param.sqrtPrice,
     param.tickLowerIndex,
     param.tickUpperIndex
   );

--- a/sdk/tests/sdk/whirlpools/quote/decrease-liquidity-quote.test.ts
+++ b/sdk/tests/sdk/whirlpools/quote/decrease-liquidity-quote.test.ts
@@ -1,0 +1,61 @@
+import *  as assert from "assert";
+import { PriceMath, decreaseLiquidityQuoteByLiquidityWithParams } from "../../../../src";
+import { BN } from "bn.js";
+import { PublicKey } from "@solana/web3.js";
+import { Percentage } from "@orca-so/common-sdk";
+
+describe("edge cases", () => {
+  const tokenMintA = new PublicKey("orcaEKTdK7LKz57vaAYr9QeNsVEPfiu6QeMU1kektZE");
+  const tokenMintB = new PublicKey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+
+  it("sqrtPrice on lower bound", async () => {
+    const quote = decreaseLiquidityQuoteByLiquidityWithParams({
+      liquidity: new BN(100000),
+      sqrtPrice: PriceMath.tickIndexToSqrtPriceX64(0),
+      tickLowerIndex: 0,
+      tickUpperIndex: 64,
+      tickCurrentIndex: 0,
+      slippageTolerance: Percentage.fromFraction(0, 100),
+    });
+
+    assert.ok(quote.tokenEstA.gtn(0));
+    assert.ok(quote.tokenEstB.isZero());
+    assert.ok(quote.tokenMinA.gtn(0));
+    assert.ok(quote.tokenMinB.isZero());
+  });
+
+  it("tickCurrentIndex on lower bound but sqrtPrice not on lower bound", async () => {
+    assert.ok(PriceMath.tickIndexToSqrtPriceX64(1).subn(1).gt(PriceMath.tickIndexToSqrtPriceX64(0)));
+
+    const quote = decreaseLiquidityQuoteByLiquidityWithParams({
+      liquidity: new BN(100000),
+      sqrtPrice: PriceMath.tickIndexToSqrtPriceX64(1).subn(1),
+      tickLowerIndex: 0,
+      tickUpperIndex: 64,
+      tickCurrentIndex: 0,
+      slippageTolerance: Percentage.fromFraction(0, 100),
+    });
+
+    assert.ok(quote.tokenEstA.gtn(0));
+    assert.ok(quote.tokenEstB.gtn(0));
+    assert.ok(quote.tokenMinA.gtn(0));
+    assert.ok(quote.tokenMinB.gtn(0));
+  });
+
+  it("sqrtPrice on upper bound", async () => {
+    const quote = decreaseLiquidityQuoteByLiquidityWithParams({
+      liquidity: new BN(100000),
+      sqrtPrice: PriceMath.tickIndexToSqrtPriceX64(64),
+      tickLowerIndex: 0,
+      tickUpperIndex: 64,
+      tickCurrentIndex: 64,
+      slippageTolerance: Percentage.fromFraction(0, 100),
+    });
+
+    assert.ok(quote.tokenEstA.isZero());
+    assert.ok(quote.tokenEstB.gtn(0));
+    assert.ok(quote.tokenMinA.isZero());
+    assert.ok(quote.tokenMinB.gtn(0));
+  });
+
+});

--- a/sdk/tests/sdk/whirlpools/quote/increase-liquidity-quote.test.ts
+++ b/sdk/tests/sdk/whirlpools/quote/increase-liquidity-quote.test.ts
@@ -1,0 +1,135 @@
+import *  as assert from "assert";
+import { PriceMath, increaseLiquidityQuoteByInputTokenWithParams } from "../../../../src";
+import { BN } from "bn.js";
+import { PublicKey } from "@solana/web3.js";
+import { Percentage } from "@orca-so/common-sdk";
+
+describe("edge cases", () => {
+  const tokenMintA = new PublicKey("orcaEKTdK7LKz57vaAYr9QeNsVEPfiu6QeMU1kektZE");
+  const tokenMintB = new PublicKey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+
+  it("sqrtPrice on lower bound, tokenB input", async () => {
+    const quote = increaseLiquidityQuoteByInputTokenWithParams({
+      inputTokenAmount: new BN(1000),
+      inputTokenMint: tokenMintB,
+      sqrtPrice: PriceMath.tickIndexToSqrtPriceX64(0),
+      tokenMintA,
+      tokenMintB,
+      tickLowerIndex: 0,
+      tickUpperIndex: 64,
+      tickCurrentIndex: 0,
+      slippageTolerance: Percentage.fromFraction(0, 100),
+    });
+
+    assert.ok(quote.liquidityAmount.isZero());
+    assert.ok(quote.tokenEstA.isZero());
+    assert.ok(quote.tokenEstB.isZero());
+    assert.ok(quote.tokenMaxA.isZero());
+    assert.ok(quote.tokenMaxB.isZero());
+  });
+
+  it("sqrtPrice on lower bound, tokenA input", async () => {
+    const quote = increaseLiquidityQuoteByInputTokenWithParams({
+      inputTokenAmount: new BN(1000),
+      inputTokenMint: tokenMintA,
+      sqrtPrice: PriceMath.tickIndexToSqrtPriceX64(0),
+      tokenMintA,
+      tokenMintB,
+      tickLowerIndex: 0,
+      tickUpperIndex: 64,
+      tickCurrentIndex: 0,
+      slippageTolerance: Percentage.fromFraction(0, 100),
+    });
+
+    assert.ok(quote.liquidityAmount.gtn(0));
+    assert.ok(quote.tokenEstA.gtn(0));
+    assert.ok(quote.tokenEstB.isZero());
+    assert.ok(quote.tokenMaxA.gtn(0));
+    assert.ok(quote.tokenMaxB.isZero());
+  });
+
+  it("tickCurrentIndex on lower bound but sqrtPrice not on lower bound, tokenA input", async () => {
+    assert.ok(PriceMath.tickIndexToSqrtPriceX64(1).subn(1).gt(PriceMath.tickIndexToSqrtPriceX64(0)));
+
+    const quote = increaseLiquidityQuoteByInputTokenWithParams({
+      inputTokenAmount: new BN(1000),
+      inputTokenMint: tokenMintA,
+      sqrtPrice: PriceMath.tickIndexToSqrtPriceX64(1).subn(1),
+      tokenMintA,
+      tokenMintB,
+      tickLowerIndex: 0,
+      tickUpperIndex: 64,
+      tickCurrentIndex: 0,
+      slippageTolerance: Percentage.fromFraction(0, 100),
+    });
+
+    assert.ok(quote.liquidityAmount.gtn(0));
+    assert.ok(quote.tokenEstA.gtn(0));
+    assert.ok(quote.tokenEstB.gtn(0));
+    assert.ok(quote.tokenMaxA.gtn(0));
+    assert.ok(quote.tokenMaxB.gtn(0));
+  });
+
+  it("tickCurrentIndex on lower bound but sqrtPrice not on lower bound, tokenB input", async () => {
+    assert.ok(PriceMath.tickIndexToSqrtPriceX64(1).subn(1).gt(PriceMath.tickIndexToSqrtPriceX64(0)));
+
+    const quote = increaseLiquidityQuoteByInputTokenWithParams({
+      inputTokenAmount: new BN(1000),
+      inputTokenMint: tokenMintB,
+      sqrtPrice: PriceMath.tickIndexToSqrtPriceX64(1).subn(1),
+      tokenMintA,
+      tokenMintB,
+      tickLowerIndex: 0,
+      tickUpperIndex: 64,
+      tickCurrentIndex: 0,
+      slippageTolerance: Percentage.fromFraction(0, 100),
+    });
+
+    assert.ok(quote.liquidityAmount.gtn(0));
+    assert.ok(quote.tokenEstA.gtn(0));
+    assert.ok(quote.tokenEstB.gtn(0));
+    assert.ok(quote.tokenMaxA.gtn(0));
+    assert.ok(quote.tokenMaxB.gtn(0));
+  });
+
+  it("sqrtPrice on upper bound, tokenA input", async () => {
+    const quote = increaseLiquidityQuoteByInputTokenWithParams({
+      inputTokenAmount: new BN(1000),
+      inputTokenMint: tokenMintA,
+      sqrtPrice: PriceMath.tickIndexToSqrtPriceX64(64),
+      tokenMintA,
+      tokenMintB,
+      tickLowerIndex: 0,
+      tickUpperIndex: 64,
+      tickCurrentIndex: 64,
+      slippageTolerance: Percentage.fromFraction(0, 100),
+    });
+
+    assert.ok(quote.liquidityAmount.isZero());
+    assert.ok(quote.tokenEstA.isZero());
+    assert.ok(quote.tokenEstB.isZero());
+    assert.ok(quote.tokenMaxA.isZero());
+    assert.ok(quote.tokenMaxB.isZero());
+  });
+
+  it("sqrtPrice on upper bound, tokenB input", async () => {
+    const quote = increaseLiquidityQuoteByInputTokenWithParams({
+      inputTokenAmount: new BN(1000),
+      inputTokenMint: tokenMintB,
+      sqrtPrice: PriceMath.tickIndexToSqrtPriceX64(64),
+      tokenMintA,
+      tokenMintB,
+      tickLowerIndex: 0,
+      tickUpperIndex: 64,
+      tickCurrentIndex: 64,
+      slippageTolerance: Percentage.fromFraction(0, 100),
+    });
+
+    assert.ok(quote.liquidityAmount.gtn(0));
+    assert.ok(quote.tokenEstA.isZero());
+    assert.ok(quote.tokenEstB.gtn(0));
+    assert.ok(quote.tokenMaxA.isZero());
+    assert.ok(quote.tokenMaxB.gtn(0));
+  });
+
+});

--- a/sdk/tests/sdk/whirlpools/utils/position-util.test.ts
+++ b/sdk/tests/sdk/whirlpools/utils/position-util.test.ts
@@ -1,0 +1,98 @@
+import * as assert from "assert";
+import { PriceMath } from "../../../../src";
+import { PositionStatus, PositionUtil } from "../../../../src/utils/position-util";
+
+describe("PositionUtil tests", () => {
+  const tickLowerIndex = 64;
+  const tickUpperIndex = 128;
+
+  describe("getPositionStatus", () => {
+    it("tickCurrentIndex < tickLowerIndex, BelowRange", async () => {
+      const tickCurrentIndex = 0;
+      const result = PositionUtil.getPositionStatus(tickCurrentIndex, tickLowerIndex, tickUpperIndex);
+      assert.equal(result, PositionStatus.BelowRange);
+    });
+
+    it("tickCurrentIndex + 1 == tickLowerIndex, BelowRange", async () => {
+      const tickCurrentIndex = tickLowerIndex - 1;
+      const result = PositionUtil.getPositionStatus(tickCurrentIndex, tickLowerIndex, tickUpperIndex);
+      assert.equal(result, PositionStatus.BelowRange);
+    });
+
+    it("tickCurrentIndex == tickLowerIndex, InRange", async () => {
+      const tickCurrentIndex = tickLowerIndex;
+      const result = PositionUtil.getPositionStatus(tickCurrentIndex, tickLowerIndex, tickUpperIndex);
+      assert.equal(result, PositionStatus.InRange);
+    });
+
+    it("tickCurrentIndex + 1 == tickUpperIndex, InRange", async () => {
+      const tickCurrentIndex = tickUpperIndex - 1;
+      const result = PositionUtil.getPositionStatus(tickCurrentIndex, tickLowerIndex, tickUpperIndex);
+      assert.equal(result, PositionStatus.InRange);
+    });
+
+    it("tickCurrentIndex == tickUpperIndex, AboveRange", async () => {
+      const tickCurrentIndex = tickUpperIndex;
+      const result = PositionUtil.getPositionStatus(tickCurrentIndex, tickLowerIndex, tickUpperIndex);
+      assert.equal(result, PositionStatus.AboveRange);
+    });
+
+    it("tickCurrentIndex > tickUpperIndex, AboveRange", async () => {
+      const tickCurrentIndex = 192;
+      const result = PositionUtil.getPositionStatus(tickCurrentIndex, tickLowerIndex, tickUpperIndex);
+      assert.equal(result, PositionStatus.AboveRange);
+    });
+
+  });
+
+  describe("getStrictPositionStatus", async () => {
+    it("sqrtPrice < toSqrtPrice(tickLowerIndex), BelowRange", async () => {
+      const sqrtPriceX64 = PriceMath.tickIndexToSqrtPriceX64(0);
+      const result = PositionUtil.getStrictPositionStatus(sqrtPriceX64, tickLowerIndex, tickUpperIndex);
+      assert.equal(result, PositionStatus.BelowRange);
+    });
+
+    it("sqrtPrice + 1 == toSqrtPrice(tickLowerIndex), BelowRange", async () => {
+      const sqrtPriceX64 = PriceMath.tickIndexToSqrtPriceX64(tickLowerIndex).subn(1);
+      const result = PositionUtil.getStrictPositionStatus(sqrtPriceX64, tickLowerIndex, tickUpperIndex);
+      assert.equal(result, PositionStatus.BelowRange);
+    });
+
+    it("sqrtPrice == toSqrtPrice(tickLowerIndex), BelowRange", async () => {
+      const sqrtPriceX64 = PriceMath.tickIndexToSqrtPriceX64(tickLowerIndex);
+      const result = PositionUtil.getStrictPositionStatus(sqrtPriceX64, tickLowerIndex, tickUpperIndex);
+      assert.equal(result, PositionStatus.BelowRange);
+    });
+
+    it("sqrtPrice - 1 == toSqrtPrice(tickLowerIndex), InRange", async () => {
+      const sqrtPriceX64 = PriceMath.tickIndexToSqrtPriceX64(tickLowerIndex).addn(1);
+      const result = PositionUtil.getStrictPositionStatus(sqrtPriceX64, tickLowerIndex, tickUpperIndex);
+      assert.equal(result, PositionStatus.InRange);
+    });
+
+    it("sqrtPrice + 1 == toSqrtPrice(tickUpperIndex), InRange", async () => {
+      const sqrtPriceX64 = PriceMath.tickIndexToSqrtPriceX64(tickUpperIndex).subn(1);
+      const result = PositionUtil.getStrictPositionStatus(sqrtPriceX64, tickLowerIndex, tickUpperIndex);
+      assert.equal(result, PositionStatus.InRange);
+    });
+
+    it("sqrtPrice == toSqrtPrice(tickUpperIndex), AboveRange", async () => {
+      const sqrtPriceX64 = PriceMath.tickIndexToSqrtPriceX64(tickUpperIndex);
+      const result = PositionUtil.getStrictPositionStatus(sqrtPriceX64, tickLowerIndex, tickUpperIndex);
+      assert.equal(result, PositionStatus.AboveRange);
+    });
+
+    it("sqrtPrice - 1 == toSqrtPrice(tickUpperIndex), AboveRange", async () => {
+      const sqrtPriceX64 = PriceMath.tickIndexToSqrtPriceX64(tickUpperIndex).addn(1);
+      const result = PositionUtil.getStrictPositionStatus(sqrtPriceX64, tickLowerIndex, tickUpperIndex);
+      assert.equal(result, PositionStatus.AboveRange);
+    });
+
+    it("sqrtPrice > toSqrtPrice(tickUpperIndex), AboveRange", async () => {
+      const sqrtPriceX64 = PriceMath.tickIndexToSqrtPriceX64(192);
+      const result = PositionUtil.getStrictPositionStatus(sqrtPriceX64, tickLowerIndex, tickUpperIndex);
+      assert.equal(result, PositionStatus.AboveRange);
+    });
+
+  });
+});


### PR DESCRIPTION
Ticket: https://app.asana.com/0/1202413563699470/1206467231374946/f

In https://github.com/orca-so/whirlpools/pull/126, PositionUtil.getPositionStatus have been updated to return PositionStatus.BelowRange when ``tickCurrentIndex == tickLowerIndex`` is true.

But when ``toSqrtPrice(tickLowerIndex) < sqrtPrice < toSqrtPrice(tickLowerIndex + 1)`` is true, position status should be InRange.

In this PR, the condition have been reverted.
To avoid zero-div in increaseLiquidityQuoteByInputToken calc, new strict method ``PositionUtil.getStrictPositionStatus`` have been added.  "Strict" means that the use of sqrtPrice and the clarification of the behavior when sqrtPrice is on the boundary.