### PR TITLE
Add price-slippage variant to the decreaseLiquidityQuote helper function

### DIFF
--- a/sdk/src/quotes/public/decrease-liquidity-quote.ts
+++ b/sdk/src/quotes/public/decrease-liquidity-quote.ts
@@ -3,15 +3,15 @@ import { Percentage, ZERO } from "@orca-so/common-sdk";
 import invariant from "tiny-invariant";
 import { DecreaseLiquidityInput } from "../../instructions";
 import {
+  PositionStatus,
+  PositionUtil,
   adjustForSlippage,
   getTokenAFromLiquidity,
   getTokenBFromLiquidity,
-  PositionStatus,
-  PositionUtil,
 } from "../../utils/position-util";
 import { PriceMath, TickUtil } from "../../utils/public";
-import { Position, Whirlpool } from "../../whirlpool-client";
 import { TokenExtensionContextForPool, TokenExtensionUtil } from "../../utils/public/token-extension-util";
+import { Position, Whirlpool } from "../../whirlpool-client";
 
 /**
  * @category Quotes
@@ -91,115 +91,126 @@ export function decreaseLiquidityQuoteByLiquidity(
  * @returns An DecreaseLiquidityInput object detailing the tokenMin & liquidity values to use when calling decrease-liquidity-ix.
  */
 export function decreaseLiquidityQuoteByLiquidityWithParams(
-  param: DecreaseLiquidityQuoteParam
+  params: DecreaseLiquidityQuoteParam
 ): DecreaseLiquidityQuote {
-  invariant(TickUtil.checkTickInBounds(param.tickLowerIndex), "tickLowerIndex is out of bounds.");
-  invariant(TickUtil.checkTickInBounds(param.tickUpperIndex), "tickUpperIndex is out of bounds.");
+  invariant(TickUtil.checkTickInBounds(params.tickLowerIndex), "tickLowerIndex is out of bounds.");
+  invariant(TickUtil.checkTickInBounds(params.tickUpperIndex), "tickUpperIndex is out of bounds.");
   invariant(
-    TickUtil.checkTickInBounds(param.tickCurrentIndex),
+    TickUtil.checkTickInBounds(params.tickCurrentIndex),
     "tickCurrentIndex is out of bounds."
   );
 
-  const positionStatus = PositionUtil.getStrictPositionStatus(
-    param.sqrtPrice,
-    param.tickLowerIndex,
-    param.tickUpperIndex
-  );
+  const { tokenExtensionCtx } = params;
+  const { tokenEstA, tokenEstB } = getTokenEstimatesFromLiquidity(params);
+  const [tokenMinA, tokenMinB] = [tokenEstA, tokenEstB].map((tokenEst) => adjustForSlippage(tokenEst, params.slippageTolerance, false));
 
-  switch (positionStatus) {
-    case PositionStatus.BelowRange:
-      return quotePositionBelowRange(param);
-    case PositionStatus.InRange:
-      return quotePositionInRange(param);
-    case PositionStatus.AboveRange:
-      return quotePositionAboveRange(param);
-    default:
-      throw new Error(`type ${positionStatus} is an unknown PositionStatus`);
+  const tokenMinAExcluded = TokenExtensionUtil.calculateTransferFeeExcludedAmount(tokenMinA, tokenExtensionCtx.tokenMintWithProgramA, tokenExtensionCtx.currentEpoch);
+  const tokenEstAExcluded = TokenExtensionUtil.calculateTransferFeeExcludedAmount(tokenEstA, tokenExtensionCtx.tokenMintWithProgramA, tokenExtensionCtx.currentEpoch);
+  const tokenMinBExcluded = TokenExtensionUtil.calculateTransferFeeExcludedAmount(tokenMinB, tokenExtensionCtx.tokenMintWithProgramB, tokenExtensionCtx.currentEpoch);
+  const tokenEstBExcluded = TokenExtensionUtil.calculateTransferFeeExcludedAmount(tokenEstB, tokenExtensionCtx.tokenMintWithProgramB, tokenExtensionCtx.currentEpoch);
+
+  return {
+    tokenMinA,
+    tokenMinB,
+    tokenEstA,
+    tokenEstB,
+    liquidityAmount: params.liquidity,
+    transferFee: {
+      deductedFromTokenMinA: tokenMinAExcluded.fee,
+      deductedFromTokenMinB: tokenMinBExcluded.fee,
+      deductedFromTokenEstA: tokenEstAExcluded.fee,
+      deductedFromTokenEstB: tokenEstBExcluded.fee,
+    },
+  };
+}
+
+/**
+ * Get an estimated quote on the minimum tokens receivable based on the desired withdraw liquidity value.
+ * This version calculates slippage based on price percentage movement, rather than setting the percentage threshold based on token estimates.
+ * @param params DecreaseLiquidityQuoteParam
+ * @returns A DecreaseLiquidityQuote object detailing the tokenMin & liquidity values to use when calling decrease-liquidity-ix.
+ */
+export function decreaseLiquidityQuoteByLiquidityWithParamsUsingPriceSlippage(params: DecreaseLiquidityQuoteParam): DecreaseLiquidityQuote {
+  const { tokenExtensionCtx } = params;
+  if (params.liquidity.eq(ZERO)) {
+    return {
+      tokenMinA: ZERO,
+      tokenMinB: ZERO,
+      liquidityAmount: ZERO,
+      tokenEstA: ZERO,
+      tokenEstB: ZERO,
+      transferFee: {
+        deductedFromTokenMinA: ZERO,
+        deductedFromTokenMinB: ZERO,
+        deductedFromTokenEstA: ZERO,
+        deductedFromTokenEstB: ZERO,
+      },
+    };
+  }
+
+  const { tokenEstA, tokenEstB } = getTokenEstimatesFromLiquidity(params);
+
+  const {
+    lowerBound: [sLowerSqrtPrice, sLowerIndex],
+    upperBound: [sUpperSqrtPrice, sUpperIndex],
+  } = PriceMath.getSlippageBoundForSqrtPrice(params.sqrtPrice, params.slippageTolerance);
+
+  const { tokenEstA: tokenEstALower, tokenEstB: tokenEstBLower } = getTokenEstimatesFromLiquidity({
+    ...params,
+    sqrtPrice: sLowerSqrtPrice,
+    tickCurrentIndex: sLowerIndex,
+  });
+
+  const { tokenEstA: tokenEstAUpper, tokenEstB: tokenEstBUpper } = getTokenEstimatesFromLiquidity({
+    ...params,
+    sqrtPrice: sUpperSqrtPrice,
+    tickCurrentIndex: sUpperIndex,
+  });
+
+  const tokenMinA = BN.min(BN.min(tokenEstA, tokenEstALower), tokenEstAUpper);
+  const tokenMinB = BN.min(BN.min(tokenEstB, tokenEstBLower), tokenEstBUpper);
+
+  const tokenMinAExcluded = TokenExtensionUtil.calculateTransferFeeExcludedAmount(tokenMinA, tokenExtensionCtx.tokenMintWithProgramA, tokenExtensionCtx.currentEpoch);
+  const tokenEstAExcluded = TokenExtensionUtil.calculateTransferFeeExcludedAmount(tokenEstA, tokenExtensionCtx.tokenMintWithProgramA, tokenExtensionCtx.currentEpoch);
+  const tokenMinBExcluded = TokenExtensionUtil.calculateTransferFeeExcludedAmount(tokenMinB, tokenExtensionCtx.tokenMintWithProgramB, tokenExtensionCtx.currentEpoch);
+  const tokenEstBExcluded = TokenExtensionUtil.calculateTransferFeeExcludedAmount(tokenEstB, tokenExtensionCtx.tokenMintWithProgramB, tokenExtensionCtx.currentEpoch);
+
+  return {
+    tokenMinA,
+    tokenMinB,
+    tokenEstA,
+    tokenEstB,
+    liquidityAmount: params.liquidity,
+    transferFee: {
+      deductedFromTokenMinA: tokenMinAExcluded.fee,
+      deductedFromTokenMinB: tokenMinBExcluded.fee,
+      deductedFromTokenEstA: tokenEstAExcluded.fee,
+      deductedFromTokenEstB: tokenEstBExcluded.fee,
+    },
   }
 }
 
-function quotePositionBelowRange(param: DecreaseLiquidityQuoteParam): DecreaseLiquidityQuote {
-  const { tickLowerIndex, tickUpperIndex, liquidity, slippageTolerance, tokenExtensionCtx } = param;
+function getTokenEstimatesFromLiquidity(params: DecreaseLiquidityQuoteParam) {
+  const { liquidity, tickLowerIndex, tickUpperIndex, sqrtPrice } = params;
 
-  const sqrtPriceLowerX64 = PriceMath.tickIndexToSqrtPriceX64(tickLowerIndex);
-  const sqrtPriceUpperX64 = PriceMath.tickIndexToSqrtPriceX64(tickUpperIndex);
+  if (liquidity.eq(ZERO)) {
+    throw new Error("liquidity must be greater than 0");
+  }
 
-  const tokenEstA = getTokenAFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceUpperX64, false);
-  const tokenMinA = adjustForSlippage(tokenEstA, slippageTolerance, false);
+  let tokenEstA = ZERO;
+  let tokenEstB = ZERO;
 
-  const tokenMinAExcluded = TokenExtensionUtil.calculateTransferFeeExcludedAmount(tokenMinA, tokenExtensionCtx.tokenMintWithProgramA, tokenExtensionCtx.currentEpoch);
-  const tokenEstAExcluded = TokenExtensionUtil.calculateTransferFeeExcludedAmount(tokenEstA, tokenExtensionCtx.tokenMintWithProgramA, tokenExtensionCtx.currentEpoch);
+  const lowerSqrtPrice = PriceMath.tickIndexToSqrtPriceX64(tickLowerIndex);
+  const upperSqrtPrice = PriceMath.tickIndexToSqrtPriceX64(tickUpperIndex);
+  const positionStatus = PositionUtil.getStrictPositionStatus(sqrtPrice, tickLowerIndex, tickUpperIndex);
 
-  return {
-    liquidityAmount: liquidity,
-    tokenMinA: tokenMinAExcluded.amount,
-    tokenMinB: ZERO,
-    tokenEstA: tokenEstAExcluded.amount,
-    tokenEstB: ZERO,
-    transferFee: {
-      deductedFromTokenMinA: tokenMinAExcluded.fee,
-      deductedFromTokenMinB: ZERO,
-      deductedFromTokenEstA: tokenEstAExcluded.fee,
-      deductedFromTokenEstB: ZERO,
-    },
-  };
-}
-
-function quotePositionInRange(param: DecreaseLiquidityQuoteParam): DecreaseLiquidityQuote {
-  const { sqrtPrice, tickLowerIndex, tickUpperIndex, liquidity, slippageTolerance, tokenExtensionCtx } = param;
-
-  const sqrtPriceX64 = sqrtPrice;
-  const sqrtPriceLowerX64 = PriceMath.tickIndexToSqrtPriceX64(tickLowerIndex);
-  const sqrtPriceUpperX64 = PriceMath.tickIndexToSqrtPriceX64(tickUpperIndex);
-
-  const tokenEstA = getTokenAFromLiquidity(liquidity, sqrtPriceX64, sqrtPriceUpperX64, false);
-  const tokenMinA = adjustForSlippage(tokenEstA, slippageTolerance, false);
-  const tokenEstB = getTokenBFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceX64, false);
-  const tokenMinB = adjustForSlippage(tokenEstB, slippageTolerance, false);
-
-  const tokenMinAExcluded = TokenExtensionUtil.calculateTransferFeeExcludedAmount(tokenMinA, tokenExtensionCtx.tokenMintWithProgramA, tokenExtensionCtx.currentEpoch);
-  const tokenEstAExcluded = TokenExtensionUtil.calculateTransferFeeExcludedAmount(tokenEstA, tokenExtensionCtx.tokenMintWithProgramA, tokenExtensionCtx.currentEpoch);
-  const tokenMinBExcluded = TokenExtensionUtil.calculateTransferFeeExcludedAmount(tokenMinB, tokenExtensionCtx.tokenMintWithProgramB, tokenExtensionCtx.currentEpoch);
-  const tokenEstBExcluded = TokenExtensionUtil.calculateTransferFeeExcludedAmount(tokenEstB, tokenExtensionCtx.tokenMintWithProgramB, tokenExtensionCtx.currentEpoch);
-
-  return {
-    liquidityAmount: liquidity,
-    tokenMinA: tokenMinAExcluded.amount,
-    tokenMinB: tokenMinBExcluded.amount,
-    tokenEstA: tokenEstAExcluded.amount,
-    tokenEstB: tokenEstBExcluded.amount,
-    transferFee: {
-      deductedFromTokenMinA: tokenMinAExcluded.fee,
-      deductedFromTokenMinB: tokenMinBExcluded.fee,
-      deductedFromTokenEstA: tokenEstAExcluded.fee,
-      deductedFromTokenEstB: tokenEstBExcluded.fee,
-    },
-  };
-}
-
-function quotePositionAboveRange(param: DecreaseLiquidityQuoteParam): DecreaseLiquidityQuote {
-  const { tickLowerIndex, tickUpperIndex, liquidity, slippageTolerance: slippageTolerance, tokenExtensionCtx } = param;
-
-  const sqrtPriceLowerX64 = PriceMath.tickIndexToSqrtPriceX64(tickLowerIndex);
-  const sqrtPriceUpperX64 = PriceMath.tickIndexToSqrtPriceX64(tickUpperIndex);
-
-  const tokenEstB = getTokenBFromLiquidity(liquidity, sqrtPriceLowerX64, sqrtPriceUpperX64, false);
-  const tokenMinB = adjustForSlippage(tokenEstB, slippageTolerance, false);
-
-  const tokenMinBExcluded = TokenExtensionUtil.calculateTransferFeeExcludedAmount(tokenMinB, tokenExtensionCtx.tokenMintWithProgramB, tokenExtensionCtx.currentEpoch);
-  const tokenEstBExcluded = TokenExtensionUtil.calculateTransferFeeExcludedAmount(tokenEstB, tokenExtensionCtx.tokenMintWithProgramB, tokenExtensionCtx.currentEpoch);
-
-  return {
-    liquidityAmount: liquidity,
-    tokenMinA: ZERO,
-    tokenMinB: tokenMinBExcluded.amount,
-    tokenEstA: ZERO,
-    tokenEstB: tokenEstBExcluded.amount,
-    transferFee: {
-      deductedFromTokenMinA: ZERO,
-      deductedFromTokenMinB: tokenMinBExcluded.fee,
-      deductedFromTokenEstA: ZERO,
-      deductedFromTokenEstB: tokenEstBExcluded.fee,
-    },
-  };
+  if (positionStatus === PositionStatus.BelowRange) {
+    tokenEstA = getTokenAFromLiquidity(liquidity, lowerSqrtPrice, upperSqrtPrice, false);
+  } else if (positionStatus === PositionStatus.InRange) {
+    tokenEstA = getTokenAFromLiquidity(liquidity, sqrtPrice, upperSqrtPrice, false);
+    tokenEstB = getTokenBFromLiquidity(liquidity, lowerSqrtPrice, sqrtPrice, false);
+  } else {
+    tokenEstB = getTokenBFromLiquidity(liquidity, lowerSqrtPrice, upperSqrtPrice, false);
+  }
+  return { tokenEstA, tokenEstB };
 }

