### PR TITLE
add ConfidentialTransferFeeConfig extension support

### DIFF
--- a/programs/whirlpool/src/util/v2/token.rs
+++ b/programs/whirlpool/src/util/v2/token.rs
@@ -250,6 +250,11 @@ pub fn is_supported_token_mint<'info>(
                 // it is impossible to send tokens directly to the vault accounts confidentially.
                 // Note: Only the owner (Whirlpool account) can call ConfidentialTransferInstruction::ConfigureAccount.
             }
+            extension::ExtensionType::ConfidentialTransferFeeConfig => {
+                // Supported, but non-confidential transfer only
+                // When both TransferFeeConfig and ConfidentialTransferMint are initialized,
+                // ConfidentialTransferFeeConfig is also initialized to store encrypted transfer fee amount.
+            }
             // supported if token badge is initialized
             extension::ExtensionType::PermanentDelegate => {
                 if !is_token_badge_initialized { return Ok(false); }

--- a/sdk/tests/integration/v2/initialize_pool_v2.test.ts
+++ b/sdk/tests/integration/v2/initialize_pool_v2.test.ts
@@ -888,6 +888,9 @@ describe("initialize_pool_v2", () => {
         })).buildAndExecute();      
       }
 
+      const isSupportedToken = await PoolUtil.isSupportedToken(ctx, configKeypair.publicKey, tokenTarget.publicKey);
+      assert.equal(isSupportedToken, params.supported);
+
       // try to initialize pool
       await checkSupported(params.supported, configKeypair.publicKey, tokenA.publicKey, tokenTarget.publicKey, tickSpacing, params.anchorPatch); // as TokenB
       await checkSupported(params.supported, configKeypair.publicKey, tokenTarget.publicKey, tokenB.publicKey, tickSpacing, params.anchorPatch); // as TokenA
@@ -1024,6 +1027,19 @@ describe("initialize_pool_v2", () => {
         tokenTrait: {
           isToken2022: true,
           hasConfidentialTransferExtension: true,
+        }
+      });
+    });
+
+    it("Token-2022: with ConfidentialTransferMint & TransferFeeConfig (& ConfidentialTransferFeeConfig)", async () => {
+      await runTest({
+        supported: true,
+        createTokenBadge: false,
+        tokenTrait: {
+          isToken2022: true,
+          hasTransferFeeExtension: true,
+          hasConfidentialTransferExtension: true,
+          // test util will automatically initialize ConfidentialTransferFeeConfig
         }
       });
     });

