### PR TITLE
use idempotent on whirlpool.swap (swapAsync)

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/whirlpools-sdk",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Typescript SDK to interact with Orca's Whirlpool program.",
   "license": "Apache-2.0",
   "main": "dist/index.js",

--- a/sdk/src/instructions/composites/swap-async.ts
+++ b/sdk/src/instructions/composites/swap-async.ts
@@ -46,7 +46,7 @@ export async function swapAsync(
     ],
     () => ctx.fetcher.getAccountRentExempt(),
     undefined, // use default
-    undefined, // use default
+    true, // use idempotent to allow multiple simultaneous calls
     ctx.accountResolverOpts.allowPDAOwnerAddress,
     ctx.accountResolverOpts.createWrappedSolAccountMethod
   );


### PR DESCRIPTION
Asana: https://app.asana.com/0/1202413563699470/1206926743112719/f

Resolve double ATA creation issue.
It happens because some users will build and send multiple transactions simultaneously.

## Test
- ``anchor test`` passed
- added new 1 test case to ensure Idempotent is used