--- a/sdk/src/quotes/public/increase-liquidity-quote.ts
+++ b/sdk/src/quotes/public/increase-liquidity-quote.ts
@@ -319,8 +319,6 @@ function getTokenEstimatesFromLiquidity(params: IncreaseLiquidityQuoteByLiquidit
   return { tokenEstA, tokenEstB };
 }
 
-/*** --------- Deprecated --------- ***/
-
 /**
  * Get an estimated quote on the maximum tokens required to deposit based on a specified input token amount.
  *
@@ -332,7 +330,6 @@ function getTokenEstimatesFromLiquidity(params: IncreaseLiquidityQuoteByLiquidit
  * @param slippageTolerance - The maximum slippage allowed when calculating the minimum tokens received.
  * @param whirlpool - A Whirlpool helper class to help interact with the Whirlpool account.
  * @returns An IncreaseLiquidityInput object detailing the required token amounts & liquidity values to use when calling increase-liquidity-ix.
- * @deprecated Use increaseLiquidityQuoteByInputTokenUsingPriceSlippage instead.
  */
 export function increaseLiquidityQuoteByInputToken(
   inputTokenMint: Address,
@@ -367,7 +364,6 @@ export function increaseLiquidityQuoteByInputToken(
  * @category Quotes
  * @param param IncreaseLiquidityQuoteParam
  * @returns An IncreaseLiquidityInput object detailing the required token amounts & liquidity values to use when calling increase-liquidity-ix.
- * @deprecated Use increaseLiquidityQuoteByInputTokenWithParams_PriceSlippage instead.
  */
 export function increaseLiquidityQuoteByInputTokenWithParams(
   param: IncreaseLiquidityQuoteParam

--- a/sdk/tests/sdk/whirlpools/quote/decrease-liquidity-quote.test.ts
+++ b/sdk/tests/sdk/whirlpools/quote/decrease-liquidity-quote.test.ts
@@ -1,10 +1,9 @@
-import *  as assert from "assert";
-import { PriceMath, decreaseLiquidityQuoteByLiquidityWithParams } from "../../../../src";
-import { BN } from "bn.js";
+import { Percentage } from "@orca-so/common-sdk";
 import { PublicKey } from "@solana/web3.js";
-import { MintWithTokenProgram, Percentage } from "@orca-so/common-sdk";
-import { NO_TOKEN_EXTENSION_CONTEXT, TokenExtensionContextForPool } from "../../../../src/utils/public/token-extension-util";
-import { TEST_TOKEN_PROGRAM_ID } from "../../../utils";
+import * as assert from "assert";
+import { BN } from "bn.js";
+import { DecreaseLiquidityQuoteParam, MAX_SQRT_PRICE_BN, MAX_TICK_INDEX, MIN_SQRT_PRICE_BN, MIN_TICK_INDEX, PriceMath, decreaseLiquidityQuoteByLiquidityWithParams, decreaseLiquidityQuoteByLiquidityWithParamsUsingPriceSlippage } from "../../../../src";
+import { NO_TOKEN_EXTENSION_CONTEXT } from "../../../../src/utils/public/token-extension-util";
 
 describe("edge cases", () => {
   const tokenMintA = new PublicKey("orcaEKTdK7LKz57vaAYr9QeNsVEPfiu6QeMU1kektZE");
@@ -62,5 +61,149 @@ describe("edge cases", () => {
     assert.ok(quote.tokenMinA.isZero());
     assert.ok(quote.tokenMinB.gtn(0));
   });
+
+});
+
+describe("decreaseLiquidityQuoteByLiquidityWithParamsUsingPriceSlippage", () => {
+  it("normal price, 1.5% slippage", () => {
+    const params: DecreaseLiquidityQuoteParam = {
+      liquidity: new BN(100000),
+      sqrtPrice: PriceMath.tickIndexToSqrtPriceX64(1).subn(1),
+      tickLowerIndex: 0,
+      tickUpperIndex: 64,
+      tickCurrentIndex: 0,
+      slippageTolerance: Percentage.fromFraction(15, 1000), //1.5%
+      tokenExtensionCtx: NO_TOKEN_EXTENSION_CONTEXT, // TokenExtension is not related to this test
+    }
+    const quote = decreaseLiquidityQuoteByLiquidityWithParamsUsingPriceSlippage(params);
+
+    const { lowerBound, upperBound } = PriceMath.getSlippageBoundForSqrtPrice(params.sqrtPrice, params.slippageTolerance);
+
+    const quoteAtPlusSlippage = decreaseLiquidityQuoteByLiquidityWithParams({
+      ...params,
+      sqrtPrice: upperBound[0],
+      tickCurrentIndex: upperBound[1],
+      slippageTolerance: Percentage.fromFraction(0, 1000)
+    })
+
+    const quoteAtMinusSlippage = decreaseLiquidityQuoteByLiquidityWithParams({
+      ...params,
+      sqrtPrice: lowerBound[0],
+      tickCurrentIndex: lowerBound[1],
+      slippageTolerance: Percentage.fromFraction(0, 1000)
+    })
+
+    const expectedTokenMinA = BN.min(BN.min(quote.tokenEstA, quoteAtPlusSlippage.tokenEstA), quoteAtMinusSlippage.tokenEstA);
+    const expectedTokenMinB = BN.min(BN.min(quote.tokenEstB, quoteAtPlusSlippage.tokenEstB), quoteAtMinusSlippage.tokenEstB);
+
+    assert.ok(quote.tokenMinA.eq(expectedTokenMinA));
+    assert.ok(quote.tokenMinB.eq(expectedTokenMinB));
+  });
+
+  it("normal price, 0 slippage", () => {
+    const params: DecreaseLiquidityQuoteParam = {
+      liquidity: new BN(100000),
+      sqrtPrice: PriceMath.tickIndexToSqrtPriceX64(1).subn(1),
+      tickLowerIndex: 0,
+      tickUpperIndex: 64,
+      tickCurrentIndex: 0,
+      slippageTolerance: Percentage.fromFraction(0, 1000),
+      tokenExtensionCtx: NO_TOKEN_EXTENSION_CONTEXT, // TokenExtension is not related to this test
+    }
+    const quote = decreaseLiquidityQuoteByLiquidityWithParamsUsingPriceSlippage(params);
+
+    const { lowerBound, upperBound } = PriceMath.getSlippageBoundForSqrtPrice(params.sqrtPrice, params.slippageTolerance);
+
+    const quoteAtPlusSlippage = decreaseLiquidityQuoteByLiquidityWithParams({
+      ...params,
+      sqrtPrice: upperBound[0],
+      tickCurrentIndex: upperBound[1],
+      slippageTolerance: Percentage.fromFraction(0, 1000)
+    })
+
+    const quoteAtMinusSlippage = decreaseLiquidityQuoteByLiquidityWithParams({
+      ...params,
+      sqrtPrice: lowerBound[0],
+      tickCurrentIndex: lowerBound[1],
+      slippageTolerance: Percentage.fromFraction(0, 1000)
+    })
+
+    const expectedTokenMinA = BN.min(BN.min(quote.tokenEstA, quoteAtPlusSlippage.tokenEstA), quoteAtMinusSlippage.tokenEstA);
+    const expectedTokenMinB = BN.min(BN.min(quote.tokenEstB, quoteAtPlusSlippage.tokenEstB), quoteAtMinusSlippage.tokenEstB);
+
+    assert.ok(quote.tokenMinA.eq(expectedTokenMinA));
+    assert.ok(quote.tokenMinB.eq(expectedTokenMinB));
+  });
+
+
+  it("at MAX_PRICE, slippage at 1.5%", () => {
+    const params: DecreaseLiquidityQuoteParam = {
+      liquidity: new BN(100000),
+      sqrtPrice: MAX_SQRT_PRICE_BN,
+      tickLowerIndex: 0,
+      tickUpperIndex: 64,
+      tickCurrentIndex: MAX_TICK_INDEX,
+      slippageTolerance: Percentage.fromFraction(15, 1000), //1.5%
+      tokenExtensionCtx: NO_TOKEN_EXTENSION_CONTEXT, // TokenExtension is not related to this test
+    }
+    const quote = decreaseLiquidityQuoteByLiquidityWithParamsUsingPriceSlippage(params);
+
+    const { lowerBound, upperBound } = PriceMath.getSlippageBoundForSqrtPrice(params.sqrtPrice, params.slippageTolerance);
+
+    const quoteAtPlusSlippage = decreaseLiquidityQuoteByLiquidityWithParams({
+      ...params,
+      sqrtPrice: upperBound[0],
+      tickCurrentIndex: upperBound[1],
+      slippageTolerance: Percentage.fromFraction(0, 1000)
+    })
+
+    const quoteAtMinusSlippage = decreaseLiquidityQuoteByLiquidityWithParams({
+      ...params,
+      sqrtPrice: lowerBound[0],
+      tickCurrentIndex: lowerBound[1],
+      slippageTolerance: Percentage.fromFraction(0, 1000)
+    })
+
+    const expectedTokenMinA = BN.min(BN.min(quote.tokenEstA, quoteAtPlusSlippage.tokenEstA), quoteAtMinusSlippage.tokenEstA);
+    const expectedTokenMinB = BN.min(BN.min(quote.tokenEstB, quoteAtPlusSlippage.tokenEstB), quoteAtMinusSlippage.tokenEstB);
+
+    assert.ok(quote.tokenMinA.eq(expectedTokenMinA));
+    assert.ok(quote.tokenMinB.eq(expectedTokenMinB));
+  })
+
+  it("at MIN_PRICE, slippage at 1.5%", () => {
+    const params: DecreaseLiquidityQuoteParam = {
+      liquidity: new BN(100000),
+      sqrtPrice: MIN_SQRT_PRICE_BN,
+      tickLowerIndex: 0,
+      tickUpperIndex: 64,
+      tickCurrentIndex: MIN_TICK_INDEX,
+      slippageTolerance: Percentage.fromFraction(15, 1000), //1.5%
+      tokenExtensionCtx: NO_TOKEN_EXTENSION_CONTEXT, // TokenExtension is not related to this test
+    }
+    const quote = decreaseLiquidityQuoteByLiquidityWithParamsUsingPriceSlippage(params);
+
+    const { lowerBound, upperBound } = PriceMath.getSlippageBoundForSqrtPrice(params.sqrtPrice, params.slippageTolerance);
+
+    const quoteAtPlusSlippage = decreaseLiquidityQuoteByLiquidityWithParams({
+      ...params,
+      sqrtPrice: upperBound[0],
+      tickCurrentIndex: upperBound[1],
+      slippageTolerance: Percentage.fromFraction(0, 1000)
+    })
+
+    const quoteAtMinusSlippage = decreaseLiquidityQuoteByLiquidityWithParams({
+      ...params,
+      sqrtPrice: lowerBound[0],
+      tickCurrentIndex: lowerBound[1],
+      slippageTolerance: Percentage.fromFraction(0, 1000)
+    })
+
+    const expectedTokenMinA = BN.min(BN.min(quoteAtMinusSlippage.tokenEstA, quoteAtPlusSlippage.tokenEstA), quoteAtMinusSlippage.tokenEstA);
+    const expectedTokenMinB = BN.min(BN.min(quoteAtMinusSlippage.tokenEstB, quoteAtPlusSlippage.tokenEstB), quoteAtMinusSlippage.tokenEstB);
+
+    assert.ok(quote.tokenMinA.eq(expectedTokenMinA));
+    assert.ok(quote.tokenMinB.eq(expectedTokenMinB));
+  })
 
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -187,10 +187,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@orca-so/common-sdk@0.6.0-alpha.1":
-  version "0.6.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@orca-so/common-sdk/-/common-sdk-0.6.0-alpha.1.tgz#9ed814ca4d6e095b2c74ecf1de6eddf6b4bbe556"
-  integrity sha512-G5pVGybh3U5CcxyMSiBqD6qugr3HqsafJXbLn/3/7SLky/YR0I7AvMBF+SiGooHb4ROIZ4jKVXRFXD1/43wKWg==
+"@orca-so/common-sdk@0.6.0-alpha.2":
+  version "0.6.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@orca-so/common-sdk/-/common-sdk-0.6.0-alpha.2.tgz#d427da5ccfe0e169c44bc39edee4b99d08c9aa1c"
+  integrity sha512-3P65GMTfaB4xDBIcfCF/seXnxsgeI8Uv6DlEZUfTjv0DIx2spX2UpUrPyRTnU/4Ig2a8vNbgPyNe3pVNDSdN1w==
   dependencies:
     tiny-invariant "^1.3.1"
 
@@ -2114,16 +2114,7 @@ source-map@^0.6.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2141,14 +2132,7 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -2410,16 +2394,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
- Add a price-slippage variant to `decreaseLiquidityQuoteByLiquidity`
- un-deprecate the token-slippage variant for `increaseLiquidityQuoteByLiquidity` since it's actually a valid calculation option 