--- a/sdk/tests/integration/v2/token-extensions/non-confidential-transfer+transfer-fee.test.ts
+++ b/sdk/tests/integration/v2/token-extensions/non-confidential-transfer+transfer-fee.test.ts
@@ -1,0 +1,361 @@
+import * as anchor from "@coral-xyz/anchor";
+import { BN } from "@coral-xyz/anchor";
+import * as assert from "assert";
+import {
+  buildWhirlpoolClient,
+  PoolUtil,
+  PositionData,
+  PriceMath,
+  TickUtil,
+  toTokenAmount,
+  toTx,
+  WhirlpoolContext,
+  WhirlpoolData,
+  WhirlpoolIx,
+} from "../../../../src";
+import { IGNORE_CACHE } from "../../../../src/network/public/fetcher";
+import {
+  getTokenBalance,
+  TEST_TOKEN_2022_PROGRAM_ID,
+  TickSpacing,
+  ZERO_BN,
+} from "../../../utils";
+import { defaultConfirmOptions } from "../../../utils/const";
+import { WhirlpoolTestFixtureV2 } from "../../../utils/v2/fixture-v2";
+import {
+  calculateTransferFeeExcludedAmount,
+  calculateTransferFeeIncludedAmount,
+  createTokenAccountV2,
+} from "../../../utils/v2/token-2022";
+import { PublicKey } from "@solana/web3.js";
+import { hasConfidentialTransferFeeConfigExtension, hasConfidentialTransferMintExtension } from "../../../utils/v2/confidential-transfer";
+import { TransferFee, getEpochFee, getMint, getTransferFeeConfig } from "@solana/spl-token";
+
+describe("TokenExtension/ConfidentialTransfer (NON confidential transfer only) + TransferFee", () => {
+  const provider = anchor.AnchorProvider.local(undefined, defaultConfirmOptions);
+  const program = anchor.workspace.Whirlpool;
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
+  const fetcher = ctx.fetcher;
+  const client = buildWhirlpoolClient(ctx);
+
+  // ConfidentialTransfer + TransferFee is combination test
+  // We'll test owner to vault transfer by increase liquidity, vault to owner transfer by decrease liquidity
+
+  async function getTransferFee(mint: PublicKey): Promise<TransferFee> {
+    const mintData = await getMint(
+      provider.connection,
+      mint,
+      undefined,
+      TEST_TOKEN_2022_PROGRAM_ID,
+    );
+    const transferFeeConfig = getTransferFeeConfig(mintData);
+    assert.ok(transferFeeConfig !== null);
+
+    const epochInfo = await provider.connection.getEpochInfo();
+    const transferFee = getEpochFee(transferFeeConfig, BigInt(epochInfo.epoch));
+    return transferFee;
+  }
+
+  describe("increase_liquidity_v2", () => {
+    const tickLowerIndex = 7168;
+    const tickUpperIndex = 8960;
+    const currTick = Math.round((tickLowerIndex + tickUpperIndex) / 2);
+
+    const aboveLowerIndex = TickUtil.getNextInitializableTickIndex(currTick + 1, TickSpacing.Standard);
+    const aboveUpperIndex = tickUpperIndex;
+    const belowLowerIndex = tickLowerIndex;
+    const belowUpperIndex = TickUtil.getPrevInitializableTickIndex(currTick - 1, TickSpacing.Standard);
+
+    let fixture: WhirlpoolTestFixtureV2;
+
+    beforeEach(async () => {
+      fixture = await new WhirlpoolTestFixtureV2(ctx).init({
+        tokenTraitA: {
+          isToken2022: true,
+          hasTransferFeeExtension: true,
+          hasConfidentialTransferExtension: true,
+          transferFeeInitialBps: 500,
+        }, // 5%
+        tokenTraitB: {
+          isToken2022: true,
+          hasTransferFeeExtension: true,
+          hasConfidentialTransferExtension: true,
+          transferFeeInitialBps: 1000,
+        }, // 10%
+        tickSpacing: TickSpacing.Standard,
+        positions: [
+          { tickLowerIndex, tickUpperIndex, liquidityAmount: ZERO_BN },
+          { tickLowerIndex: aboveLowerIndex, tickUpperIndex: aboveUpperIndex, liquidityAmount: ZERO_BN },
+          { tickLowerIndex: belowLowerIndex, tickUpperIndex: belowUpperIndex, liquidityAmount: ZERO_BN },
+        ],
+        initialSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currTick),
+      });
+    });
+
+    it("increase_liquidity_v2: with transfer fee", async () => {
+      const { poolInitInfo, positions, tokenAccountA, tokenAccountB } = fixture.getInfos();
+      const positionInitInfo = positions[0];
+
+      // transfer fee
+      const transferFeeA = await getTransferFee(poolInitInfo.tokenMintA);
+      const transferFeeB = await getTransferFee(poolInitInfo.tokenMintB);
+      assert.equal(transferFeeA.transferFeeBasisPoints, 500); // 5%
+      assert.equal(transferFeeB.transferFeeBasisPoints, 1000); // 10%
+
+      // confidential transfer
+      assert.equal(await hasConfidentialTransferMintExtension(provider, poolInitInfo.tokenMintA), true);
+      assert.equal(await hasConfidentialTransferMintExtension(provider, poolInitInfo.tokenMintB), true);
+      // confidential transfer fee config
+      assert.equal(await hasConfidentialTransferFeeConfigExtension(provider, poolInitInfo.tokenMintA), true);
+      assert.equal(await hasConfidentialTransferFeeConfigExtension(provider, poolInitInfo.tokenMintB), true);
+
+      const tokenAmount = toTokenAmount(1_000_000 * 0.8, 1_000_000 * 0.8);
+      const liquidityAmount = PoolUtil.estimateLiquidityFromTokenAmounts(
+        currTick,
+        tickLowerIndex,
+        tickUpperIndex,
+        tokenAmount,
+      );
+      const requiredAmountDelta = PoolUtil.getTokenAmountsFromLiquidity(
+        liquidityAmount,
+        PriceMath.tickIndexToSqrtPriceX64(currTick),
+        PriceMath.tickIndexToSqrtPriceX64(tickLowerIndex),
+        PriceMath.tickIndexToSqrtPriceX64(tickUpperIndex),
+        true,
+      );
+
+      // transfer fee should be non zero
+      assert.ok(requiredAmountDelta.tokenA.gtn(0));
+      assert.ok(requiredAmountDelta.tokenB.gtn(0));
+      const expectedTransferFeeIncludedAmountA = calculateTransferFeeIncludedAmount(
+        transferFeeA,
+        requiredAmountDelta.tokenA,
+      );
+      const expectedTransferFeeIncludedAmountB = calculateTransferFeeIncludedAmount(
+        transferFeeB,
+        requiredAmountDelta.tokenB,
+      );
+      assert.ok(expectedTransferFeeIncludedAmountA.fee.gtn(0));
+      assert.ok(expectedTransferFeeIncludedAmountB.fee.gtn(0));
+
+      const preVaultBalanceA = new BN(
+        await getTokenBalance(provider, poolInitInfo.tokenVaultAKeypair.publicKey),
+      );
+      const preVaultBalanceB = new BN(
+        await getTokenBalance(provider, poolInitInfo.tokenVaultBKeypair.publicKey),
+      );
+      const preOwnerAccountBalanceA = new BN(await getTokenBalance(provider, tokenAccountA));
+      const preOwnerAccountBalanceB = new BN(await getTokenBalance(provider, tokenAccountB));
+
+      await toTx(
+        ctx,
+        WhirlpoolIx.increaseLiquidityV2Ix(ctx.program, {
+          liquidityAmount,
+          tokenMaxA: expectedTransferFeeIncludedAmountA.amount,
+          tokenMaxB: expectedTransferFeeIncludedAmountB.amount,
+          whirlpool: poolInitInfo.whirlpoolPda.publicKey,
+          positionAuthority: provider.wallet.publicKey,
+          position: positionInitInfo.publicKey,
+          positionTokenAccount: positionInitInfo.tokenAccount,
+          tokenMintA: poolInitInfo.tokenMintA,
+          tokenMintB: poolInitInfo.tokenMintB,
+          tokenProgramA: poolInitInfo.tokenProgramA,
+          tokenProgramB: poolInitInfo.tokenProgramB,
+          tokenOwnerAccountA: tokenAccountA,
+          tokenOwnerAccountB: tokenAccountB,
+          tokenVaultA: poolInitInfo.tokenVaultAKeypair.publicKey,
+          tokenVaultB: poolInitInfo.tokenVaultBKeypair.publicKey,
+          tickArrayLower: positionInitInfo.tickArrayLower,
+          tickArrayUpper: positionInitInfo.tickArrayUpper,
+        }),
+      ).buildAndExecute();
+
+      const postVaultBalanceA = new BN(
+        await getTokenBalance(provider, poolInitInfo.tokenVaultAKeypair.publicKey),
+      );
+      const postVaultBalanceB = new BN(
+        await getTokenBalance(provider, poolInitInfo.tokenVaultBKeypair.publicKey),
+      );
+      const postOwnerAccountBalanceA = new BN(await getTokenBalance(provider, tokenAccountA));
+      const postOwnerAccountBalanceB = new BN(await getTokenBalance(provider, tokenAccountB));
+
+      // owner sent requiredAmountDelta plus transfer fees
+      assert.ok(
+        preOwnerAccountBalanceA
+          .sub(postOwnerAccountBalanceA)
+          .eq(expectedTransferFeeIncludedAmountA.amount),
+      );
+      assert.ok(
+        preOwnerAccountBalanceB
+          .sub(postOwnerAccountBalanceB)
+          .eq(expectedTransferFeeIncludedAmountB.amount),
+      );
+      // vault received requiredAmountDelta
+      assert.ok(postVaultBalanceA.sub(preVaultBalanceA).eq(requiredAmountDelta.tokenA));
+      assert.ok(postVaultBalanceB.sub(preVaultBalanceB).eq(requiredAmountDelta.tokenB));
+    });
+
+  });
+
+  describe("decrease_liquidity_v2", () => {
+    let fixture: WhirlpoolTestFixtureV2;
+    let destAccountA: PublicKey;
+    let destAccountB: PublicKey;
+
+    const tickLowerIndex = 7168;
+    const tickUpperIndex = 8960;
+    const currTick = Math.round((tickLowerIndex + tickUpperIndex) / 2);
+
+    const aboveLowerIndex = TickUtil.getNextInitializableTickIndex(currTick + 1, TickSpacing.Standard);
+    const aboveUpperIndex = tickUpperIndex;
+    const belowLowerIndex = tickLowerIndex;
+    const belowUpperIndex = TickUtil.getPrevInitializableTickIndex(currTick - 1, TickSpacing.Standard);
+
+    beforeEach(async () => {
+      const liquidityAmount = new anchor.BN(1_250_000);
+      fixture = await new WhirlpoolTestFixtureV2(ctx).init({
+        tokenTraitA: {
+          isToken2022: true,
+          hasTransferFeeExtension: true,
+          hasConfidentialTransferExtension: true,
+          transferFeeInitialBps: 500,
+        }, // 5%
+        tokenTraitB: {
+          isToken2022: true,
+          hasTransferFeeExtension: true,
+          hasConfidentialTransferExtension: true,
+          transferFeeInitialBps: 1000,
+        }, // 10%
+        tickSpacing: TickSpacing.Standard,
+        initialSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currTick),
+        positions: [
+          { tickLowerIndex, tickUpperIndex, liquidityAmount },
+          { tickLowerIndex: aboveLowerIndex, tickUpperIndex: aboveUpperIndex, liquidityAmount },
+          { tickLowerIndex: belowLowerIndex, tickUpperIndex: belowUpperIndex, liquidityAmount },
+        ],
+      });
+      const { poolInitInfo } = fixture.getInfos();
+
+      destAccountA = await createTokenAccountV2(
+        provider,
+        { isToken2022: true },
+        poolInitInfo.tokenMintA,
+        provider.wallet.publicKey,
+      );
+      destAccountB = await createTokenAccountV2(
+        provider,
+        { isToken2022: true },
+        poolInitInfo.tokenMintB,
+        provider.wallet.publicKey,
+      );
+    });
+
+    it("decrease_liquidity_v2: with transfer fee", async () => {
+      const { poolInitInfo, positions } = fixture.getInfos();
+
+      // transfer fee
+      const transferFeeA = await getTransferFee(poolInitInfo.tokenMintA);
+      const transferFeeB = await getTransferFee(poolInitInfo.tokenMintB);
+      assert.equal(transferFeeA.transferFeeBasisPoints, 500); // 5%
+      assert.equal(transferFeeB.transferFeeBasisPoints, 1000); // 10%
+
+      // confidential transfer
+      assert.equal(await hasConfidentialTransferMintExtension(provider, poolInitInfo.tokenMintA), true);
+      assert.equal(await hasConfidentialTransferMintExtension(provider, poolInitInfo.tokenMintB), true);
+      // confidential transfer fee config
+      assert.equal(await hasConfidentialTransferFeeConfigExtension(provider, poolInitInfo.tokenMintA), true);
+      assert.equal(await hasConfidentialTransferFeeConfigExtension(provider, poolInitInfo.tokenMintB), true);
+
+      const position = positions[0];
+      const positionData = (await fetcher.getPosition(
+        position.publicKey,
+        IGNORE_CACHE,
+      )) as PositionData;
+      const whirlpoolData = (await fetcher.getPool(
+        positionData.whirlpool,
+        IGNORE_CACHE,
+      )) as WhirlpoolData;
+      const expectedAmount = PoolUtil.getTokenAmountsFromLiquidity(
+        positionData.liquidity,
+        whirlpoolData.sqrtPrice,
+        PriceMath.tickIndexToSqrtPriceX64(positionData.tickLowerIndex),
+        PriceMath.tickIndexToSqrtPriceX64(positionData.tickUpperIndex),
+        false,
+      );
+
+      // transfer fee should be non zero
+      assert.ok(expectedAmount.tokenA.gtn(0));
+      assert.ok(expectedAmount.tokenB.gtn(0));
+      const expectedTransferFeeExcludedAmountA = calculateTransferFeeExcludedAmount(
+        transferFeeA,
+        expectedAmount.tokenA,
+      );
+      const expectedTransferFeeExcludedAmountB = calculateTransferFeeExcludedAmount(
+        transferFeeB,
+        expectedAmount.tokenB,
+      );
+      assert.ok(expectedTransferFeeExcludedAmountA.fee.gtn(0));
+      assert.ok(expectedTransferFeeExcludedAmountB.fee.gtn(0));
+
+      const preVaultBalanceA = await getTokenBalance(
+        provider,
+        poolInitInfo.tokenVaultAKeypair.publicKey,
+      );
+      const preVaultBalanceB = await getTokenBalance(
+        provider,
+        poolInitInfo.tokenVaultBKeypair.publicKey,
+      );
+
+      const sig = await toTx(
+        ctx,
+        WhirlpoolIx.decreaseLiquidityV2Ix(ctx.program, {
+          liquidityAmount: positionData.liquidity,
+          tokenMinA: expectedAmount.tokenA.sub(expectedTransferFeeExcludedAmountA.fee),
+          tokenMinB: expectedAmount.tokenB.sub(expectedTransferFeeExcludedAmountB.fee),
+          whirlpool: poolInitInfo.whirlpoolPda.publicKey,
+          positionAuthority: provider.wallet.publicKey,
+          position: position.publicKey,
+          positionTokenAccount: position.tokenAccount,
+          tokenMintA: poolInitInfo.tokenMintA,
+          tokenMintB: poolInitInfo.tokenMintB,
+          tokenProgramA: poolInitInfo.tokenProgramA,
+          tokenProgramB: poolInitInfo.tokenProgramB,
+          tokenOwnerAccountA: destAccountA,
+          tokenOwnerAccountB: destAccountB,
+          tokenVaultA: poolInitInfo.tokenVaultAKeypair.publicKey,
+          tokenVaultB: poolInitInfo.tokenVaultBKeypair.publicKey,
+          tickArrayLower: position.tickArrayLower,
+          tickArrayUpper: position.tickArrayUpper,
+        }),
+      ).buildAndExecute();
+
+      const postVaultBalanceA = await getTokenBalance(
+        provider,
+        poolInitInfo.tokenVaultAKeypair.publicKey,
+      );
+      const postVaultBalanceB = await getTokenBalance(
+        provider,
+        poolInitInfo.tokenVaultBKeypair.publicKey,
+      );
+      assert.ok(new BN(preVaultBalanceA).sub(new BN(postVaultBalanceA)).eq(expectedAmount.tokenA));
+      assert.ok(new BN(preVaultBalanceB).sub(new BN(postVaultBalanceB)).eq(expectedAmount.tokenB));
+
+      // owner received withdrawable amount minus transfer fee (transferFeeExcludedAmount)
+      const destBalanceA = await getTokenBalance(provider, destAccountA);
+      const destBalanceB = await getTokenBalance(provider, destAccountB);
+      //console.log("A", destBalanceA.toString(), expectedTransferFeeExcludedAmountA.amount.toString(), expectedTransferFeeExcludedAmountA.fee.toString());
+      //console.log("B", destBalanceB.toString(), expectedTransferFeeExcludedAmountB.amount.toString(), expectedTransferFeeExcludedAmountB.fee.toString());
+
+      assert.ok(new BN(destBalanceA).eq(expectedTransferFeeExcludedAmountA.amount));
+      assert.ok(new BN(destBalanceB).eq(expectedTransferFeeExcludedAmountB.amount));
+
+      // all liquidity have been decreased
+      const positionDataAfterWithdraw = (await fetcher.getPosition(
+        position.publicKey,
+        IGNORE_CACHE,
+      )) as PositionData;
+      assert.ok(positionDataAfterWithdraw.liquidity.isZero());
+    });
+  });
+
+});

