### PR TITLE
Bump common-sdk to 0.5.2

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/whirlpools-sdk",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Typescript SDK to interact with Orca's Whirlpool program.",
   "license": "Apache-2.0",
   "main": "dist/index.js",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -7,7 +7,7 @@
   "types": "dist/index.d.ts",
   "peerDependencies": {
     "@coral-xyz/anchor": "~0.27.0",
-    "@orca-so/common-sdk": "^0.4.0",
+    "@orca-so/common-sdk": "^0.5.2",
     "@solana/spl-token": "^0.3.8",
     "@solana/web3.js": "^1.75.0",
     "decimal.js": "^10.3.1"
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@coral-xyz/anchor": "^0.27.0",
     "@metaplex-foundation/mpl-token-metadata": "2.12.0",
-    "@orca-so/common-sdk": "^0.4.0",
+    "@orca-so/common-sdk": "^0.5.2",
     "@solana/spl-token": "^0.3.11",
     "@solana/web3.js": "^1.88.0",
     "@types/bn.js": "~5.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -221,10 +221,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@orca-so/common-sdk@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@orca-so/common-sdk/-/common-sdk-0.4.0.tgz#b09e169f23aebcba28ce72c3db35ecff12abe8f2"
-  integrity sha512-ki170oydM+Az1EZznzXfoKx8CEwTXUDl20FfW/vZLaZPuU46T46KQMWDS/u8OYJnUDDqr0dZwY0MugDi/9Py8g==
+"@orca-so/common-sdk@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@orca-so/common-sdk/-/common-sdk-0.5.2.tgz#fd9daf8bee35c02017c1fc6bb9fa0b0fd2bbf353"
+  integrity sha512-bX/v6tFLJQ78jAvNRKmWoRHw+nm4Zh0DTUYrToz4b+TMJegBKMnfRtPeeyp85Z6xCjaaBTx5d83BLX199oObCA==
   dependencies:
     tiny-invariant "^1.3.1"
 


### PR DESCRIPTION
Bump common-sdk to pick up priority fee changes in transaction builder.

0.5.2 needs to be published after https://github.com/orca-so/orca-sdks/pull/73 is merged.