--- a/sdk/tests/utils/v2/confidential-transfer.ts
+++ b/sdk/tests/utils/v2/confidential-transfer.ts
@@ -11,7 +11,7 @@ enum ConfidentialTransferInstruction {
   // We are interested in initilization only
   InitializeMint = 0,
   // ...
-  // https://github.com/solana-labs/solana-program-library/blob/master/token/program-2022/src/extension/confidential_transfer/instruction.rs
+  // https://github.com/solana-labs/solana-program-library/blob/d4bbd51b5167d3f0c8a247b5f304a92e6482cd6f/token/program-2022/src/extension/confidential_transfer/instruction.rs#L33
 }
 
 interface InitializeConfidentialTransferMintInstructionData {
@@ -84,4 +84,83 @@ export async function hasConfidentialTransferMintExtension(
 
   const extensions = getExtensionTypes(account.tlvData);
   return extensions.includes(ExtensionType.ConfidentialTransferMint);
+}
+
+enum ConfidentialTransferFeeInstruction {
+  // We are interested in initilization only
+  InitializeConfidentialTransferFeeConfig = 0,
+  // ...
+  // https://github.com/solana-labs/solana-program-library/blob/d4bbd51b5167d3f0c8a247b5f304a92e6482cd6f/token/program-2022/src/extension/confidential_transfer_fee/instruction.rs#L37
+}
+
+const TOKEN_INSTRUCTION_CONFIDENTIAL_TRANSFER_FEE_CONFIG_EXTENSION = 37;
+const EXTENSION_TYPE_CONFIDENTIAL_TRANSFER_FEE_CONFIG = 16 as ExtensionType;
+
+interface InitializeConfidentialTransferFeeConfigInstructionData {
+  //TokenInstruction.ConfidentialTransferFeeExtension = 37 is commented out
+  //instruction: TokenInstruction.ConfidentialTransferFeeExtension;
+  instruction: 37;
+  confidentialTransferFeeInstruction: ConfidentialTransferFeeInstruction.InitializeConfidentialTransferFeeConfig;
+  authority: PublicKey | null;
+  withdrawWithheldAuthorityElgamalPubkey: PublicKey | null;
+}
+
+/*
+
+Sample transaction instruction data
+
+25 00 d1 4f 53 ad b4 2c 4c 61 09 57 13 38 5d 13
+6b e7 d5 37 30 d4 38 4a 38 d3 4c 84 cd c6 a9 93
+83 09 1c 37 e6 43 3b 73 04 dd 82 73 7a e4 0d 9b
+8b f3 c4 9f 5b 0e 6c 49 a8 d5 33 28 b3 e5 06 90
+1c 57
+
+data length: 67 bytes
+
+   1: confidential transfer fee prefix
+   1: confidential transfer fee ix
+  32: authority
+  32: withdraw withheld authority elgamal pubkey
+
+*/
+const initializeConfidentialTransferFeeConfigInstructionData = struct<InitializeConfidentialTransferFeeConfigInstructionData>([
+  u8('instruction'),
+  u8('confidentialTransferFeeInstruction'),
+  publicKey('authority'),
+  publicKey('withdrawWithheldAuthorityElgamalPubkey'),
+]);
+
+export function createInitializeConfidentialTransferFeeConfigInstruction(
+  mint: PublicKey,
+  authority: PublicKey,
+  withdrawWithheldAuthorityElgamalPubkey: PublicKey = PublicKey.default,
+  programId: PublicKey = TOKEN_2022_PROGRAM_ID,
+) {
+  if (!programSupportsExtensions(programId)) {
+    throw new TokenUnsupportedInstructionError();
+  }
+
+  const keys = [{ pubkey: mint, isSigner: false, isWritable: true }];
+  const data = Buffer.alloc(initializeConfidentialTransferFeeConfigInstructionData.span);
+  initializeConfidentialTransferFeeConfigInstructionData.encode(
+    {
+        instruction: TOKEN_INSTRUCTION_CONFIDENTIAL_TRANSFER_FEE_CONFIG_EXTENSION,
+        confidentialTransferFeeInstruction: ConfidentialTransferFeeInstruction.InitializeConfidentialTransferFeeConfig,
+        authority,
+        withdrawWithheldAuthorityElgamalPubkey,
+    },
+    data
+  );
+
+  return new TransactionInstruction({ keys, programId, data });
+}
+
+export async function hasConfidentialTransferFeeConfigExtension(
+  provider: AnchorProvider,
+  mint: PublicKey,
+): Promise<boolean> {
+  const account = await getMint(provider.connection, mint, "confirmed", TEST_TOKEN_2022_PROGRAM_ID);
+
+  const extensions = getExtensionTypes(account.tlvData);
+  return extensions.includes(EXTENSION_TYPE_CONFIDENTIAL_TRANSFER_FEE_CONFIG);
 }


### PR DESCRIPTION
When both `TransferFeeConfig` and `ConfidentialTransferMint` are initialized, `ConfidentialTransferFeeConfig` must be initialized.

https://github.com/solana-labs/solana-program-library/blob/master/token/program-2022/src/extension/mod.rs#L1292

So we need to support `ConfidentialTransferFeeConfig` extension.

Whirlpool uses only non-confidential transfers, so this extension is not used in Whirlpool's operation, but must be allowed to be set to mint.