### PR TITLE
SparseSwap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2725,7 +2725,9 @@ version = "0.3.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
+ "arrayref",
  "borsh 0.9.3",
+ "bytemuck",
  "proptest",
  "serde",
  "serde_json",

--- a/programs/whirlpool/Cargo.toml
+++ b/programs/whirlpool/Cargo.toml
@@ -23,6 +23,8 @@ solana-program = "1.17"
 thiserror = "1.0"
 uint = {version = "0.9.1", default-features = false}
 borsh09 = {package = "borsh", version = "0.9.1"}
+arrayref = "0.3.7"
+bytemuck = "1.14.3"
 solana-security-txt = { version = "=1.1.1" }
 
 [dev-dependencies]

--- a/programs/whirlpool/src/errors.rs
+++ b/programs/whirlpool/src/errors.rs
@@ -135,6 +135,11 @@ pub enum ErrorCode {
 
     #[msg("Same accounts type is provided more than once")]
     RemainingAccountsDuplicatedAccountsType, // 0x17a5 (6053)
+
+    #[msg("Too many additional tick arrays provided")]
+    TooManyAdditionalTickArrays, // 0x17a6 (6054)
+    #[msg("TickArray account for different whirlpool provided")]
+    DifferentWhirlpoolTickArrayAccount, // 0x17a7 (6055)
 }
 
 impl From<TryFromIntError> for ErrorCode {

--- a/programs/whirlpool/src/errors.rs
+++ b/programs/whirlpool/src/errors.rs
@@ -136,8 +136,8 @@ pub enum ErrorCode {
     #[msg("Same accounts type is provided more than once")]
     RemainingAccountsDuplicatedAccountsType, // 0x17a5 (6053)
 
-    #[msg("Too many additional tick arrays provided")]
-    TooManyAdditionalTickArrays, // 0x17a6 (6054)
+    #[msg("Too many supplemental tick arrays provided")]
+    TooManySupplementalTickArrays, // 0x17a6 (6054)
     #[msg("TickArray account for different whirlpool provided")]
     DifferentWhirlpoolTickArrayAccount, // 0x17a7 (6055)
 }

--- a/programs/whirlpool/src/instructions/swap.rs
+++ b/programs/whirlpool/src/instructions/swap.rs
@@ -64,7 +64,7 @@ pub fn handler(
         ctx.accounts.tick_array_2.to_account_info(),
     ];
     let builder = SparseSwapTickSequenceBuilder::try_from(
-        whirlpool.clone(),
+        whirlpool,
         a_to_b,
         tick_array_account_infos
     )?;

--- a/programs/whirlpool/src/instructions/swap.rs
+++ b/programs/whirlpool/src/instructions/swap.rs
@@ -1,10 +1,11 @@
+use std::{cell::{RefCell, RefMut}, collections::VecDeque};
 use anchor_lang::prelude::*;
 use anchor_spl::token::{self, Token, TokenAccount};
 
 use crate::{
     errors::ErrorCode,
     manager::swap_manager::*,
-    state::{TickArray, Whirlpool},
+    state::{TickArray, Whirlpool, MAX_TICK_INDEX, MIN_TICK_INDEX, TICK_ARRAY_SIZE},
     util::{to_timestamp_u64, update_and_swap_whirlpool, SwapTickSequence},
 };
 
@@ -28,14 +29,23 @@ pub struct Swap<'info> {
     #[account(mut, address = whirlpool.token_vault_b)]
     pub token_vault_b: Box<Account<'info, TokenAccount>>,
 
-    #[account(mut, has_one = whirlpool)]
-    pub tick_array_0: AccountLoader<'info, TickArray>,
+    // #[account(mut, has_one = whirlpool)]
+    // pub tick_array_0: AccountLoader<'info, TickArray>,
+    #[account(mut)]
+    /// CHECK: checked in the handler
+    pub tick_array_0: UncheckedAccount<'info>,
 
-    #[account(mut, has_one = whirlpool)]
-    pub tick_array_1: AccountLoader<'info, TickArray>,
+    // #[account(mut, has_one = whirlpool)]
+    // pub tick_array_1: AccountLoader<'info, TickArray>,
+    #[account(mut)]
+    /// CHECK: checked in the handler
+    pub tick_array_1: UncheckedAccount<'info>,
 
-    #[account(mut, has_one = whirlpool)]
-    pub tick_array_2: AccountLoader<'info, TickArray>,
+    // #[account(mut, has_one = whirlpool)]
+    // pub tick_array_2: AccountLoader<'info, TickArray>,
+    #[account(mut)]
+    /// CHECK: checked in the handler
+    pub tick_array_2: UncheckedAccount<'info>,
 
     #[account(seeds = [b"oracle", whirlpool.key().as_ref()],bump)]
     /// CHECK: Oracle is currently unused and will be enabled on subsequent updates
@@ -54,12 +64,27 @@ pub fn handler(
     let clock = Clock::get()?;
     // Update the global reward growth which increases as a function of time.
     let timestamp = to_timestamp_u64(clock.unix_timestamp)?;
+
+    let mut virtual_zero_tick_arrays: [Option<Box<RefCell<TickArray>>>; 3] = [None, None, None];
+    let provided_tick_array_accounts = vec![
+        ctx.accounts.tick_array_0.to_account_info(),
+        ctx.accounts.tick_array_1.to_account_info(),
+        ctx.accounts.tick_array_2.to_account_info(),
+    ];
+    let mut provided_tick_array_account_refs = provided_tick_array_accounts.iter().collect::<Vec<_>>();
+    let mut swap_tick_sequence = build_swap_tick_sequence(
+        &whirlpool,
+        a_to_b,
+        &mut virtual_zero_tick_arrays,
+        &mut provided_tick_array_account_refs,
+    )?;
+/*
     let mut swap_tick_sequence = SwapTickSequence::new(
         ctx.accounts.tick_array_0.load_mut().unwrap(),
         ctx.accounts.tick_array_1.load_mut().ok(),
         ctx.accounts.tick_array_2.load_mut().ok(),
     );
-
+*/
     let swap_update = swap(
         &whirlpool,
         &mut swap_tick_sequence,
@@ -96,4 +121,203 @@ pub fn handler(
         a_to_b,
         timestamp,
     )
+}
+
+
+fn build_swap_tick_sequence<'a, 't, 'info>(
+    whirlpool: &'t Account<'info, Whirlpool>,
+    a_to_b: bool,
+    virtual_zero_tick_arrays: &'a mut [Option<Box<RefCell<TickArray>>>; 3],
+    provided_tick_array_account_refs: &'a mut Vec<&'a AccountInfo<'info>>,
+) -> Result<SwapTickSequence<'a>> {
+    // dedup by key
+    provided_tick_array_account_refs.sort_by_key(|a| a.key());
+    provided_tick_array_account_refs.dedup_by_key(|a| a.key());
+
+    let mut initialized = vec![];
+    let mut uninitialized = vec![];
+    for account_info in provided_tick_array_account_refs {
+        match load_tick_array_mut(account_info)? {
+            TickArrayAccountState::Initialized(tick_array) => {
+                // has_one constraint equivalent check
+                if tick_array.whirlpool != whirlpool.key() {
+                    // TODO: our own error definition
+                    return Err(anchor_lang::error::ErrorCode::ConstraintHasOne.into());
+                }
+
+                initialized.push(tick_array);
+            }
+            TickArrayAccountState::Uninitialized(pubkey) => {
+                uninitialized.push(pubkey);
+            }
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Now successfully loaded tick arrays have been verified as:
+    // - Owned by Whirlpool Program
+    // - Initialized as TickArray account
+    // - And has_one constraint is satisfied (i.e. belongs to trading whirlpool)
+    // - Writable
+    ////////////////////////////////////////////////////////////////////////
+    let tick_current_index = whirlpool.tick_current_index;
+    let tick_spacing = whirlpool.tick_spacing as i32;
+    let ticks_in_array = TICK_ARRAY_SIZE * tick_spacing;
+
+    let start_tick_index_base = floor_division(tick_current_index, ticks_in_array) * ticks_in_array;
+    let offset = if a_to_b {
+        [0, -1, -2]
+    } else {
+        let shifted = tick_current_index + tick_spacing >= start_tick_index_base + ticks_in_array;
+        if shifted { [1, 2, 3] } else { [0, 1, 2] }
+    };
+
+    let start_tick_indexes = offset
+        .iter()
+        .filter_map(|&o| {
+            let start_tick_index = start_tick_index_base + o * ticks_in_array;
+            let valid = start_tick_index + ticks_in_array > MIN_TICK_INDEX && start_tick_index < MAX_TICK_INDEX;
+            if valid {
+                Some(start_tick_index)
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<i32>>();
+
+    // TODO: debug
+    msg!("tick_current_index: {}, ts: {}, ticks_in_array: {}", tick_current_index, tick_spacing, ticks_in_array);
+    msg!("a_to_b: {}", a_to_b);
+    msg!("start_tick_indexes: {:?}", start_tick_indexes);
+
+    // to make virtual
+    for (i, start_tick_index) in start_tick_indexes.iter().enumerate() {
+        // find from initialized tick arrays
+        if let Some(pos) = initialized.iter().position(|tick_array| tick_array.start_tick_index == *start_tick_index) {
+            continue;
+        }
+
+        // find from uninitialized tick arrays
+        let tick_array_pda = derive_tick_array_pda(whirlpool, *start_tick_index);
+        if let Some(pos) = uninitialized.iter().position(|key| key == &tick_array_pda) {
+            let virtual_zero_tick_array = Some(Box::new(RefCell::new(TickArray::default())));
+            virtual_zero_tick_array.as_ref().unwrap().borrow_mut().initialize(whirlpool, *start_tick_index)?;
+            virtual_zero_tick_arrays[i] = virtual_zero_tick_array;
+            continue;
+        }
+
+        // no more valid tickarrays for this swap
+        break;
+    }
+
+    let mut refmut_tick_arrays = VecDeque::with_capacity(3);
+    for (i, start_tick_index) in start_tick_indexes.iter().enumerate() {
+        // find from initialized tick arrays
+        if let Some(pos) = initialized.iter().position(|tick_array| tick_array.start_tick_index == *start_tick_index) {
+            refmut_tick_arrays.push_back(initialized.remove(pos));
+            continue;
+        }
+
+        // find from uninitialized tick arrays
+        let tick_array_pda = derive_tick_array_pda(whirlpool, *start_tick_index);
+        if let Some(pos) = uninitialized.iter().position(|key| key == &tick_array_pda) {
+            uninitialized.remove(pos);
+
+            //let x = virtual_zero_tick_array.as_ref().as_ref().unwrap().borrow_mut();
+            let refmut_tick_array = virtual_zero_tick_arrays[i].as_ref().as_ref().unwrap().borrow_mut();            
+            refmut_tick_arrays.push_back(refmut_tick_array);
+            continue;
+        }
+
+        // no more valid tickarrays for this swap
+        break;
+    }
+
+    // TODO: debug
+    msg!("refmut_tick_arrays len: {}", refmut_tick_arrays.len());
+    for r in &refmut_tick_arrays {
+        let s = r.start_tick_index;
+        msg!("start_tick_index: {}", s);
+    }
+
+    if refmut_tick_arrays.is_empty() {
+        // TODO: define specific error
+        return Err(crate::errors::ErrorCode::InvalidTickArraySequence.into());
+    }
+
+    Ok(SwapTickSequence::<'a>::new(
+        refmut_tick_arrays.pop_front().unwrap(),
+        refmut_tick_arrays.pop_front(),
+        refmut_tick_arrays.pop_front(),
+    ))
+}
+
+enum TickArrayAccountState<'a> {
+    // owned by this whirlpool program and its discriminator is valid and writable
+    // but not sure if this TickArray is valid for this whirlpool (maybe for another whirlpool)
+    Initialized(RefMut<'a, TickArray>),
+    // owned by system program and its data size is zero and writable
+    // but not sure if this key is valid PDA for TickArray
+    Uninitialized(Pubkey),
+}
+
+fn load_tick_array_mut<'a, 'info>(
+    account_info: &'a AccountInfo<'info>,
+) -> Result<TickArrayAccountState<'a>> {
+    use anchor_lang::Discriminator;
+    use std::ops::DerefMut;
+
+    // following process is ported from anchor-lang's AccountLoader::try_from and AccountLoader::load_mut
+
+    if !account_info.is_writable {
+        return Err(anchor_lang::error::ErrorCode::AccountNotMutable.into());
+    }
+
+    // uninitialized writable account (owned by system program and its data size is zero)
+    if account_info.owner == &System::id() && account_info.data_is_empty() {
+        return Ok(TickArrayAccountState::Uninitialized(*account_info.key));
+    }
+
+    // owner program check
+    if account_info.owner != &TickArray::owner() {
+        return Err(Error::from(anchor_lang::error::ErrorCode::AccountOwnedByWrongProgram)
+            .with_pubkeys((*account_info.owner, TickArray::owner())));
+    }
+
+    let data = account_info.try_borrow_mut_data()?;
+    if data.len() < TickArray::discriminator().len() {
+        return Err(anchor_lang::error::ErrorCode::AccountDiscriminatorNotFound.into());
+    }
+
+    let disc_bytes = arrayref::array_ref![data, 0, 8];
+    if disc_bytes != &TickArray::discriminator() {
+        return Err(anchor_lang::error::ErrorCode::AccountDiscriminatorMismatch.into());
+    }
+
+    Ok(TickArrayAccountState::Initialized(RefMut::map(data, |data| {
+        bytemuck::from_bytes_mut(&mut data.deref_mut()[8..std::mem::size_of::<TickArray>() + 8])
+    })))
+}
+
+fn floor_division(dividend: i32, divisor: i32) -> i32 {
+    assert!(divisor != 0, "Divisor cannot be zero.");
+    if dividend % divisor == 0 || dividend.signum() == divisor.signum() {
+        dividend / divisor
+    } else {
+        dividend / divisor - 1
+    }
+}
+
+fn derive_tick_array_pda(
+    whirlpool: &Account<Whirlpool>,
+    start_tick_index: i32,
+) -> Pubkey {
+    Pubkey::find_program_address(
+        &[
+            b"tick_array",
+            whirlpool.key().as_ref(),
+            start_tick_index.to_string().as_bytes(),
+        ],
+        &TickArray::owner()
+    ).0
 }

--- a/programs/whirlpool/src/instructions/swap.rs
+++ b/programs/whirlpool/src/instructions/swap.rs
@@ -65,7 +65,7 @@ pub fn handler(
     // Update the global reward growth which increases as a function of time.
     let timestamp = to_timestamp_u64(clock.unix_timestamp)?;
 
-    let mut virtual_zero_tick_arrays: [Option<Box<RefCell<TickArray>>>; 3] = [None, None, None];
+    let mut virtual_zero_tick_arrays: Vec<Option<Box<RefCell<TickArray>>>> = vec![];
     let provided_tick_array_accounts = vec![
         ctx.accounts.tick_array_0.to_account_info(),
         ctx.accounts.tick_array_1.to_account_info(),
@@ -127,7 +127,7 @@ pub fn handler(
 fn build_swap_tick_sequence<'a, 't, 'info>(
     whirlpool: &'t Account<'info, Whirlpool>,
     a_to_b: bool,
-    virtual_zero_tick_arrays: &'a mut [Option<Box<RefCell<TickArray>>>; 3],
+    virtual_zero_tick_arrays: &'a mut Vec<Option<Box<RefCell<TickArray>>>>,
     provided_tick_array_account_refs: &'a mut Vec<&'a AccountInfo<'info>>,
 ) -> Result<SwapTickSequence<'a>> {
     // dedup by key
@@ -191,6 +191,7 @@ fn build_swap_tick_sequence<'a, 't, 'info>(
     msg!("start_tick_indexes: {:?}", start_tick_indexes);
 
     // to make virtual
+    virtual_zero_tick_arrays.resize(start_tick_indexes.len(), None);
     for (i, start_tick_index) in start_tick_indexes.iter().enumerate() {
         // find from initialized tick arrays
         if let Some(pos) = initialized.iter().position(|tick_array| tick_array.start_tick_index == *start_tick_index) {

--- a/programs/whirlpool/src/instructions/swap.rs
+++ b/programs/whirlpool/src/instructions/swap.rs
@@ -1,12 +1,11 @@
-use std::{cell::{RefCell, RefMut}, collections::VecDeque};
 use anchor_lang::prelude::*;
 use anchor_spl::token::{self, Token, TokenAccount};
 
 use crate::{
     errors::ErrorCode,
     manager::swap_manager::*,
-    state::{TickArray, Whirlpool, MAX_TICK_INDEX, MIN_TICK_INDEX, TICK_ARRAY_SIZE},
-    util::{to_timestamp_u64, update_and_swap_whirlpool, SwapTickSequence},
+    state::Whirlpool,
+    util::{to_timestamp_u64, update_and_swap_whirlpool, SparseSwapTickSequenceBuilder},
 };
 
 #[derive(Accounts)]
@@ -29,20 +28,14 @@ pub struct Swap<'info> {
     #[account(mut, address = whirlpool.token_vault_b)]
     pub token_vault_b: Box<Account<'info, TokenAccount>>,
 
-    // #[account(mut, has_one = whirlpool)]
-    // pub tick_array_0: AccountLoader<'info, TickArray>,
     #[account(mut)]
     /// CHECK: checked in the handler
     pub tick_array_0: UncheckedAccount<'info>,
 
-    // #[account(mut, has_one = whirlpool)]
-    // pub tick_array_1: AccountLoader<'info, TickArray>,
     #[account(mut)]
     /// CHECK: checked in the handler
     pub tick_array_1: UncheckedAccount<'info>,
 
-    // #[account(mut, has_one = whirlpool)]
-    // pub tick_array_2: AccountLoader<'info, TickArray>,
     #[account(mut)]
     /// CHECK: checked in the handler
     pub tick_array_2: UncheckedAccount<'info>,
@@ -65,26 +58,18 @@ pub fn handler(
     // Update the global reward growth which increases as a function of time.
     let timestamp = to_timestamp_u64(clock.unix_timestamp)?;
 
-    let mut virtual_zero_tick_arrays: Vec<Option<Box<RefCell<TickArray>>>> = vec![];
-    let provided_tick_array_accounts = vec![
+    let tick_array_account_infos = vec![
         ctx.accounts.tick_array_0.to_account_info(),
         ctx.accounts.tick_array_1.to_account_info(),
         ctx.accounts.tick_array_2.to_account_info(),
     ];
-    let mut provided_tick_array_account_refs = provided_tick_array_accounts.iter().collect::<Vec<_>>();
-    let mut swap_tick_sequence = build_swap_tick_sequence(
-        &whirlpool,
+    let builder = SparseSwapTickSequenceBuilder::try_from(
+        whirlpool.clone(),
         a_to_b,
-        &mut virtual_zero_tick_arrays,
-        &mut provided_tick_array_account_refs,
+        tick_array_account_infos
     )?;
-/*
-    let mut swap_tick_sequence = SwapTickSequence::new(
-        ctx.accounts.tick_array_0.load_mut().unwrap(),
-        ctx.accounts.tick_array_1.load_mut().ok(),
-        ctx.accounts.tick_array_2.load_mut().ok(),
-    );
-*/
+    let mut swap_tick_sequence = builder.build()?;
+    
     let swap_update = swap(
         &whirlpool,
         &mut swap_tick_sequence,
@@ -121,204 +106,4 @@ pub fn handler(
         a_to_b,
         timestamp,
     )
-}
-
-
-fn build_swap_tick_sequence<'a, 't, 'info>(
-    whirlpool: &'t Account<'info, Whirlpool>,
-    a_to_b: bool,
-    virtual_zero_tick_arrays: &'a mut Vec<Option<Box<RefCell<TickArray>>>>,
-    provided_tick_array_account_refs: &'a mut Vec<&'a AccountInfo<'info>>,
-) -> Result<SwapTickSequence<'a>> {
-    // dedup by key
-    provided_tick_array_account_refs.sort_by_key(|a| a.key());
-    provided_tick_array_account_refs.dedup_by_key(|a| a.key());
-
-    let mut initialized = vec![];
-    let mut uninitialized = vec![];
-    for account_info in provided_tick_array_account_refs {
-        match load_tick_array_mut(account_info)? {
-            TickArrayAccountState::Initialized(tick_array) => {
-                // has_one constraint equivalent check
-                if tick_array.whirlpool != whirlpool.key() {
-                    // TODO: our own error definition
-                    return Err(anchor_lang::error::ErrorCode::ConstraintHasOne.into());
-                }
-
-                initialized.push(tick_array);
-            }
-            TickArrayAccountState::Uninitialized(pubkey) => {
-                uninitialized.push(pubkey);
-            }
-        }
-    }
-
-    ////////////////////////////////////////////////////////////////////////
-    // Now successfully loaded tick arrays have been verified as:
-    // - Owned by Whirlpool Program
-    // - Initialized as TickArray account
-    // - And has_one constraint is satisfied (i.e. belongs to trading whirlpool)
-    // - Writable
-    ////////////////////////////////////////////////////////////////////////
-    let tick_current_index = whirlpool.tick_current_index;
-    let tick_spacing = whirlpool.tick_spacing as i32;
-    let ticks_in_array = TICK_ARRAY_SIZE * tick_spacing;
-
-    let start_tick_index_base = floor_division(tick_current_index, ticks_in_array) * ticks_in_array;
-    let offset = if a_to_b {
-        [0, -1, -2]
-    } else {
-        let shifted = tick_current_index + tick_spacing >= start_tick_index_base + ticks_in_array;
-        if shifted { [1, 2, 3] } else { [0, 1, 2] }
-    };
-
-    let start_tick_indexes = offset
-        .iter()
-        .filter_map(|&o| {
-            let start_tick_index = start_tick_index_base + o * ticks_in_array;
-            let valid = start_tick_index + ticks_in_array > MIN_TICK_INDEX && start_tick_index < MAX_TICK_INDEX;
-            if valid {
-                Some(start_tick_index)
-            } else {
-                None
-            }
-        })
-        .collect::<Vec<i32>>();
-
-    // TODO: debug
-    msg!("tick_current_index: {}, ts: {}, ticks_in_array: {}", tick_current_index, tick_spacing, ticks_in_array);
-    msg!("a_to_b: {}", a_to_b);
-    msg!("start_tick_indexes: {:?}", start_tick_indexes);
-
-    // to make virtual
-    virtual_zero_tick_arrays.resize(start_tick_indexes.len(), None);
-    for (i, start_tick_index) in start_tick_indexes.iter().enumerate() {
-        // find from initialized tick arrays
-        if let Some(pos) = initialized.iter().position(|tick_array| tick_array.start_tick_index == *start_tick_index) {
-            continue;
-        }
-
-        // find from uninitialized tick arrays
-        let tick_array_pda = derive_tick_array_pda(whirlpool, *start_tick_index);
-        if let Some(pos) = uninitialized.iter().position(|key| key == &tick_array_pda) {
-            let virtual_zero_tick_array = Some(Box::new(RefCell::new(TickArray::default())));
-            virtual_zero_tick_array.as_ref().unwrap().borrow_mut().initialize(whirlpool, *start_tick_index)?;
-            virtual_zero_tick_arrays[i] = virtual_zero_tick_array;
-            continue;
-        }
-
-        // no more valid tickarrays for this swap
-        break;
-    }
-
-    let mut refmut_tick_arrays = VecDeque::with_capacity(3);
-    for (i, start_tick_index) in start_tick_indexes.iter().enumerate() {
-        // find from initialized tick arrays
-        if let Some(pos) = initialized.iter().position(|tick_array| tick_array.start_tick_index == *start_tick_index) {
-            refmut_tick_arrays.push_back(initialized.remove(pos));
-            continue;
-        }
-
-        // find from uninitialized tick arrays
-        let tick_array_pda = derive_tick_array_pda(whirlpool, *start_tick_index);
-        if let Some(pos) = uninitialized.iter().position(|key| key == &tick_array_pda) {
-            uninitialized.remove(pos);
-
-            //let x = virtual_zero_tick_array.as_ref().as_ref().unwrap().borrow_mut();
-            let refmut_tick_array = virtual_zero_tick_arrays[i].as_ref().as_ref().unwrap().borrow_mut();            
-            refmut_tick_arrays.push_back(refmut_tick_array);
-            continue;
-        }
-
-        // no more valid tickarrays for this swap
-        break;
-    }
-
-    // TODO: debug
-    msg!("refmut_tick_arrays len: {}", refmut_tick_arrays.len());
-    for r in &refmut_tick_arrays {
-        let s = r.start_tick_index;
-        msg!("start_tick_index: {}", s);
-    }
-
-    if refmut_tick_arrays.is_empty() {
-        // TODO: define specific error
-        return Err(crate::errors::ErrorCode::InvalidTickArraySequence.into());
-    }
-
-    Ok(SwapTickSequence::<'a>::new(
-        refmut_tick_arrays.pop_front().unwrap(),
-        refmut_tick_arrays.pop_front(),
-        refmut_tick_arrays.pop_front(),
-    ))
-}
-
-enum TickArrayAccountState<'a> {
-    // owned by this whirlpool program and its discriminator is valid and writable
-    // but not sure if this TickArray is valid for this whirlpool (maybe for another whirlpool)
-    Initialized(RefMut<'a, TickArray>),
-    // owned by system program and its data size is zero and writable
-    // but not sure if this key is valid PDA for TickArray
-    Uninitialized(Pubkey),
-}
-
-fn load_tick_array_mut<'a, 'info>(
-    account_info: &'a AccountInfo<'info>,
-) -> Result<TickArrayAccountState<'a>> {
-    use anchor_lang::Discriminator;
-    use std::ops::DerefMut;
-
-    // following process is ported from anchor-lang's AccountLoader::try_from and AccountLoader::load_mut
-
-    if !account_info.is_writable {
-        return Err(anchor_lang::error::ErrorCode::AccountNotMutable.into());
-    }
-
-    // uninitialized writable account (owned by system program and its data size is zero)
-    if account_info.owner == &System::id() && account_info.data_is_empty() {
-        return Ok(TickArrayAccountState::Uninitialized(*account_info.key));
-    }
-
-    // owner program check
-    if account_info.owner != &TickArray::owner() {
-        return Err(Error::from(anchor_lang::error::ErrorCode::AccountOwnedByWrongProgram)
-            .with_pubkeys((*account_info.owner, TickArray::owner())));
-    }
-
-    let data = account_info.try_borrow_mut_data()?;
-    if data.len() < TickArray::discriminator().len() {
-        return Err(anchor_lang::error::ErrorCode::AccountDiscriminatorNotFound.into());
-    }
-
-    let disc_bytes = arrayref::array_ref![data, 0, 8];
-    if disc_bytes != &TickArray::discriminator() {
-        return Err(anchor_lang::error::ErrorCode::AccountDiscriminatorMismatch.into());
-    }
-
-    Ok(TickArrayAccountState::Initialized(RefMut::map(data, |data| {
-        bytemuck::from_bytes_mut(&mut data.deref_mut()[8..std::mem::size_of::<TickArray>() + 8])
-    })))
-}
-
-fn floor_division(dividend: i32, divisor: i32) -> i32 {
-    assert!(divisor != 0, "Divisor cannot be zero.");
-    if dividend % divisor == 0 || dividend.signum() == divisor.signum() {
-        dividend / divisor
-    } else {
-        dividend / divisor - 1
-    }
-}
-
-fn derive_tick_array_pda(
-    whirlpool: &Account<Whirlpool>,
-    start_tick_index: i32,
-) -> Pubkey {
-    Pubkey::find_program_address(
-        &[
-            b"tick_array",
-            whirlpool.key().as_ref(),
-            start_tick_index.to_string().as_bytes(),
-        ],
-        &TickArray::owner()
-    ).0
 }

--- a/programs/whirlpool/src/instructions/swap.rs
+++ b/programs/whirlpool/src/instructions/swap.rs
@@ -58,15 +58,15 @@ pub fn handler(
     // Update the global reward growth which increases as a function of time.
     let timestamp = to_timestamp_u64(clock.unix_timestamp)?;
 
-    let tick_array_account_infos = vec![
-        ctx.accounts.tick_array_0.to_account_info(),
-        ctx.accounts.tick_array_1.to_account_info(),
-        ctx.accounts.tick_array_2.to_account_info(),
-    ];
     let builder = SparseSwapTickSequenceBuilder::try_from(
         whirlpool,
         a_to_b,
-        tick_array_account_infos
+        vec![
+            ctx.accounts.tick_array_0.to_account_info(),
+            ctx.accounts.tick_array_1.to_account_info(),
+            ctx.accounts.tick_array_2.to_account_info(),
+        ],
+        None,
     )?;
     let mut swap_tick_sequence = builder.build()?;
     

--- a/programs/whirlpool/src/instructions/two_hop_swap.rs
+++ b/programs/whirlpool/src/instructions/two_hop_swap.rs
@@ -4,8 +4,8 @@ use anchor_spl::token::{self, Token, TokenAccount};
 use crate::{
     errors::ErrorCode,
     manager::swap_manager::*,
-    state::{TickArray, Whirlpool},
-    util::{to_timestamp_u64, update_and_swap_whirlpool, SwapTickSequence},
+    state::Whirlpool,
+    util::{to_timestamp_u64, update_and_swap_whirlpool, SparseSwapTickSequenceBuilder},
 };
 
 #[derive(Accounts)]
@@ -41,23 +41,29 @@ pub struct TwoHopSwap<'info> {
     #[account(mut, address = whirlpool_two.token_vault_b)]
     pub token_vault_two_b: Box<Account<'info, TokenAccount>>,
 
-    #[account(mut, constraint = tick_array_one_0.load()?.whirlpool == whirlpool_one.key())]
-    pub tick_array_one_0: AccountLoader<'info, TickArray>,
+    #[account(mut)]
+    /// CHECK: checked in the handler
+    pub tick_array_one_0: UncheckedAccount<'info>,
 
-    #[account(mut, constraint = tick_array_one_1.load()?.whirlpool == whirlpool_one.key())]
-    pub tick_array_one_1: AccountLoader<'info, TickArray>,
+    #[account(mut)]
+    /// CHECK: checked in the handler
+    pub tick_array_one_1: UncheckedAccount<'info>,
 
-    #[account(mut, constraint = tick_array_one_2.load()?.whirlpool == whirlpool_one.key())]
-    pub tick_array_one_2: AccountLoader<'info, TickArray>,
+    #[account(mut)]
+    /// CHECK: checked in the handler
+    pub tick_array_one_2: UncheckedAccount<'info>,
 
-    #[account(mut, constraint = tick_array_two_0.load()?.whirlpool == whirlpool_two.key())]
-    pub tick_array_two_0: AccountLoader<'info, TickArray>,
+    #[account(mut)]
+    /// CHECK: checked in the handler
+    pub tick_array_two_0: UncheckedAccount<'info>,
 
-    #[account(mut, constraint = tick_array_two_1.load()?.whirlpool == whirlpool_two.key())]
-    pub tick_array_two_1: AccountLoader<'info, TickArray>,
+    #[account(mut)]
+    /// CHECK: checked in the handler
+    pub tick_array_two_1: UncheckedAccount<'info>,
 
-    #[account(mut, constraint = tick_array_two_2.load()?.whirlpool == whirlpool_two.key())]
-    pub tick_array_two_2: AccountLoader<'info, TickArray>,
+    #[account(mut)]
+    /// CHECK: checked in the handler
+    pub tick_array_two_2: UncheckedAccount<'info>,
 
     #[account(seeds = [b"oracle", whirlpool_one.key().as_ref()],bump)]
     /// CHECK: Oracle is currently unused and will be enabled on subsequent updates
@@ -105,17 +111,29 @@ pub fn handler(
         return Err(ErrorCode::InvalidIntermediaryMint.into());
     }
 
-    let mut swap_tick_sequence_one = SwapTickSequence::new(
-        ctx.accounts.tick_array_one_0.load_mut().unwrap(),
-        ctx.accounts.tick_array_one_1.load_mut().ok(),
-        ctx.accounts.tick_array_one_2.load_mut().ok(),
-    );
+    let builder_one = SparseSwapTickSequenceBuilder::try_from(
+        whirlpool_one,
+        a_to_b_one,
+        vec![
+            ctx.accounts.tick_array_one_0.to_account_info(),
+            ctx.accounts.tick_array_one_1.to_account_info(),
+            ctx.accounts.tick_array_one_2.to_account_info(),
+        ],
+        None,
+    )?;
+    let mut swap_tick_sequence_one = builder_one.build()?;
 
-    let mut swap_tick_sequence_two = SwapTickSequence::new(
-        ctx.accounts.tick_array_two_0.load_mut().unwrap(),
-        ctx.accounts.tick_array_two_1.load_mut().ok(),
-        ctx.accounts.tick_array_two_2.load_mut().ok(),
-    );
+    let builder_two = SparseSwapTickSequenceBuilder::try_from(
+        whirlpool_two,
+        a_to_b_two,
+        vec![
+            ctx.accounts.tick_array_two_0.to_account_info(),
+            ctx.accounts.tick_array_two_1.to_account_info(),
+            ctx.accounts.tick_array_two_2.to_account_info(),
+        ],
+        None,
+    )?;
+    let mut swap_tick_sequence_two = builder_two.build()?;
 
     // TODO: WLOG, we could extend this to N-swaps, but the account inputs to the instruction would
     // need to be jankier and we may need to programatically map/verify rather than using anchor constraints

--- a/programs/whirlpool/src/instructions/v2/swap.rs
+++ b/programs/whirlpool/src/instructions/v2/swap.rs
@@ -59,7 +59,7 @@ pub struct SwapV2<'info> {
     // remaining accounts
     // - accounts for transfer hook program of token_mint_a
     // - accounts for transfer hook program of token_mint_b
-    // - additional TickArray accounts
+    // - supplemental TickArray accounts
 }
 
 pub fn handler<'a, 'b, 'c, 'info>(
@@ -83,7 +83,7 @@ pub fn handler<'a, 'b, 'c, 'info>(
         &[
             AccountsType::TransferHookA,
             AccountsType::TransferHookB,
-            AccountsType::AdditionalTickArrays,
+            AccountsType::SupplementalTickArrays,
         ],
     )?;
 
@@ -95,7 +95,7 @@ pub fn handler<'a, 'b, 'c, 'info>(
             ctx.accounts.tick_array_1.to_account_info(),
             ctx.accounts.tick_array_2.to_account_info(),
         ],
-        remaining_accounts.additional_tick_arrays,
+        remaining_accounts.supplemental_tick_arrays,
     )?;
     let mut swap_tick_sequence = builder.build()?;
 

--- a/programs/whirlpool/src/instructions/v2/swap.rs
+++ b/programs/whirlpool/src/instructions/v2/swap.rs
@@ -59,6 +59,7 @@ pub struct SwapV2<'info> {
     // remaining accounts
     // - accounts for transfer hook program of token_mint_a
     // - accounts for transfer hook program of token_mint_b
+    // - additional TickArray accounts
 }
 
 pub fn handler<'a, 'b, 'c, 'info>(
@@ -82,6 +83,7 @@ pub fn handler<'a, 'b, 'c, 'info>(
         &[
             AccountsType::TransferHookA,
             AccountsType::TransferHookB,
+            AccountsType::AdditionalTickArrays,
         ],
     )?;
 

--- a/programs/whirlpool/src/instructions/v2/swap.rs
+++ b/programs/whirlpool/src/instructions/v2/swap.rs
@@ -6,8 +6,8 @@ use crate::util::{calculate_transfer_fee_excluded_amount, calculate_transfer_fee
 use crate::{
     errors::ErrorCode,
     manager::swap_manager::*,
-    state::{TickArray, Whirlpool},
-    util::{to_timestamp_u64, v2::update_and_swap_whirlpool_v2, SwapTickSequence},
+    state::Whirlpool,
+    util::{to_timestamp_u64, v2::update_and_swap_whirlpool_v2, SwapTickSequence, SparseSwapTickSequenceBuilder},
     constants::transfer_memo,
 };
 
@@ -40,14 +40,17 @@ pub struct SwapV2<'info> {
     #[account(mut, address = whirlpool.token_vault_b)]
     pub token_vault_b: Box<InterfaceAccount<'info, TokenAccount>>,
 
-    #[account(mut, has_one = whirlpool)]
-    pub tick_array_0: AccountLoader<'info, TickArray>,
+    #[account(mut)]
+    /// CHECK: checked in the handler
+    pub tick_array_0: UncheckedAccount<'info>,
 
-    #[account(mut, has_one = whirlpool)]
-    pub tick_array_1: AccountLoader<'info, TickArray>,
+    #[account(mut)]
+    /// CHECK: checked in the handler
+    pub tick_array_1: UncheckedAccount<'info>,
 
-    #[account(mut, has_one = whirlpool)]
-    pub tick_array_2: AccountLoader<'info, TickArray>,
+    #[account(mut)]
+    /// CHECK: checked in the handler
+    pub tick_array_2: UncheckedAccount<'info>,
 
     #[account(mut, seeds = [b"oracle", whirlpool.key().as_ref()], bump)]
     /// CHECK: Oracle is currently unused and will be enabled on subsequent updates
@@ -82,11 +85,17 @@ pub fn handler<'a, 'b, 'c, 'info>(
         ],
     )?;
 
-    let mut swap_tick_sequence = SwapTickSequence::new(
-        ctx.accounts.tick_array_0.load_mut().unwrap(),
-        ctx.accounts.tick_array_1.load_mut().ok(),
-        ctx.accounts.tick_array_2.load_mut().ok(),
-    );
+    let builder = SparseSwapTickSequenceBuilder::try_from(
+        whirlpool,
+        a_to_b,
+        vec![
+            ctx.accounts.tick_array_0.to_account_info(),
+            ctx.accounts.tick_array_1.to_account_info(),
+            ctx.accounts.tick_array_2.to_account_info(),
+        ],
+        remaining_accounts.additional_tick_arrays,
+    )?;
+    let mut swap_tick_sequence = builder.build()?;
 
     let swap_update = swap_with_transfer_fee_extension(
         &whirlpool,

--- a/programs/whirlpool/src/instructions/v2/two_hop_swap.rs
+++ b/programs/whirlpool/src/instructions/v2/two_hop_swap.rs
@@ -93,8 +93,8 @@ pub struct TwoHopSwapV2<'info> {
     // - accounts for transfer hook program of token_mint_input
     // - accounts for transfer hook program of token_mint_intermediate
     // - accounts for transfer hook program of token_mint_output
-    // - additional TickArray accounts for whirlpool_one
-    // - additional TickArray accounts for whirlpool_two
+    // - supplemental TickArray accounts for whirlpool_one
+    // - supplemental TickArray accounts for whirlpool_two
 }
 
 pub fn handler<'a, 'b, 'c, 'info>(
@@ -143,8 +143,8 @@ pub fn handler<'a, 'b, 'c, 'info>(
             AccountsType::TransferHookInput,
             AccountsType::TransferHookIntermediate,
             AccountsType::TransferHookOutput,
-            AccountsType::AdditionalTickArraysOne,
-            AccountsType::AdditionalTickArraysTwo,
+            AccountsType::SupplementalTickArraysOne,
+            AccountsType::SupplementalTickArraysTwo,
         ],
     )?;
 
@@ -156,7 +156,7 @@ pub fn handler<'a, 'b, 'c, 'info>(
             ctx.accounts.tick_array_one_1.to_account_info(),
             ctx.accounts.tick_array_one_2.to_account_info(),
         ],
-        remaining_accounts.additional_tick_arrays_one,
+        remaining_accounts.supplemental_tick_arrays_one,
     )?;
     let mut swap_tick_sequence_one = builder_one.build()?;
 
@@ -168,7 +168,7 @@ pub fn handler<'a, 'b, 'c, 'info>(
             ctx.accounts.tick_array_two_1.to_account_info(),
             ctx.accounts.tick_array_two_2.to_account_info(),
         ],
-        remaining_accounts.additional_tick_arrays_two,
+        remaining_accounts.supplemental_tick_arrays_two,
     )?;
     let mut swap_tick_sequence_two = builder_two.build()?;
 

--- a/programs/whirlpool/src/util/mod.rs
+++ b/programs/whirlpool/src/util/mod.rs
@@ -1,9 +1,11 @@
+pub mod sparse_swap;
 pub mod swap_tick_sequence;
 pub mod swap_utils;
 pub mod token;
 pub mod util;
 pub mod v2;
 
+pub use sparse_swap::*;
 pub use swap_tick_sequence::*;
 pub use swap_utils::*;
 pub use token::*;

--- a/programs/whirlpool/src/util/sparse_swap.rs
+++ b/programs/whirlpool/src/util/sparse_swap.rs
@@ -1,5 +1,8 @@
-use std::{cell::{Ref, RefCell, RefMut}, collections::VecDeque};
 use anchor_lang::prelude::*;
+use std::{
+    cell::{Ref, RefCell, RefMut},
+    collections::VecDeque,
+};
 
 use crate::{
     errors::ErrorCode,
@@ -8,219 +11,240 @@ use crate::{
 };
 
 enum TickArrayAccount<'info> {
-  // owned by this whirlpool program and its discriminator is valid and writable
-  // but not sure if this TickArray is valid for this whirlpool (maybe for another whirlpool)
-  Initialized(Pubkey, i32, AccountInfo<'info>),
-  // owned by system program and its data size is zero and writable
-  // but not sure if this key is valid PDA for TickArray
-  Uninitialized(Pubkey, AccountInfo<'info>, Option<Box<RefCell<TickArray>>>),
+    // owned by this whirlpool program and its discriminator is valid and writable
+    // but not sure if this TickArray is valid for this whirlpool (maybe for another whirlpool)
+    Initialized(Pubkey, i32, AccountInfo<'info>),
+    // owned by system program and its data size is zero and writable
+    // but not sure if this key is valid PDA for TickArray
+    Uninitialized(Pubkey, AccountInfo<'info>, Option<Box<RefCell<TickArray>>>),
 }
 
 pub struct SparseSwapTickSequenceBuilder<'info> {
-  tick_array_accounts: Vec<TickArrayAccount<'info>>,
+    tick_array_accounts: Vec<TickArrayAccount<'info>>,
 }
 
 impl<'info> SparseSwapTickSequenceBuilder<'info> {
-  pub fn try_from(
-      whirlpool: &Account<'info, Whirlpool>,
-      a_to_b: bool,
-      mut tick_array_account_infos: Vec<AccountInfo<'info>>,
-  ) -> Result<Self> {
-      // dedup by key
-      tick_array_account_infos.sort_by_key(|a| a.key());
-      tick_array_account_infos.dedup_by_key(|a| a.key());
+    pub fn try_from(
+        whirlpool: &Account<'info, Whirlpool>,
+        a_to_b: bool,
+        static_tick_array_account_infos: Vec<AccountInfo<'info>>,
+        additional_tick_array_account_infos: Option<Vec<AccountInfo<'info>>>,
+    ) -> Result<Self> {
+        let mut tick_array_account_infos = static_tick_array_account_infos;
+        if let Some(additional_tick_array_account_infos) = additional_tick_array_account_infos {
+            tick_array_account_infos.extend(additional_tick_array_account_infos);
+        }
 
-      let mut initialized = vec![];
-      let mut uninitialized = vec![];
-      for account_info in tick_array_account_infos.into_iter() {
-          let state = peek_tick_array(account_info)?;
+        // dedup by key
+        tick_array_account_infos.sort_by_key(|a| a.key());
+        tick_array_account_infos.dedup_by_key(|a| a.key());
 
-          match &state {
-              TickArrayAccount::Initialized(tick_array_whirlpool, start_tick_index, ..) => {
-                  // has_one constraint equivalent check
-                  if *tick_array_whirlpool != whirlpool.key() {
-                      // TODO: our own error definition
-                      return Err(anchor_lang::error::ErrorCode::ConstraintHasOne.into());
-                  }
-                  initialized.push((*start_tick_index, state));
-              }
-              TickArrayAccount::Uninitialized(pubkey, ..) => {
-                  uninitialized.push((*pubkey, state));
-              }
-          }
-      }
-  
-      ////////////////////////////////////////////////////////////////////////
-      // Now successfully loaded tick arrays have been verified as:
-      // - Owned by Whirlpool Program
-      // - Initialized as TickArray account
-      // - And has_one constraint is satisfied (i.e. belongs to trading whirlpool)
-      // - Writable
-      ////////////////////////////////////////////////////////////////////////
-      let start_tick_indexes = get_start_tick_indexes(whirlpool, a_to_b);
-  
-      let mut tick_array_accounts: Vec<TickArrayAccount> = vec![];
-      for start_tick_index in start_tick_indexes.iter() {
-          // find from initialized tick arrays
-          if let Some(pos) = initialized.iter().position(|t| t.0 == *start_tick_index) {
-              let state = initialized.remove(pos).1;
-              tick_array_accounts.push(state);
-              continue;
-          }
-  
-          // find from uninitialized tick arrays
-          let tick_array_pda = derive_tick_array_pda(&whirlpool, *start_tick_index);
-          if let Some(pos) = uninitialized.iter().position(|t| t.0 == tick_array_pda) {
-              let state = uninitialized.remove(pos).1;
-              if let TickArrayAccount::Uninitialized(pubkey, account_info, ..) = state {
-                  // create zeroed TickArray data
-                  let zeroed = Box::new(RefCell::new(TickArray::default()));
-                  zeroed.borrow_mut().initialize(whirlpool, *start_tick_index)?;
+        let mut initialized = vec![];
+        let mut uninitialized = vec![];
+        for account_info in tick_array_account_infos.into_iter() {
+            let state = peek_tick_array(account_info)?;
 
-                  tick_array_accounts.push(TickArrayAccount::Uninitialized(
-                      pubkey,
-                      account_info,
-                      Some(zeroed)
-                  ));
-              } else {
-                  unreachable!("state in uninitialized must be Uninitialized");
-              }
-              continue;
-          }
-  
-          // no more valid tickarrays for this swap
-          break;
-      }
+            match &state {
+                TickArrayAccount::Initialized(tick_array_whirlpool, start_tick_index, ..) => {
+                    // has_one constraint equivalent check
+                    if *tick_array_whirlpool != whirlpool.key() {
+                        return Err(ErrorCode::DifferentWhirlpoolTickArrayAccount.into());
+                    }
+                    initialized.push((*start_tick_index, state));
+                }
+                TickArrayAccount::Uninitialized(pubkey, ..) => {
+                    uninitialized.push((*pubkey, state));
+                }
+            }
+        }
 
-      Ok(Self { tick_array_accounts })
-  }
+        ////////////////////////////////////////////////////////////////////////
+        // Now successfully loaded tick arrays have been verified as:
+        // - Owned by Whirlpool Program
+        // - Initialized as TickArray account
+        // - And has_one constraint is satisfied (i.e. belongs to trading whirlpool)
+        // - Writable
+        ////////////////////////////////////////////////////////////////////////
+        let start_tick_indexes = get_start_tick_indexes(whirlpool, a_to_b);
 
-  pub fn build<'a>(&'a self) -> Result<SwapTickSequence<'a>> {
-      let mut tick_array_refmuts = VecDeque::with_capacity(3);
-      for tick_array_account in self.tick_array_accounts.iter() {
-          match tick_array_account {
-              TickArrayAccount::Initialized(_, _, account_info) => {
-                  use std::ops::DerefMut;
+        let mut tick_array_accounts: Vec<TickArrayAccount> = vec![];
+        for start_tick_index in start_tick_indexes.iter() {
+            // find from initialized tick arrays
+            if let Some(pos) = initialized.iter().position(|t| t.0 == *start_tick_index) {
+                let state = initialized.remove(pos).1;
+                tick_array_accounts.push(state);
+                continue;
+            }
 
-                  let data = account_info.try_borrow_mut_data()?;
-                  let tick_array_refmut = RefMut::map(data, |data| {
-                      bytemuck::from_bytes_mut(&mut data.deref_mut()[8..std::mem::size_of::<TickArray>() + 8])
-                  });
-                  tick_array_refmuts.push_back(tick_array_refmut);
-              }
-              TickArrayAccount::Uninitialized(_, _, tick_array) => {
-                  let tick_array_refmut = tick_array.as_ref().unwrap().borrow_mut();
-                  tick_array_refmuts.push_back(tick_array_refmut);
-              }
-          }
-      }
-      
-      if tick_array_refmuts.is_empty() {
-          return Err(crate::errors::ErrorCode::InvalidTickArraySequence.into());
-      }
-  
-      Ok(SwapTickSequence::<'a>::new(
-          tick_array_refmuts.pop_front().unwrap(),
-          tick_array_refmuts.pop_front(),
-          tick_array_refmuts.pop_front(),
-      ))    
-  }
+            // find from uninitialized tick arrays
+            let tick_array_pda = derive_tick_array_pda(&whirlpool, *start_tick_index);
+            if let Some(pos) = uninitialized.iter().position(|t| t.0 == tick_array_pda) {
+                let state = uninitialized.remove(pos).1;
+                if let TickArrayAccount::Uninitialized(pubkey, account_info, ..) = state {
+                    // create zeroed TickArray data
+                    let zeroed = Box::new(RefCell::new(TickArray::default()));
+                    zeroed
+                        .borrow_mut()
+                        .initialize(whirlpool, *start_tick_index)?;
+
+                    tick_array_accounts.push(TickArrayAccount::Uninitialized(
+                        pubkey,
+                        account_info,
+                        Some(zeroed),
+                    ));
+                } else {
+                    unreachable!("state in uninitialized must be Uninitialized");
+                }
+                continue;
+            }
+
+            // no more valid tickarrays for this swap
+            break;
+        }
+
+        Ok(Self {
+            tick_array_accounts,
+        })
+    }
+
+    pub fn build<'a>(&'a self) -> Result<SwapTickSequence<'a>> {
+        let mut tick_array_refmuts = VecDeque::with_capacity(3);
+        for tick_array_account in self.tick_array_accounts.iter() {
+            match tick_array_account {
+                TickArrayAccount::Initialized(_, _, account_info) => {
+                    use std::ops::DerefMut;
+
+                    let data = account_info.try_borrow_mut_data()?;
+                    let tick_array_refmut = RefMut::map(data, |data| {
+                        bytemuck::from_bytes_mut(
+                            &mut data.deref_mut()[8..std::mem::size_of::<TickArray>() + 8],
+                        )
+                    });
+                    tick_array_refmuts.push_back(tick_array_refmut);
+                }
+                TickArrayAccount::Uninitialized(_, _, tick_array) => {
+                    let tick_array_refmut = tick_array.as_ref().unwrap().borrow_mut();
+                    tick_array_refmuts.push_back(tick_array_refmut);
+                }
+            }
+        }
+
+        if tick_array_refmuts.is_empty() {
+            return Err(crate::errors::ErrorCode::InvalidTickArraySequence.into());
+        }
+
+        Ok(SwapTickSequence::<'a>::new(
+            tick_array_refmuts.pop_front().unwrap(),
+            tick_array_refmuts.pop_front(),
+            tick_array_refmuts.pop_front(),
+        ))
+    }
 }
 
-fn peek_tick_array<'info>(
-  account_info: AccountInfo<'info>,
-) -> Result<TickArrayAccount<'info>> {
-  use anchor_lang::Discriminator;
+fn peek_tick_array<'info>(account_info: AccountInfo<'info>) -> Result<TickArrayAccount<'info>> {
+    use anchor_lang::Discriminator;
 
-  // following process is ported from anchor-lang's AccountLoader::try_from and AccountLoader::load_mut
+    // following process is ported from anchor-lang's AccountLoader::try_from and AccountLoader::load_mut
 
-  if !account_info.is_writable {
-      return Err(anchor_lang::error::ErrorCode::AccountNotMutable.into());
-  }
+    if !account_info.is_writable {
+        return Err(anchor_lang::error::ErrorCode::AccountNotMutable.into());
+    }
 
-  // uninitialized writable account (owned by system program and its data size is zero)
-  if account_info.owner == &System::id() && account_info.data_is_empty() {
-      return Ok(TickArrayAccount::Uninitialized(*account_info.key, account_info, None));
-  }
+    // uninitialized writable account (owned by system program and its data size is zero)
+    if account_info.owner == &System::id() && account_info.data_is_empty() {
+        return Ok(TickArrayAccount::Uninitialized(
+            *account_info.key,
+            account_info,
+            None,
+        ));
+    }
 
-  // owner program check
-  if account_info.owner != &TickArray::owner() {
-      return Err(Error::from(anchor_lang::error::ErrorCode::AccountOwnedByWrongProgram)
-          .with_pubkeys((*account_info.owner, TickArray::owner())));
-  }
+    // owner program check
+    if account_info.owner != &TickArray::owner() {
+        return Err(
+            Error::from(anchor_lang::error::ErrorCode::AccountOwnedByWrongProgram)
+                .with_pubkeys((*account_info.owner, TickArray::owner())),
+        );
+    }
 
-  let data = account_info.try_borrow_data()?;
-  if data.len() < TickArray::discriminator().len() {
-      return Err(anchor_lang::error::ErrorCode::AccountDiscriminatorNotFound.into());
-  }
+    let data = account_info.try_borrow_data()?;
+    if data.len() < TickArray::discriminator().len() {
+        return Err(anchor_lang::error::ErrorCode::AccountDiscriminatorNotFound.into());
+    }
 
-  let disc_bytes = arrayref::array_ref![data, 0, 8];
-  if disc_bytes != &TickArray::discriminator() {
-      return Err(anchor_lang::error::ErrorCode::AccountDiscriminatorMismatch.into());
-  }
+    let disc_bytes = arrayref::array_ref![data, 0, 8];
+    if disc_bytes != &TickArray::discriminator() {
+        return Err(anchor_lang::error::ErrorCode::AccountDiscriminatorMismatch.into());
+    }
 
-  let tick_array: Ref<TickArray> = Ref::map(data, |data| {
-      bytemuck::from_bytes(&data[8..std::mem::size_of::<TickArray>() + 8])
-  });
+    let tick_array: Ref<TickArray> = Ref::map(data, |data| {
+        bytemuck::from_bytes(&data[8..std::mem::size_of::<TickArray>() + 8])
+    });
 
-  let start_tick_index = tick_array.start_tick_index;
-  let whirlpool = tick_array.whirlpool;
-  drop(tick_array);
+    let start_tick_index = tick_array.start_tick_index;
+    let whirlpool = tick_array.whirlpool;
+    drop(tick_array);
 
-  Ok(TickArrayAccount::Initialized(whirlpool, start_tick_index, account_info))
+    Ok(TickArrayAccount::Initialized(
+        whirlpool,
+        start_tick_index,
+        account_info,
+    ))
 }
 
 fn get_start_tick_indexes(whirlpool: &Account<Whirlpool>, a_to_b: bool) -> Vec<i32> {
-  let tick_current_index = whirlpool.tick_current_index;
-  let tick_spacing = whirlpool.tick_spacing as i32;
-  let ticks_in_array = TICK_ARRAY_SIZE * tick_spacing;
+    let tick_current_index = whirlpool.tick_current_index;
+    let tick_spacing = whirlpool.tick_spacing as i32;
+    let ticks_in_array = TICK_ARRAY_SIZE * tick_spacing;
 
-  let start_tick_index_base = floor_division(tick_current_index, ticks_in_array) * ticks_in_array;
-  let offset = if a_to_b {
-      [0, -1, -2]
-  } else {
-      let shifted = tick_current_index + tick_spacing >= start_tick_index_base + ticks_in_array;
-      if shifted { [1, 2, 3] } else { [0, 1, 2] }
-  };
+    let start_tick_index_base = floor_division(tick_current_index, ticks_in_array) * ticks_in_array;
+    let offset = if a_to_b {
+        [0, -1, -2]
+    } else {
+        let shifted = tick_current_index + tick_spacing >= start_tick_index_base + ticks_in_array;
+        if shifted {
+            [1, 2, 3]
+        } else {
+            [0, 1, 2]
+        }
+    };
 
-  let start_tick_indexes = offset
-      .iter()
-      .filter_map(|&o| {
-          let start_tick_index = start_tick_index_base + o * ticks_in_array;
-          if is_valid_start_tick_index(start_tick_index, ticks_in_array) {
-              Some(start_tick_index)
-          } else {
-              None
-          }
-      })
-      .collect::<Vec<i32>>();
+    let start_tick_indexes = offset
+        .iter()
+        .filter_map(|&o| {
+            let start_tick_index = start_tick_index_base + o * ticks_in_array;
+            if is_valid_start_tick_index(start_tick_index, ticks_in_array) {
+                Some(start_tick_index)
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<i32>>();
 
-  start_tick_indexes
+    start_tick_indexes
 }
 
 fn is_valid_start_tick_index(start_tick_index: i32, ticks_in_array: i32) -> bool {
-  start_tick_index + ticks_in_array > MIN_TICK_INDEX && start_tick_index < MAX_TICK_INDEX
+    start_tick_index + ticks_in_array > MIN_TICK_INDEX && start_tick_index < MAX_TICK_INDEX
 }
 
 fn floor_division(dividend: i32, divisor: i32) -> i32 {
-  assert!(divisor != 0, "Divisor cannot be zero.");
-  if dividend % divisor == 0 || dividend.signum() == divisor.signum() {
-      dividend / divisor
-  } else {
-      dividend / divisor - 1
-  }
+    assert!(divisor != 0, "Divisor cannot be zero.");
+    if dividend % divisor == 0 || dividend.signum() == divisor.signum() {
+        dividend / divisor
+    } else {
+        dividend / divisor - 1
+    }
 }
 
-fn derive_tick_array_pda(
-  whirlpool: &Account<Whirlpool>,
-  start_tick_index: i32,
-) -> Pubkey {
-  Pubkey::find_program_address(
-      &[
-          b"tick_array",
-          whirlpool.key().as_ref(),
-          start_tick_index.to_string().as_bytes(),
-      ],
-      &TickArray::owner()
-  ).0
+fn derive_tick_array_pda(whirlpool: &Account<Whirlpool>, start_tick_index: i32) -> Pubkey {
+    Pubkey::find_program_address(
+        &[
+            b"tick_array",
+            whirlpool.key().as_ref(),
+            start_tick_index.to_string().as_bytes(),
+        ],
+        &TickArray::owner(),
+    )
+    .0
 }

--- a/programs/whirlpool/src/util/sparse_swap.rs
+++ b/programs/whirlpool/src/util/sparse_swap.rs
@@ -124,6 +124,10 @@ impl<'info> SparseSwapTickSequenceBuilder<'info> {
             break;
         }
 
+        if tick_array_accounts.is_empty() {
+            return Err(crate::errors::ErrorCode::InvalidTickArraySequence.into());
+        }
+
         Ok(Self {
             tick_array_accounts,
         })
@@ -149,10 +153,6 @@ impl<'info> SparseSwapTickSequenceBuilder<'info> {
                     tick_array_refmuts.push_back(tick_array_refmut);
                 }
             }
-        }
-
-        if tick_array_refmuts.is_empty() {
-            return Err(crate::errors::ErrorCode::InvalidTickArraySequence.into());
         }
 
         Ok(SwapTickSequence::<'a>::new(
@@ -247,6 +247,7 @@ fn get_start_tick_indexes(whirlpool: &Account<Whirlpool>, a_to_b: bool) -> Vec<i
 }
 
 fn is_valid_start_tick_index(start_tick_index: i32, ticks_in_array: i32) -> bool {
+    // caller must assure that start_tick_index is multiple of ticks_in_array
     start_tick_index + ticks_in_array > MIN_TICK_INDEX && start_tick_index < MAX_TICK_INDEX
 }
 
@@ -269,4 +270,1210 @@ fn derive_tick_array_pda(whirlpool: &Account<Whirlpool>, start_tick_index: i32) 
         &TickArray::owner(),
     )
     .0
+}
+
+#[cfg(test)]
+mod sparse_swap_tick_sequence_tests {
+    use anchor_lang::Discriminator;
+
+    use super::*;
+    use anchor_lang::solana_program::pubkey;
+
+    struct AccountInfoMock {
+        pub key: Pubkey,
+        pub lamports: u64,
+        pub data: Vec<u8>,
+        pub owner: Pubkey,
+        pub rent_epoch: u64,
+        pub executable: bool,
+    }
+
+    impl AccountInfoMock {
+        pub fn new(key: Pubkey, data: Vec<u8>, owner: Pubkey) -> Self {
+            Self {
+                key,
+                lamports: 0,
+                data,
+                owner,
+                rent_epoch: 0,
+                executable: false,
+            }
+        }
+
+        pub fn new_whirlpool(
+            key: Pubkey,
+            tick_spacing: u16,
+            tick_current_index: i32,
+            owner: Option<Pubkey>,
+        ) -> Self {
+            let whirlpool = Whirlpool {
+                tick_spacing,
+                tick_current_index,
+                ..Whirlpool::default()
+            };
+
+            let mut data = vec![0u8; Whirlpool::LEN];
+            whirlpool.try_serialize(&mut data.as_mut_slice()).unwrap();
+            Self::new(key, data, owner.unwrap_or(Whirlpool::owner()))
+        }
+
+        pub fn new_tick_array(
+            key: Pubkey,
+            whirlpool: Pubkey,
+            start_tick_index: i32,
+            owner: Option<Pubkey>,
+        ) -> Self {
+            let tick_array = TickArray {
+                whirlpool,
+                start_tick_index,
+                ..TickArray::default()
+            };
+
+            let mut data = vec![0u8; TickArray::LEN];
+            data[0..8].copy_from_slice(&TickArray::discriminator());
+            data[8..12].copy_from_slice(&start_tick_index.to_le_bytes());
+            data[9956..9988].copy_from_slice(&whirlpool.to_bytes());
+            Self::new(key, data, owner.unwrap_or(TickArray::owner()))
+        }
+
+        pub fn to_account_info<'a>(&'a mut self, is_writable: bool) -> AccountInfo<'a> {
+            AccountInfo {
+                key: &self.key,
+                is_signer: false,
+                is_writable,
+                lamports: std::rc::Rc::new(RefCell::new(&mut self.lamports)),
+                data: std::rc::Rc::new(RefCell::new(&mut self.data)),
+                owner: &self.owner,
+                rent_epoch: self.rent_epoch,
+                executable: self.executable,
+            }
+        }
+    }
+
+    #[test]
+    fn test_derive_tick_array_pda() {
+        let mut account_info_mock = AccountInfoMock::new_whirlpool(
+            pubkey!("HJPjoWUrhoZzkNfRpHuieeFk9WcZWjwy6PBjZ81ngndJ"), // well-known whirlpool key (SOL/USDC(ts=64))
+            64,
+            0,
+            Some(pubkey!("whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc")),
+        );
+        let account_info = account_info_mock.to_account_info(false);
+        let whirlpool_account = Account::<Whirlpool>::try_from(&account_info).unwrap();
+
+        let ta_start_neg_11264 = derive_tick_array_pda(
+            &whirlpool_account,
+            -11264,
+        );
+        assert_eq!(ta_start_neg_11264, pubkey!("81T5kNuPRkyVzhwbe2RpKR7wmQpGJ7RBkGPdTqyfa5vq"));
+
+        let ta_start_neg_5632 = derive_tick_array_pda(
+            &whirlpool_account,
+            -5632,
+        );
+        assert_eq!(ta_start_neg_5632, pubkey!("9K1HWrGKZKfjTnKfF621BmEQdai4FcUz9tsoF41jwz5B"));
+
+        let ta_start_0 = derive_tick_array_pda(
+            &whirlpool_account,
+            0,
+        );
+        assert_eq!(ta_start_0, pubkey!("JCpxMSDRDPBMqjoX7LkhMwro2y6r85Q8E6p5zNdBZyWa"));
+
+        let ta_start_5632 = derive_tick_array_pda(
+            &whirlpool_account,
+            5632,
+        );
+        assert_eq!(ta_start_5632, pubkey!("BW2Mr823NUQN7vnVpv5E6yCTnqEXQ3ZnqjZyiywXPcUp"));
+
+        let ta_start_11264 = derive_tick_array_pda(
+            &whirlpool_account,
+            11264,
+        );
+        assert_eq!(ta_start_11264, pubkey!("2ezvsnoXdukw5dAAZ4EkW67bmUo8PHRPX8ZDqf76BKtV"));
+    }
+
+    #[test]
+    fn test_floor_division() {
+        assert_eq!(floor_division(0, 64), 0);
+        assert_eq!(floor_division(1, 64), 0);
+        assert_eq!(floor_division(63, 64), 0);
+        assert_eq!(floor_division(64, 64), 1);
+        assert_eq!(floor_division(65, 64), 1);
+        assert_eq!(floor_division(127, 64), 1);
+        assert_eq!(floor_division(128, 64), 2);
+        assert_eq!(floor_division(129, 64), 2);
+        assert_eq!(floor_division(-1, 64), -1);
+        assert_eq!(floor_division(-63, 64), -1);
+        assert_eq!(floor_division(-64, 64), -1);
+        assert_eq!(floor_division(-65, 64), -2);
+        assert_eq!(floor_division(-127, 64), -2);
+        assert_eq!(floor_division(-128, 64), -2);
+        assert_eq!(floor_division(-129, 64), -3);
+    }
+
+    mod test_is_valid_start_tick_index {
+        use super::*;
+
+        // valid tick range: -443636 ~ +443636
+
+        fn get_ticks_in_array(tick_spacing: i32) -> i32 {
+            TICK_ARRAY_SIZE * tick_spacing
+        }
+
+        #[test]
+        fn tick_spacing_1() {
+            let ticks_in_array = get_ticks_in_array(1);
+            assert_eq!(is_valid_start_tick_index(-443784, ticks_in_array), false);
+            assert_eq!(is_valid_start_tick_index(-443696, ticks_in_array), true);
+            assert_eq!(is_valid_start_tick_index(-443608, ticks_in_array), true); 
+            assert_eq!(is_valid_start_tick_index(-88, ticks_in_array), true);
+            assert_eq!(is_valid_start_tick_index(0, ticks_in_array), true);
+            assert_eq!(is_valid_start_tick_index(88, ticks_in_array), true);
+            assert_eq!(is_valid_start_tick_index(443608, ticks_in_array), true); 
+            assert_eq!(is_valid_start_tick_index(443696, ticks_in_array), false); 
+        }
+
+        #[test]
+        fn tick_spacing_64() {
+            let ticks_in_array = get_ticks_in_array(64);
+            assert_eq!(is_valid_start_tick_index(-450560, ticks_in_array), false);
+            assert_eq!(is_valid_start_tick_index(-444928, ticks_in_array), true);
+            assert_eq!(is_valid_start_tick_index(-439296, ticks_in_array), true); 
+            assert_eq!(is_valid_start_tick_index(-5632, ticks_in_array), true);
+            assert_eq!(is_valid_start_tick_index(0, ticks_in_array), true);
+            assert_eq!(is_valid_start_tick_index(5632, ticks_in_array), true);
+            assert_eq!(is_valid_start_tick_index(439296, ticks_in_array), true); 
+            assert_eq!(is_valid_start_tick_index(444928, ticks_in_array), false); 
+        }
+
+        #[test]
+        fn tick_spacing_4096() {
+            let ticks_in_array = get_ticks_in_array(4096);
+            assert_eq!(is_valid_start_tick_index(-1081344, ticks_in_array), false);
+            assert_eq!(is_valid_start_tick_index(-720896, ticks_in_array), true);
+            assert_eq!(is_valid_start_tick_index(-360448, ticks_in_array), true);
+            assert_eq!(is_valid_start_tick_index(0, ticks_in_array), true);
+            assert_eq!(is_valid_start_tick_index(360448, ticks_in_array), true);
+            assert_eq!(is_valid_start_tick_index(720896, ticks_in_array), false);
+        }
+
+        #[test]
+        fn tick_spacing_8192() {
+            let ticks_in_array = get_ticks_in_array(8192);
+            assert_eq!(is_valid_start_tick_index(-1441792, ticks_in_array), false);
+            assert_eq!(is_valid_start_tick_index(-720896, ticks_in_array), true);
+            assert_eq!(is_valid_start_tick_index(0, ticks_in_array), true);
+            assert_eq!(is_valid_start_tick_index(720896, ticks_in_array), false);
+        }
+
+        #[test]
+        fn tick_spacing_32768() {
+            let ticks_in_array = get_ticks_in_array(32768);
+            assert_eq!(is_valid_start_tick_index(-5767168, ticks_in_array), false);
+            assert_eq!(is_valid_start_tick_index(-2883584, ticks_in_array), true);
+            assert_eq!(is_valid_start_tick_index(0, ticks_in_array), true);
+            assert_eq!(is_valid_start_tick_index(2883584, ticks_in_array), false);
+        }
+    }
+
+    mod test_get_start_tick_indexes {
+        use super::*;
+
+        // a to b
+        // a to b (not shifted)
+        // a to b (only 2 ta)
+        // a to b (only 1 ta)
+        // b to a (not shifted)
+        // b to a (shifted)
+        // b to a (only 2 ta)
+        // b to a (only 1 ta)
+
+        fn do_test(
+            a_to_b: bool,
+            tick_spacing: u16,
+            tick_current_index: i32,
+            expected: Vec<i32>,
+        ) {
+            let mut account_info_mock = AccountInfoMock::new_whirlpool(
+                Pubkey::new_unique(),
+                tick_spacing,
+                tick_current_index,
+                None,
+            );
+            let account_info = account_info_mock.to_account_info(true);
+            let whirlpool_account = Account::<Whirlpool>::try_from(&account_info).unwrap();
+            let start_tick_indexes = get_start_tick_indexes(&whirlpool_account, a_to_b);
+            assert_eq!(start_tick_indexes, expected);
+        }
+
+        mod tick_spacing_1 {
+            use super::*;
+
+            #[test]
+            fn a_to_b() {
+                do_test(true, 1, 0, vec![0, -88, -176]);
+            }                            
+
+            #[test]
+            fn a_to_b_not_shifted() {
+                do_test(true, 1, -1, vec![-88, -176, -264]);
+            }
+
+            #[test]
+            fn a_to_b_only_2_ta() {
+                do_test(true, 1, -443608, vec![-443608, -443696]);
+            }
+
+            #[test]
+            fn a_to_b_only_1_ta() {
+                do_test(true, 1, -443635, vec![-443696]);
+            }
+
+            #[test]
+            fn b_to_a_not_shifted() {
+                do_test(false, 1, 86, vec![0, 88, 176]);
+            }
+
+            #[test]
+            fn b_to_a_shifted() {
+                do_test(false, 1, 87, vec![88, 176, 264]);
+            }
+
+            #[test]
+            fn b_to_a_only_2_ta() {
+                do_test(false, 1, 443600, vec![443520, 443608]);
+            }
+
+            #[test]
+            fn b_to_a_only_1_ta() {
+                do_test(false, 1, 443608, vec![443608]);
+            }
+        }
+
+        mod tick_spacing_64 {
+            use super::*;
+
+            #[test]
+            fn a_to_b() {
+                do_test(true, 64, 0, vec![0, -5632, -11264]);
+            }                            
+
+            #[test]
+            fn a_to_b_not_shifted() {
+                do_test(true, 64, -64, vec![-5632, -11264, -16896]);
+            }
+
+            #[test]
+            fn a_to_b_only_2_ta() {
+                do_test(true, 64, -439296, vec![-439296, -444928]);
+            }
+
+            #[test]
+            fn a_to_b_only_1_ta() {
+                do_test(true, 64, -443635, vec![-444928]);
+            }
+
+            #[test]
+            fn b_to_a_not_shifted() {
+                do_test(false, 64, 5567, vec![0, 5632, 11264]);
+            }
+
+            #[test]
+            fn b_to_a_shifted() {
+                do_test(false, 64, 5568, vec![5632, 11264, 16896]);
+            }
+
+            #[test]
+            fn b_to_a_only_2_ta() {
+                do_test(false, 64, 439200, vec![433664, 439296]);
+            }
+
+            #[test]
+            fn b_to_a_only_1_ta() {
+                do_test(false, 64, 443608, vec![439296]);
+            }
+        }
+
+        mod tick_spacing_32768 {
+            use super::*;
+
+            #[test]
+            fn a_to_b() {
+                do_test(true, 32768, 0, vec![0, -2883584]);
+            }                            
+
+            #[test]
+            fn a_to_b_not_shifted() {
+                do_test(true, 32768, -1, vec![-2883584]);
+            }
+
+            #[test]
+            fn a_to_b_only_2_ta() {
+                do_test(true, 32768, 443635, vec![0, -2883584]);
+            }
+
+            #[test]
+            fn a_to_b_only_1_ta() {
+                do_test(true, 32768, -443635, vec![-2883584]);
+            }
+
+            #[test]
+            fn b_to_a_not_shifted() {
+                do_test(false, 32768, -32769, vec![-2883584, 0]);
+            }
+
+            #[test]
+            fn b_to_a_shifted() {
+                do_test(false, 32768, -32768, vec![0]);
+            }
+
+            #[test]
+            fn b_to_a_only_2_ta() {
+                do_test(false, 32768, -443635, vec![-2883584, 0]);
+            }
+
+            #[test]
+            fn b_to_a_only_1_ta() {
+                do_test(false, 32768, 443608, vec![0]);
+            }
+        }
+    }
+
+    mod test_peek_tick_array {
+        use super::*;
+
+        #[test]
+        fn fail_not_writable() {
+            let mut account_info_mock = AccountInfoMock::new_tick_array(
+                Pubkey::new_unique(),
+                Pubkey::new_unique(),
+                0,
+                None
+            );
+            let account_info = account_info_mock.to_account_info(false); // not writable
+
+            let result = peek_tick_array(account_info);
+            assert!(result.is_err());
+            assert!(result.err().unwrap().to_string().contains("AccountNotMutable"));
+        }
+
+        #[test]
+        fn uninitialized_tick_array() {
+            let account_address = Pubkey::new_unique();
+            let mut account_info_mock = AccountInfoMock::new(
+                account_address.clone(),
+                vec![],
+                System::id(),
+            );
+            let account_info = account_info_mock.to_account_info(true);
+
+            let result = peek_tick_array(account_info);
+            assert!(result.is_ok());
+            match result.unwrap() {
+                TickArrayAccount::Uninitialized { pubkey, account_info, zeroed } => {
+                    assert_eq!(pubkey, account_address);
+                    assert_eq!(account_info.key(), account_address);
+                    assert!(zeroed.is_none());
+                }
+                _ => panic!("unexpected state"),
+            }
+        }
+
+        #[test]
+        fn fail_system_program_but_not_zero_size() {
+            let mut account_info_mock = AccountInfoMock::new(
+                Pubkey::new_unique(),
+                vec![0u8; 1],
+                System::id()
+            );
+            let account_info = account_info_mock.to_account_info(true);
+
+            let result = peek_tick_array(account_info);
+            assert!(result.is_err());
+            // non empty account should be owned by this program
+            assert!(result.err().unwrap().to_string().contains("AccountOwnedByWrongProgram"));
+        }
+
+        #[test]
+        fn fail_account_discriminator_not_found() {
+            let mut account_info_mock = AccountInfoMock::new(
+                Pubkey::new_unique(),
+                vec![],
+                TickArray::owner()
+            );
+            let account_info = account_info_mock.to_account_info(true);
+
+            let result = peek_tick_array(account_info);
+            assert!(result.is_err());
+            assert!(result.err().unwrap().to_string().contains("AccountDiscriminatorNotFound"));
+        }
+
+        #[test]
+        fn fail_discriminator_mismatch() {
+            let mut account_info_mock = AccountInfoMock::new_whirlpool(
+                Pubkey::new_unique(),
+                64,
+                0,
+                None,
+            );
+            let account_info = account_info_mock.to_account_info(true);
+
+            let result = peek_tick_array(account_info);
+            assert!(result.is_err());
+            assert!(result.err().unwrap().to_string().contains("AccountDiscriminatorMismatch"));
+        }
+
+        #[test]
+        fn initialized_tick_array() {
+            let tick_array_address = Pubkey::new_unique();
+            let whirlpool_address = Pubkey::new_unique();
+            let mut account_info_mock = AccountInfoMock::new_tick_array(
+                tick_array_address.clone(),
+                whirlpool_address,
+                439296,
+                None
+            );
+            let account_info = account_info_mock.to_account_info(true);
+
+            let result = peek_tick_array(account_info);
+            assert!(result.is_ok());
+            match result.unwrap() {
+                TickArrayAccount::Initialized { start_tick_index, tick_array_whirlpool, account_info } => {
+                    assert_eq!(start_tick_index, 439296);
+                    assert_eq!(tick_array_whirlpool, whirlpool_address);
+                    assert_eq!(account_info.key(), tick_array_address);
+                }
+                _ => panic!("unexpected state"),
+            }
+        }
+    }
+
+    mod test_sparse_swap_tick_sequence_builder {
+        use crate::state::TICK_ARRAY_SIZE_USIZE;
+
+        use super::*;
+
+        #[test]
+        fn check_zeroed_tick_array_data() {
+            let whirlpool_address = Pubkey::new_unique();
+            let mut account_info_mock = AccountInfoMock::new_whirlpool(
+                whirlpool_address.clone(),
+                64,
+                5650,
+                None,
+            );
+            let account_info = account_info_mock.to_account_info(false);
+            let whirlpool = Account::<Whirlpool>::try_from(&account_info).unwrap();
+
+            // uninitialized
+            let ta0_address = derive_tick_array_pda(&whirlpool, 5632);
+            let mut ta0_mock = AccountInfoMock::new(
+                ta0_address.clone(),
+                vec![],
+                System::id(),
+            );
+            let ta0 = ta0_mock.to_account_info(true);
+
+            let builder = SparseSwapTickSequenceBuilder::try_from(
+                &whirlpool,
+                false,
+                vec![
+                    ta0.clone(),
+                    ta0.clone(),
+                    ta0.clone(),
+                ],
+                None,
+            ).unwrap();
+
+            assert_eq!(builder.tick_array_accounts.len(), 1);
+            match &builder.tick_array_accounts[0] {
+                TickArrayAccount::Initialized { .. } => {
+                    panic!("unexpected state");
+                }
+                TickArrayAccount::Uninitialized { zeroed, .. } => {
+                    assert!(zeroed.is_some());
+                    let ta = zeroed.as_ref().unwrap().borrow();
+
+                    // .start_tick_index
+                    let start_tick_index = ta.start_tick_index;
+                    assert_eq!(start_tick_index, 5632);
+
+                    // .whirlpool
+                    assert_eq!(ta.whirlpool, whirlpool_address);
+
+                    // .ticks
+                    assert_eq!(ta.ticks.len(), TICK_ARRAY_SIZE_USIZE);
+                    for i in 0..TICK_ARRAY_SIZE_USIZE {
+                        let tick = ta.ticks[i];
+                    
+                        let initialized = tick.initialized;
+                        assert_eq!(initialized, false);
+                        let liquidity_net = tick.liquidity_net;
+                        assert_eq!(liquidity_net, 0);
+                        let liquidity_gross = tick.liquidity_gross;
+                        assert_eq!(liquidity_gross, 0);
+                        let fee_growth_outside_a = tick.fee_growth_outside_a;
+                        assert_eq!(fee_growth_outside_a, 0);
+                        let fee_growth_outside_b = tick.fee_growth_outside_b;
+                        assert_eq!(fee_growth_outside_b, 0);
+                        let reward_growth_outside_r0 = tick.reward_growths_outside[0];
+                        assert_eq!(reward_growth_outside_r0, 0);
+                        let reward_growth_outside_r1 = tick.reward_growths_outside[1];
+                        assert_eq!(reward_growth_outside_r1, 0);
+                        let reward_growth_outside_r2 = tick.reward_growths_outside[2];
+                        assert_eq!(reward_growth_outside_r2, 0);
+                    }
+                }
+            }
+
+            // after build
+            let swap_tick_sequence = builder.build().unwrap();
+            for i in 0..TICK_ARRAY_SIZE_USIZE {
+                let tick = swap_tick_sequence.get_tick(0, 5632 + (i as i32) * 64, 64).unwrap();
+            
+                let initialized = tick.initialized;
+                assert_eq!(initialized, false);
+                let liquidity_net = tick.liquidity_net;
+                assert_eq!(liquidity_net, 0);
+                let liquidity_gross = tick.liquidity_gross;
+                assert_eq!(liquidity_gross, 0);
+                let fee_growth_outside_a = tick.fee_growth_outside_a;
+                assert_eq!(fee_growth_outside_a, 0);
+                let fee_growth_outside_b = tick.fee_growth_outside_b;
+                assert_eq!(fee_growth_outside_b, 0);
+                let reward_growth_outside_r0 = tick.reward_growths_outside[0];
+                assert_eq!(reward_growth_outside_r0, 0);
+                let reward_growth_outside_r1 = tick.reward_growths_outside[1];
+                assert_eq!(reward_growth_outside_r1, 0);
+                let reward_growth_outside_r2 = tick.reward_growths_outside[2];
+                assert_eq!(reward_growth_outside_r2, 0);
+            }
+        }
+
+        #[test]
+        fn dedup_tick_array_account_infos() {
+            let whirlpool_address = Pubkey::new_unique();
+            let mut account_info_mock = AccountInfoMock::new_whirlpool(
+                whirlpool_address.clone(),
+                64,
+                0,
+                None,
+            );
+            let account_info = account_info_mock.to_account_info(false);
+            let whirlpool = Account::<Whirlpool>::try_from(&account_info).unwrap();
+
+            // initialized
+            let ta0_address = derive_tick_array_pda(&whirlpool, 0);
+            let mut ta0_mock = AccountInfoMock::new_tick_array(
+                ta0_address.clone(),
+                whirlpool_address,
+                0,
+                None
+            );
+            let ta0 = ta0_mock.to_account_info(true);
+
+            // uninitialized
+            let ta1_address = derive_tick_array_pda(&whirlpool, 5632);
+            let mut ta1_mock = AccountInfoMock::new(
+                ta1_address.clone(),
+                vec![],
+                System::id(),
+            );
+            let ta1 = ta1_mock.to_account_info(true);
+
+            // initialized
+            let ta2_address = derive_tick_array_pda(&whirlpool, 11264);
+            let mut ta2_mock = AccountInfoMock::new_tick_array(
+                ta2_address.clone(),
+                whirlpool_address,
+                11264,
+                None
+            );
+            let ta2 = ta2_mock.to_account_info(true);
+
+            let builder = SparseSwapTickSequenceBuilder::try_from(
+                &whirlpool,
+                false,
+                vec![
+                    ta0.clone(),
+                    ta0.clone(), // dup
+                    ta1.clone(),
+                ],
+                Some(vec![
+                    ta1.clone(), // dup
+                    ta2.clone(),
+                    ta2.clone(), // dup
+                ]),
+            ).unwrap();
+
+            assert_eq!(builder.tick_array_accounts.len(), 3);
+            vec![0, 5632, 11264].iter().enumerate().for_each(|(i, &expected)| {
+                match &builder.tick_array_accounts[i] {
+                    TickArrayAccount::Initialized { start_tick_index: actual, .. } => {
+                        assert_eq!(*actual, expected);
+                    }
+                    TickArrayAccount::Uninitialized { zeroed, .. } => {
+                        assert!(zeroed.is_some());
+                        let ta = zeroed.as_ref().unwrap().borrow();
+                        let start_tick_index = ta.start_tick_index;
+                        assert_eq!(start_tick_index, expected);
+                    }
+                }
+            });
+        }
+
+        #[test]
+        fn fail_wrong_whirlpool_tick_array() {
+            let whirlpool_address = Pubkey::new_unique();
+            let mut account_info_mock = AccountInfoMock::new_whirlpool(
+                whirlpool_address.clone(),
+                64,
+                0,
+                None,
+            );
+            let account_info = account_info_mock.to_account_info(false);
+            let whirlpool = Account::<Whirlpool>::try_from(&account_info).unwrap();
+
+            let another_whirlpool_address = Pubkey::new_unique();
+            let mut another_account_info_mock = AccountInfoMock::new_whirlpool(
+                another_whirlpool_address.clone(),
+                64,
+                0,
+                None,
+            );
+            let another_account_info = another_account_info_mock.to_account_info(true);
+            let another_whirlpool = Account::<Whirlpool>::try_from(&another_account_info).unwrap();
+
+            let ta0_address = derive_tick_array_pda(&whirlpool, 0);
+            let mut ta0_mock = AccountInfoMock::new_tick_array(
+                ta0_address.clone(),
+                whirlpool_address,
+                0,
+                None
+            );
+            let ta0 = ta0_mock.to_account_info(true);
+
+            // uninitialized
+            let ta1_address = derive_tick_array_pda(&whirlpool, 5632);
+            let mut ta1_mock = AccountInfoMock::new(
+                ta1_address.clone(),
+                vec![],
+                System::id(),
+            );
+            let ta1 = ta1_mock.to_account_info(true);
+
+            // initialized but for another whirlpool
+            let ta2_address = derive_tick_array_pda(&another_whirlpool, 11264);
+            let mut ta2_mock = AccountInfoMock::new_tick_array(
+                ta2_address.clone(),
+                another_whirlpool_address,
+                11264,
+                None
+            );
+            let ta2 = ta2_mock.to_account_info(true);
+
+            let result = SparseSwapTickSequenceBuilder::try_from(
+                &whirlpool,
+                false,
+                vec![ta0, ta1, ta2],
+                None,
+            );
+            assert!(result.is_err());
+            assert!(result.err().unwrap().to_string().contains("DifferentWhirlpoolTickArrayAccount"));
+        }
+
+        #[test]
+        fn ignore_wrong_uninitialized_tick_array() {
+            let whirlpool_address = Pubkey::new_unique();
+            let mut account_info_mock = AccountInfoMock::new_whirlpool(
+                whirlpool_address.clone(),
+                64,
+                0,
+                None,
+            );
+            let account_info = account_info_mock.to_account_info(false);
+            let whirlpool = Account::<Whirlpool>::try_from(&account_info).unwrap();
+
+            let another_whirlpool_address = Pubkey::new_unique();
+            let mut another_account_info_mock = AccountInfoMock::new_whirlpool(
+                another_whirlpool_address.clone(),
+                64,
+                0,
+                None,
+            );
+            let another_account_info = another_account_info_mock.to_account_info(true);
+            let another_whirlpool = Account::<Whirlpool>::try_from(&another_account_info).unwrap();
+
+            let ta0_address = derive_tick_array_pda(&whirlpool, 0);
+            let mut ta0_mock = AccountInfoMock::new_tick_array(
+                ta0_address.clone(),
+                whirlpool_address,
+                0,
+                None
+            );
+            let ta0 = ta0_mock.to_account_info(true);
+
+            // uninitialized and for another whirlpool
+            let ta1_address = derive_tick_array_pda(&another_whirlpool, 5632);
+            let mut ta1_mock = AccountInfoMock::new(
+                ta1_address.clone(),
+                vec![],
+                System::id(),
+            );
+            let ta1 = ta1_mock.to_account_info(true);
+
+            let builder = SparseSwapTickSequenceBuilder::try_from(
+                &whirlpool,
+                false,
+                vec![ta0, ta1.clone(), ta1.clone()],
+                None,
+            ).unwrap();
+
+            // ta1 should be ignored
+            assert_eq!(builder.tick_array_accounts.len(), 1);
+            match &builder.tick_array_accounts[0] {
+                TickArrayAccount::Initialized { start_tick_index: actual, .. } => {
+                    assert_eq!(*actual, 0);
+                }
+                _ => panic!("unexpected state"),
+            }
+        }
+
+        #[test]
+        fn fail_if_no_appropriate_tick_arrays() {
+            let whirlpool_address = Pubkey::new_unique();
+            let mut account_info_mock = AccountInfoMock::new_whirlpool(
+                whirlpool_address.clone(),
+                64,
+                1,
+                None,
+            );
+            let account_info = account_info_mock.to_account_info(false);
+            let whirlpool = Account::<Whirlpool>::try_from(&account_info).unwrap();
+
+            let ta0_address = derive_tick_array_pda(&whirlpool, 5632);
+            let mut ta0_mock = AccountInfoMock::new_tick_array(
+                ta0_address.clone(),
+                whirlpool_address,
+                5632,
+                None
+            );
+            let ta0 = ta0_mock.to_account_info(true);
+
+            let ta1_address = derive_tick_array_pda(&whirlpool, 11264);
+            let mut ta1_mock = AccountInfoMock::new_tick_array(
+                ta1_address.clone(),
+                whirlpool_address,
+                11264,
+                None
+            );
+            let ta1 = ta1_mock.to_account_info(true);
+            
+            let result = SparseSwapTickSequenceBuilder::try_from(
+                &whirlpool,
+                false,
+                vec![ta0, ta1], // provided, but no TA stating at 0
+                None,
+            );
+            assert!(result.is_err());
+            assert!(result.err().unwrap().to_string().contains("InvalidTickArraySequence"));
+        }
+
+        #[test]
+        fn adjust_tick_array_account_ordering() {
+            let whirlpool_address = Pubkey::new_unique();
+            let mut account_info_mock = AccountInfoMock::new_whirlpool(
+                whirlpool_address.clone(),
+                64,
+                -65, // no shift
+                None,
+            );
+            let account_info = account_info_mock.to_account_info(false);
+            let whirlpool = Account::<Whirlpool>::try_from(&account_info).unwrap();
+
+            // initialized
+            let ta0_address = derive_tick_array_pda(&whirlpool, 0);
+            let mut ta0_mock = AccountInfoMock::new_tick_array(
+                ta0_address.clone(),
+                whirlpool_address,
+                0,
+                None
+            );
+            let ta0 = ta0_mock.to_account_info(true);
+
+            // uninitialized
+            let ta1_address = derive_tick_array_pda(&whirlpool, 5632);
+            let mut ta1_mock = AccountInfoMock::new(
+                ta1_address.clone(),
+                vec![],
+                System::id(),
+            );
+            let ta1 = ta1_mock.to_account_info(true);
+
+            // initialized
+            let ta2_address = derive_tick_array_pda(&whirlpool, 11264);
+            let mut ta2_mock = AccountInfoMock::new_tick_array(
+                ta2_address.clone(),
+                whirlpool_address,
+                11264,
+                None
+            );
+            let ta2 = ta2_mock.to_account_info(true);
+
+            // initialized
+            let ta3_address = derive_tick_array_pda(&whirlpool, -5632);
+            let mut ta3_mock = AccountInfoMock::new_tick_array(
+                ta3_address.clone(),
+                whirlpool_address,
+                -5632,
+                None
+            );
+            let ta3 = ta3_mock.to_account_info(true);
+
+            let builder = SparseSwapTickSequenceBuilder::try_from(
+                &whirlpool,
+                false,
+                vec![
+                    // reverse order
+                    ta2.clone(), // 11264
+                    ta1.clone(), // 5632
+                    ta0.clone(), // 0
+                ],
+                Some(vec![
+                    ta3.clone(), // -5632
+                ]),
+            ).unwrap();
+
+            // -5632 should be used as the first tick array
+            assert_eq!(builder.tick_array_accounts.len(), 3);
+            vec![-5632, 0, 5632].iter().enumerate().for_each(|(i, &expected)| {
+                match &builder.tick_array_accounts[i] {
+                    TickArrayAccount::Initialized { start_tick_index: actual, .. } => {
+                        assert_eq!(*actual, expected);
+                    }
+                    TickArrayAccount::Uninitialized { zeroed, .. } => {
+                        assert!(zeroed.is_some());
+                        let ta = zeroed.as_ref().unwrap().borrow();
+                        let start_tick_index = ta.start_tick_index;
+                        assert_eq!(start_tick_index, expected);
+                    }
+                }
+            });
+        }
+
+        #[test]
+        fn uninitialized_tick_array_not_provided() {
+            let whirlpool_address = Pubkey::new_unique();
+            let mut account_info_mock = AccountInfoMock::new_whirlpool(
+                whirlpool_address.clone(),
+                64,
+                -65, // no shift
+                None,
+            );
+            let account_info = account_info_mock.to_account_info(false);
+            let whirlpool = Account::<Whirlpool>::try_from(&account_info).unwrap();
+
+            // initialized
+            let ta0_address = derive_tick_array_pda(&whirlpool, 0);
+            let mut ta0_mock = AccountInfoMock::new_tick_array(
+                ta0_address.clone(),
+                whirlpool_address,
+                0,
+                None
+            );
+            let ta0 = ta0_mock.to_account_info(true);
+
+            // uninitialized
+            let ta1_address = derive_tick_array_pda(&whirlpool, 5632);
+            let mut ta1_mock = AccountInfoMock::new(
+                ta1_address.clone(),
+                vec![],
+                System::id(),
+            );
+            let ta1 = ta1_mock.to_account_info(true);
+
+            // initialized
+            let ta2_address = derive_tick_array_pda(&whirlpool, 11264);
+            let mut ta2_mock = AccountInfoMock::new_tick_array(
+                ta2_address.clone(),
+                whirlpool_address,
+                11264,
+                None
+            );
+            let ta2 = ta2_mock.to_account_info(true);
+
+            // initialized
+            let ta3_address = derive_tick_array_pda(&whirlpool, -5632);
+            let mut ta3_mock = AccountInfoMock::new_tick_array(
+                ta3_address.clone(),
+                whirlpool_address,
+                -5632,
+                None
+            );
+            let ta3 = ta3_mock.to_account_info(true);
+
+            let builder = SparseSwapTickSequenceBuilder::try_from(
+                &whirlpool,
+                false,
+                vec![
+                    ta3.clone(), // -5632
+                    ta0.clone(), // 0
+                    // no ta1 provided
+                    ta2.clone(), // 11264
+                ],
+                None,
+            ).unwrap();
+
+            // -5632 should be used as the first tick array
+            // 5632 should not be included because it is not provided
+            assert_eq!(builder.tick_array_accounts.len(), 2);
+            vec![-5632, 0].iter().enumerate().for_each(|(i, &expected)| {
+                match &builder.tick_array_accounts[i] {
+                    TickArrayAccount::Initialized { start_tick_index: actual, .. } => {
+                        assert_eq!(*actual, expected);
+                    }
+                    TickArrayAccount::Uninitialized { zeroed, .. } => {
+                        assert!(zeroed.is_some());
+                        let ta = zeroed.as_ref().unwrap().borrow();
+                        let start_tick_index = ta.start_tick_index;
+                        assert_eq!(start_tick_index, expected);
+                    }
+                }
+            });
+        }
+
+        #[test]
+        fn all_tick_array_uninitialized() {
+            let whirlpool_address = Pubkey::new_unique();
+            let mut account_info_mock = AccountInfoMock::new_whirlpool(
+                whirlpool_address.clone(),
+                64,
+                6000,
+                None,
+            );
+            let account_info = account_info_mock.to_account_info(false);
+            let whirlpool = Account::<Whirlpool>::try_from(&account_info).unwrap();
+
+            // uninitialized
+            let ta0_address = derive_tick_array_pda(&whirlpool, 0);
+            let mut ta0_mock = AccountInfoMock::new(
+                ta0_address.clone(),
+                vec![],
+                System::id(),
+            );
+            let ta0 = ta0_mock.to_account_info(true);
+
+            // uninitialized
+            let ta1_address = derive_tick_array_pda(&whirlpool, 5632);
+            let mut ta1_mock = AccountInfoMock::new(
+                ta1_address.clone(),
+                vec![],
+                System::id(),
+            );
+            let ta1 = ta1_mock.to_account_info(true);
+
+            // uninitialized
+            let ta2_address = derive_tick_array_pda(&whirlpool, 11264);
+            let mut ta2_mock = AccountInfoMock::new(
+                ta2_address.clone(),
+                vec![],
+                System::id(),
+            );
+            let ta2 = ta2_mock.to_account_info(true);
+
+            // uninitialized
+            let ta3_address = derive_tick_array_pda(&whirlpool, -5632);
+            let mut ta3_mock = AccountInfoMock::new(
+                ta3_address.clone(),
+                vec![],
+                System::id(),
+            );
+            let ta3 = ta3_mock.to_account_info(true);
+
+            let builder = SparseSwapTickSequenceBuilder::try_from(
+                &whirlpool,
+                true,
+                vec![
+                    ta0.clone(), // 0
+                    ta1.clone(), // 5632
+                    ta2.clone(), // 11264
+                ],
+                Some(vec![
+                    ta3.clone(), // -5632
+                ]),
+            ).unwrap();
+
+            // 5632 should be used as the first tick array and its direction should be a to b.
+            assert_eq!(builder.tick_array_accounts.len(), 3);
+            vec![5632, 0, -5632].iter().enumerate().for_each(|(i, &expected)| {
+                match &builder.tick_array_accounts[i] {
+                    TickArrayAccount::Initialized { .. } => {
+                        panic!("unexpected state");
+                    }
+                    TickArrayAccount::Uninitialized { zeroed, .. } => {
+                        assert!(zeroed.is_some());
+                        let ta = zeroed.as_ref().unwrap().borrow();
+                        let start_tick_index = ta.start_tick_index;
+                        assert_eq!(start_tick_index, expected);
+                    }
+                }
+            });
+
+        }
+
+        #[test]
+        fn fail_if_account_is_not_writable() {
+            fn run_test(i: usize) {
+                let whirlpool_address = Pubkey::new_unique();
+                let mut account_info_mock = AccountInfoMock::new_whirlpool(
+                    whirlpool_address.clone(),
+                    64,
+                    0,
+                    None,
+                );
+                let account_info = account_info_mock.to_account_info(false);
+                let whirlpool = Account::<Whirlpool>::try_from(&account_info).unwrap();
+
+                // initialized
+                let ta0_address = derive_tick_array_pda(&whirlpool, 0);
+                let mut ta0_mock = AccountInfoMock::new_tick_array(
+                    ta0_address.clone(),
+                    whirlpool_address,
+                    0,
+                    None
+                );
+
+                // uninitialized
+                let ta1_address = derive_tick_array_pda(&whirlpool, 5632);
+                let mut ta1_mock = AccountInfoMock::new(
+                    ta1_address.clone(),
+                    vec![],
+                    System::id(),
+                );
+
+                // initialized
+                let ta2_address = derive_tick_array_pda(&whirlpool, 11264);
+                let mut ta2_mock = AccountInfoMock::new_tick_array(
+                    ta2_address.clone(),
+                    whirlpool_address,
+                    11264,
+                    None
+                );
+
+                let ta0 = ta0_mock.to_account_info(i != 0);
+                let ta1 = ta1_mock.to_account_info(i != 1);
+                let ta2 = ta2_mock.to_account_info(i != 2);
+                let result = SparseSwapTickSequenceBuilder::try_from(
+                    &whirlpool,
+                    false,
+                    vec![ta0, ta1, ta2],
+                    None,
+                );
+                assert!(result.is_err());
+                assert!(result.err().unwrap().to_string().contains("AccountNotMutable"));    
+            }
+
+            run_test(0);
+            run_test(1);
+            run_test(2);
+        }
+
+        #[test]
+        fn fail_if_uninitialized_account_is_not_empty() {
+            let whirlpool_address = Pubkey::new_unique();
+            let mut account_info_mock = AccountInfoMock::new_whirlpool(
+                whirlpool_address.clone(),
+                64,
+                0,
+                None,
+            );
+            let account_info = account_info_mock.to_account_info(false);
+            let whirlpool = Account::<Whirlpool>::try_from(&account_info).unwrap();
+
+            // initialized
+            let ta0_address = derive_tick_array_pda(&whirlpool, 0);
+            let mut ta0_mock = AccountInfoMock::new_tick_array(
+                ta0_address.clone(),
+                whirlpool_address,
+                0,
+                None
+            );
+
+            // uninitialized
+            let ta1_address = derive_tick_array_pda(&whirlpool, 5632);
+            let mut ta1_mock = AccountInfoMock::new(
+                ta1_address.clone(),
+                vec![0u8; 8], // not empty
+                System::id(),
+            );
+
+            // initialized
+            let ta2_address = derive_tick_array_pda(&whirlpool, 11264);
+            let mut ta2_mock = AccountInfoMock::new_tick_array(
+                ta2_address.clone(),
+                whirlpool_address,
+                11264,
+                None
+            );
+
+            let ta0 = ta0_mock.to_account_info(true);
+            let ta1 = ta1_mock.to_account_info(true);
+            let ta2 = ta2_mock.to_account_info(true);
+            let result = SparseSwapTickSequenceBuilder::try_from(
+                &whirlpool,
+                false,
+                vec![ta0, ta1, ta2],
+                None,
+            );
+            assert!(result.is_err());
+            assert!(result.err().unwrap().to_string().contains("AccountOwnedByWrongProgram"));    
+        }
+
+        #[test]
+        fn fail_if_wrong_tick_array_account() {
+            let whirlpool_address = Pubkey::new_unique();
+            let mut account_info_mock = AccountInfoMock::new_whirlpool(
+                whirlpool_address.clone(),
+                64,
+                0,
+                None,
+            );
+            let whirlpool_account_info = account_info_mock.to_account_info(true);
+            let whirlpool = Account::<Whirlpool>::try_from(&whirlpool_account_info).unwrap();
+
+            // initialized
+            let ta0_address = derive_tick_array_pda(&whirlpool, 0);
+            let mut ta0_mock = AccountInfoMock::new_tick_array(
+                ta0_address.clone(),
+                whirlpool_address,
+                0,
+                None
+            );
+
+            // initialized
+            let ta2_address = derive_tick_array_pda(&whirlpool, 11264);
+            let mut ta2_mock = AccountInfoMock::new_tick_array(
+                ta2_address.clone(),
+                whirlpool_address,
+                11264,
+                None
+            );
+
+            let ta0 = ta0_mock.to_account_info(true);
+            let ta1 = whirlpool_account_info.clone();
+            let ta2 = ta2_mock.to_account_info(true);
+            let result = SparseSwapTickSequenceBuilder::try_from(
+                &whirlpool,
+                false,
+                vec![
+                    ta0,
+                    ta1,
+                    ta2
+                ],
+                None,
+            );
+            assert!(result.is_err());
+            assert!(result.err().unwrap().to_string().contains("AccountDiscriminatorMismatch"));
+        }
+    }
 }

--- a/programs/whirlpool/src/util/sparse_swap.rs
+++ b/programs/whirlpool/src/util/sparse_swap.rs
@@ -1,0 +1,226 @@
+use std::{cell::{Ref, RefCell, RefMut}, collections::VecDeque};
+use anchor_lang::prelude::*;
+
+use crate::{
+    errors::ErrorCode,
+    state::{TickArray, Whirlpool, MAX_TICK_INDEX, MIN_TICK_INDEX, TICK_ARRAY_SIZE},
+    util::SwapTickSequence,
+};
+
+enum TickArrayAccount<'info> {
+  // owned by this whirlpool program and its discriminator is valid and writable
+  // but not sure if this TickArray is valid for this whirlpool (maybe for another whirlpool)
+  Initialized(Pubkey, i32, AccountInfo<'info>),
+  // owned by system program and its data size is zero and writable
+  // but not sure if this key is valid PDA for TickArray
+  Uninitialized(Pubkey, AccountInfo<'info>, Option<Box<RefCell<TickArray>>>),
+}
+
+pub struct SparseSwapTickSequenceBuilder<'info> {
+  tick_array_accounts: Vec<TickArrayAccount<'info>>,
+}
+
+impl<'info> SparseSwapTickSequenceBuilder<'info> {
+  pub fn try_from(
+      whirlpool: Box<Account<'info, Whirlpool>>,
+      a_to_b: bool,
+      mut tick_array_account_infos: Vec<AccountInfo<'info>>,
+  ) -> Result<Self> {
+      // dedup by key
+      tick_array_account_infos.sort_by_key(|a| a.key());
+      tick_array_account_infos.dedup_by_key(|a| a.key());
+
+      let mut initialized = vec![];
+      let mut uninitialized = vec![];
+      for account_info in tick_array_account_infos.into_iter() {
+          let state = peek_tick_array(account_info)?;
+
+          match &state {
+              TickArrayAccount::Initialized(tick_array_whirlpool, start_tick_index, ..) => {
+                  // has_one constraint equivalent check
+                  if *tick_array_whirlpool != whirlpool.key() {
+                      // TODO: our own error definition
+                      return Err(anchor_lang::error::ErrorCode::ConstraintHasOne.into());
+                  }
+                  initialized.push((*start_tick_index, state));
+              }
+              TickArrayAccount::Uninitialized(pubkey, ..) => {
+                  uninitialized.push((*pubkey, state));
+              }
+          }
+      }
+  
+      ////////////////////////////////////////////////////////////////////////
+      // Now successfully loaded tick arrays have been verified as:
+      // - Owned by Whirlpool Program
+      // - Initialized as TickArray account
+      // - And has_one constraint is satisfied (i.e. belongs to trading whirlpool)
+      // - Writable
+      ////////////////////////////////////////////////////////////////////////
+      let start_tick_indexes = get_start_tick_indexes(&whirlpool, a_to_b);
+  
+      let mut tick_array_accounts: Vec<TickArrayAccount> = vec![];
+      for start_tick_index in start_tick_indexes.iter() {
+          // find from initialized tick arrays
+          if let Some(pos) = initialized.iter().position(|t| t.0 == *start_tick_index) {
+              let state = initialized.remove(pos).1;
+              tick_array_accounts.push(state);
+              continue;
+          }
+  
+          // find from uninitialized tick arrays
+          let tick_array_pda = derive_tick_array_pda(&whirlpool, *start_tick_index);
+          if let Some(pos) = uninitialized.iter().position(|t| t.0 == tick_array_pda) {
+              let state = uninitialized.remove(pos).1;
+              if let TickArrayAccount::Uninitialized(pubkey, account_info, ..) = state {
+                  // create zeroed TickArray data
+                  let zeroed = Box::new(RefCell::new(TickArray::default()));
+                  zeroed.borrow_mut().initialize(&whirlpool, *start_tick_index)?;
+
+                  tick_array_accounts.push(TickArrayAccount::Uninitialized(
+                      pubkey,
+                      account_info,
+                      Some(zeroed)
+                  ));
+              } else {
+                  unreachable!("state in uninitialized must be Uninitialized");
+              }
+              continue;
+          }
+  
+          // no more valid tickarrays for this swap
+          break;
+      }
+
+      Ok(Self { tick_array_accounts })
+  }
+
+  pub fn build<'a>(&'a self) -> Result<SwapTickSequence<'a>> {
+      let mut tick_array_refmuts = VecDeque::with_capacity(3);
+      for tick_array_account in self.tick_array_accounts.iter() {
+          match tick_array_account {
+              TickArrayAccount::Initialized(_, _, account_info) => {
+                  use std::ops::DerefMut;
+
+                  let data = account_info.try_borrow_mut_data()?;
+                  let tick_array_refmut = RefMut::map(data, |data| {
+                      bytemuck::from_bytes_mut(&mut data.deref_mut()[8..std::mem::size_of::<TickArray>() + 8])
+                  });
+                  tick_array_refmuts.push_back(tick_array_refmut);
+              }
+              TickArrayAccount::Uninitialized(_, _, tick_array) => {
+                  let tick_array_refmut = tick_array.as_ref().unwrap().borrow_mut();
+                  tick_array_refmuts.push_back(tick_array_refmut);
+              }
+          }
+      }
+      
+      if tick_array_refmuts.is_empty() {
+          return Err(crate::errors::ErrorCode::InvalidTickArraySequence.into());
+      }
+  
+      Ok(SwapTickSequence::<'a>::new(
+          tick_array_refmuts.pop_front().unwrap(),
+          tick_array_refmuts.pop_front(),
+          tick_array_refmuts.pop_front(),
+      ))    
+  }
+}
+
+fn peek_tick_array<'info>(
+  account_info: AccountInfo<'info>,
+) -> Result<TickArrayAccount<'info>> {
+  use anchor_lang::Discriminator;
+
+  // following process is ported from anchor-lang's AccountLoader::try_from and AccountLoader::load_mut
+
+  if !account_info.is_writable {
+      return Err(anchor_lang::error::ErrorCode::AccountNotMutable.into());
+  }
+
+  // uninitialized writable account (owned by system program and its data size is zero)
+  if account_info.owner == &System::id() && account_info.data_is_empty() {
+      return Ok(TickArrayAccount::Uninitialized(*account_info.key, account_info, None));
+  }
+
+  // owner program check
+  if account_info.owner != &TickArray::owner() {
+      return Err(Error::from(anchor_lang::error::ErrorCode::AccountOwnedByWrongProgram)
+          .with_pubkeys((*account_info.owner, TickArray::owner())));
+  }
+
+  let data = account_info.try_borrow_data()?;
+  if data.len() < TickArray::discriminator().len() {
+      return Err(anchor_lang::error::ErrorCode::AccountDiscriminatorNotFound.into());
+  }
+
+  let disc_bytes = arrayref::array_ref![data, 0, 8];
+  if disc_bytes != &TickArray::discriminator() {
+      return Err(anchor_lang::error::ErrorCode::AccountDiscriminatorMismatch.into());
+  }
+
+  let tick_array: Ref<TickArray> = Ref::map(data, |data| {
+      bytemuck::from_bytes(&data[8..std::mem::size_of::<TickArray>() + 8])
+  });
+
+  let start_tick_index = tick_array.start_tick_index;
+  let whirlpool = tick_array.whirlpool;
+  drop(tick_array);
+
+  Ok(TickArrayAccount::Initialized(whirlpool, start_tick_index, account_info))
+}
+
+fn get_start_tick_indexes(whirlpool: &Account<Whirlpool>, a_to_b: bool) -> Vec<i32> {
+  let tick_current_index = whirlpool.tick_current_index;
+  let tick_spacing = whirlpool.tick_spacing as i32;
+  let ticks_in_array = TICK_ARRAY_SIZE * tick_spacing;
+
+  let start_tick_index_base = floor_division(tick_current_index, ticks_in_array) * ticks_in_array;
+  let offset = if a_to_b {
+      [0, -1, -2]
+  } else {
+      let shifted = tick_current_index + tick_spacing >= start_tick_index_base + ticks_in_array;
+      if shifted { [1, 2, 3] } else { [0, 1, 2] }
+  };
+
+  let start_tick_indexes = offset
+      .iter()
+      .filter_map(|&o| {
+          let start_tick_index = start_tick_index_base + o * ticks_in_array;
+          if is_valid_start_tick_index(start_tick_index, ticks_in_array) {
+              Some(start_tick_index)
+          } else {
+              None
+          }
+      })
+      .collect::<Vec<i32>>();
+
+  start_tick_indexes
+}
+
+fn is_valid_start_tick_index(start_tick_index: i32, ticks_in_array: i32) -> bool {
+  start_tick_index + ticks_in_array > MIN_TICK_INDEX && start_tick_index < MAX_TICK_INDEX
+}
+
+fn floor_division(dividend: i32, divisor: i32) -> i32 {
+  assert!(divisor != 0, "Divisor cannot be zero.");
+  if dividend % divisor == 0 || dividend.signum() == divisor.signum() {
+      dividend / divisor
+  } else {
+      dividend / divisor - 1
+  }
+}
+
+fn derive_tick_array_pda(
+  whirlpool: &Account<Whirlpool>,
+  start_tick_index: i32,
+) -> Pubkey {
+  Pubkey::find_program_address(
+      &[
+          b"tick_array",
+          whirlpool.key().as_ref(),
+          start_tick_index.to_string().as_bytes(),
+      ],
+      &TickArray::owner()
+  ).0
+}

--- a/programs/whirlpool/src/util/sparse_swap.rs
+++ b/programs/whirlpool/src/util/sparse_swap.rs
@@ -22,7 +22,7 @@ pub struct SparseSwapTickSequenceBuilder<'info> {
 
 impl<'info> SparseSwapTickSequenceBuilder<'info> {
   pub fn try_from(
-      whirlpool: Box<Account<'info, Whirlpool>>,
+      whirlpool: &Account<'info, Whirlpool>,
       a_to_b: bool,
       mut tick_array_account_infos: Vec<AccountInfo<'info>>,
   ) -> Result<Self> {
@@ -57,7 +57,7 @@ impl<'info> SparseSwapTickSequenceBuilder<'info> {
       // - And has_one constraint is satisfied (i.e. belongs to trading whirlpool)
       // - Writable
       ////////////////////////////////////////////////////////////////////////
-      let start_tick_indexes = get_start_tick_indexes(&whirlpool, a_to_b);
+      let start_tick_indexes = get_start_tick_indexes(whirlpool, a_to_b);
   
       let mut tick_array_accounts: Vec<TickArrayAccount> = vec![];
       for start_tick_index in start_tick_indexes.iter() {
@@ -75,7 +75,7 @@ impl<'info> SparseSwapTickSequenceBuilder<'info> {
               if let TickArrayAccount::Uninitialized(pubkey, account_info, ..) = state {
                   // create zeroed TickArray data
                   let zeroed = Box::new(RefCell::new(TickArray::default()));
-                  zeroed.borrow_mut().initialize(&whirlpool, *start_tick_index)?;
+                  zeroed.borrow_mut().initialize(whirlpool, *start_tick_index)?;
 
                   tick_array_accounts.push(TickArrayAccount::Uninitialized(
                       pubkey,

--- a/programs/whirlpool/src/util/sparse_swap.rs
+++ b/programs/whirlpool/src/util/sparse_swap.rs
@@ -136,11 +136,11 @@ impl<'info> SparseSwapTickSequenceBuilder<'info> {
         whirlpool: &Account<'info, Whirlpool>,
         a_to_b: bool,
         static_tick_array_account_infos: Vec<AccountInfo<'info>>,
-        additional_tick_array_account_infos: Option<Vec<AccountInfo<'info>>>,
+        supplemental_tick_array_account_infos: Option<Vec<AccountInfo<'info>>>,
     ) -> Result<Self> {
         let mut tick_array_account_infos = static_tick_array_account_infos;
-        if let Some(additional_tick_array_account_infos) = additional_tick_array_account_infos {
-            tick_array_account_infos.extend(additional_tick_array_account_infos);
+        if let Some(supplemental_tick_array_account_infos) = supplemental_tick_array_account_infos {
+            tick_array_account_infos.extend(supplemental_tick_array_account_infos);
         }
 
         // dedup by key

--- a/programs/whirlpool/src/util/swap_tick_sequence.rs
+++ b/programs/whirlpool/src/util/swap_tick_sequence.rs
@@ -2,13 +2,26 @@ use crate::errors::ErrorCode;
 use crate::state::*;
 use crate::util::ProxiedTickArray;
 use anchor_lang::prelude::*;
+use std::cell::RefMut;
 
 pub struct SwapTickSequence<'info> {
     arrays: Vec<ProxiedTickArray<'info>>,
 }
 
 impl<'info> SwapTickSequence<'info> {
-    pub(crate) fn new(
+    pub fn new(
+        ta0: RefMut<'info, TickArray>,
+        ta1: Option<RefMut<'info, TickArray>>,
+        ta2: Option<RefMut<'info, TickArray>>,
+    ) -> Self {
+        Self::new_with_proxy(
+            ProxiedTickArray::new_initialized(ta0),
+            ta1.map(|refmut| ProxiedTickArray::new_initialized(refmut)),
+            ta2.map(|refmut| ProxiedTickArray::new_initialized(refmut)),
+        )
+    }
+
+    pub(crate) fn new_with_proxy(
         ta0: ProxiedTickArray<'info>,
         ta1: Option<ProxiedTickArray<'info>>,
         ta2: Option<ProxiedTickArray<'info>>,

--- a/programs/whirlpool/src/util/swap_tick_sequence.rs
+++ b/programs/whirlpool/src/util/swap_tick_sequence.rs
@@ -1,17 +1,17 @@
 use crate::errors::ErrorCode;
 use crate::state::*;
+use crate::util::ProxiedTickArray;
 use anchor_lang::prelude::*;
-use std::cell::RefMut;
 
 pub struct SwapTickSequence<'info> {
-    arrays: Vec<RefMut<'info, TickArray>>,
+    arrays: Vec<ProxiedTickArray<'info>>,
 }
 
 impl<'info> SwapTickSequence<'info> {
-    pub fn new(
-        ta0: RefMut<'info, TickArray>,
-        ta1: Option<RefMut<'info, TickArray>>,
-        ta2: Option<RefMut<'info, TickArray>>,
+    pub(crate) fn new(
+        ta0: ProxiedTickArray<'info>,
+        ta1: Option<ProxiedTickArray<'info>>,
+        ta2: Option<ProxiedTickArray<'info>>,
     ) -> Self {
         let mut vec = Vec::with_capacity(3);
         vec.push(ta0);
@@ -140,9 +140,9 @@ impl<'info> SwapTickSequence<'info> {
                     // If we are at the last tick array in the sequencer, return the last tick
                     if array_index + 1 == self.arrays.len() {
                         if a_to_b {
-                            return Ok((array_index, next_array.start_tick_index));
+                            return Ok((array_index, next_array.start_tick_index()));
                         } else {
-                            let last_tick = next_array.start_tick_index + ticks_in_array - 1;
+                            let last_tick = next_array.start_tick_index() + ticks_in_array - 1;
                             return Ok((array_index, last_tick));
                         }
                     }
@@ -150,9 +150,9 @@ impl<'info> SwapTickSequence<'info> {
                     // No initialized index found. Move the search-index to the 1st search position
                     // of the next array in sequence.
                     search_index = if a_to_b {
-                        next_array.start_tick_index - 1
+                        next_array.start_tick_index() - 1
                     } else {
-                        next_array.start_tick_index + ticks_in_array - 1
+                        next_array.start_tick_index() + ticks_in_array - 1
                     };
 
                     array_index += 1;

--- a/programs/whirlpool/src/util/v2/remaining_accounts_utils.rs
+++ b/programs/whirlpool/src/util/v2/remaining_accounts_utils.rs
@@ -12,8 +12,8 @@ pub enum AccountsType {
     TransferHookIntermediate,
     TransferHookOutput,
     AdditionalTickArrays,
-    //TickArrayOne,
-    //TickArrayTwo,
+    AdditionalTickArraysOne,
+    AdditionalTickArraysTwo,
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone)]
@@ -36,8 +36,8 @@ pub struct ParsedRemainingAccounts<'info> {
     pub transfer_hook_intermediate: Option<Vec<AccountInfo<'info>>>,
     pub transfer_hook_output: Option<Vec<AccountInfo<'info>>>,
     pub additional_tick_arrays: Option<Vec<AccountInfo<'info>>>,
-    //pub tick_array_one: Option<Vec<AccountInfo<'info>>>,
-    //pub tick_array_two: Option<Vec<AccountInfo<'info>>>,
+    pub additional_tick_arrays_one: Option<Vec<AccountInfo<'info>>>,
+    pub additional_tick_arrays_two: Option<Vec<AccountInfo<'info>>>,
 }
 
 pub fn parse_remaining_accounts<'info>(
@@ -109,22 +109,35 @@ pub fn parse_remaining_accounts<'info>(
         parsed_remaining_accounts.transfer_hook_output = Some(accounts);
       }
       AccountsType::AdditionalTickArrays => {
-        if parsed_remaining_accounts.additional_tick_arrays.is_some() {
-          return Err(ErrorCode::RemainingAccountsDuplicatedAccountsType.into());
-        }
         if accounts.len() > MAX_ADDITIONAL_TICK_ARRAYS_LEN {
           return Err(ErrorCode::TooManyAdditionalTickArrays.into());
         }
+
+        if parsed_remaining_accounts.additional_tick_arrays.is_some() {
+          return Err(ErrorCode::RemainingAccountsDuplicatedAccountsType.into());
+        }
         parsed_remaining_accounts.additional_tick_arrays = Some(accounts);
       }
-      /* 
-      AccountsType::TickArrayOne => {
-        parsed_remaining_accounts.tick_array_one = Some(accounts);
+      AccountsType::AdditionalTickArraysOne => {
+        if accounts.len() > MAX_ADDITIONAL_TICK_ARRAYS_LEN {
+          return Err(ErrorCode::TooManyAdditionalTickArrays.into());
+        }
+
+        if parsed_remaining_accounts.additional_tick_arrays_one.is_some() {
+          return Err(ErrorCode::RemainingAccountsDuplicatedAccountsType.into());
+        }
+        parsed_remaining_accounts.additional_tick_arrays_one = Some(accounts);
       }
-      AccountsType::TickArrayTwo => {
-        parsed_remaining_accounts.tick_array_two = Some(accounts);
+      AccountsType::AdditionalTickArraysTwo => {
+        if accounts.len() > MAX_ADDITIONAL_TICK_ARRAYS_LEN {
+          return Err(ErrorCode::TooManyAdditionalTickArrays.into());
+        }
+
+        if parsed_remaining_accounts.additional_tick_arrays_two.is_some() {
+          return Err(ErrorCode::RemainingAccountsDuplicatedAccountsType.into());
+        }
+        parsed_remaining_accounts.additional_tick_arrays_two = Some(accounts);
       }
-      */
     }
   }
 

--- a/programs/whirlpool/src/util/v2/remaining_accounts_utils.rs
+++ b/programs/whirlpool/src/util/v2/remaining_accounts_utils.rs
@@ -1,7 +1,7 @@
 use anchor_lang::prelude::*;
 use crate::errors::ErrorCode;
 
-pub const MAX_ADDITIONAL_TICK_ARRAYS_LEN: usize = 3;
+pub const MAX_SUPPLEMENTAL_TICK_ARRAYS_LEN: usize = 3;
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq, Eq)]
 pub enum AccountsType {
@@ -11,9 +11,9 @@ pub enum AccountsType {
     TransferHookInput,
     TransferHookIntermediate,
     TransferHookOutput,
-    AdditionalTickArrays,
-    AdditionalTickArraysOne,
-    AdditionalTickArraysTwo,
+    SupplementalTickArrays,
+    SupplementalTickArraysOne,
+    SupplementalTickArraysTwo,
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone)]
@@ -35,9 +35,9 @@ pub struct ParsedRemainingAccounts<'info> {
     pub transfer_hook_input: Option<Vec<AccountInfo<'info>>>,
     pub transfer_hook_intermediate: Option<Vec<AccountInfo<'info>>>,
     pub transfer_hook_output: Option<Vec<AccountInfo<'info>>>,
-    pub additional_tick_arrays: Option<Vec<AccountInfo<'info>>>,
-    pub additional_tick_arrays_one: Option<Vec<AccountInfo<'info>>>,
-    pub additional_tick_arrays_two: Option<Vec<AccountInfo<'info>>>,
+    pub supplemental_tick_arrays: Option<Vec<AccountInfo<'info>>>,
+    pub supplemental_tick_arrays_one: Option<Vec<AccountInfo<'info>>>,
+    pub supplemental_tick_arrays_two: Option<Vec<AccountInfo<'info>>>,
 }
 
 pub fn parse_remaining_accounts<'info>(
@@ -108,35 +108,35 @@ pub fn parse_remaining_accounts<'info>(
         }
         parsed_remaining_accounts.transfer_hook_output = Some(accounts);
       }
-      AccountsType::AdditionalTickArrays => {
-        if accounts.len() > MAX_ADDITIONAL_TICK_ARRAYS_LEN {
-          return Err(ErrorCode::TooManyAdditionalTickArrays.into());
+      AccountsType::SupplementalTickArrays => {
+        if accounts.len() > MAX_SUPPLEMENTAL_TICK_ARRAYS_LEN {
+          return Err(ErrorCode::TooManySupplementalTickArrays.into());
         }
 
-        if parsed_remaining_accounts.additional_tick_arrays.is_some() {
+        if parsed_remaining_accounts.supplemental_tick_arrays.is_some() {
           return Err(ErrorCode::RemainingAccountsDuplicatedAccountsType.into());
         }
-        parsed_remaining_accounts.additional_tick_arrays = Some(accounts);
+        parsed_remaining_accounts.supplemental_tick_arrays = Some(accounts);
       }
-      AccountsType::AdditionalTickArraysOne => {
-        if accounts.len() > MAX_ADDITIONAL_TICK_ARRAYS_LEN {
-          return Err(ErrorCode::TooManyAdditionalTickArrays.into());
+      AccountsType::SupplementalTickArraysOne => {
+        if accounts.len() > MAX_SUPPLEMENTAL_TICK_ARRAYS_LEN {
+          return Err(ErrorCode::TooManySupplementalTickArrays.into());
         }
 
-        if parsed_remaining_accounts.additional_tick_arrays_one.is_some() {
+        if parsed_remaining_accounts.supplemental_tick_arrays_one.is_some() {
           return Err(ErrorCode::RemainingAccountsDuplicatedAccountsType.into());
         }
-        parsed_remaining_accounts.additional_tick_arrays_one = Some(accounts);
+        parsed_remaining_accounts.supplemental_tick_arrays_one = Some(accounts);
       }
-      AccountsType::AdditionalTickArraysTwo => {
-        if accounts.len() > MAX_ADDITIONAL_TICK_ARRAYS_LEN {
-          return Err(ErrorCode::TooManyAdditionalTickArrays.into());
+      AccountsType::SupplementalTickArraysTwo => {
+        if accounts.len() > MAX_SUPPLEMENTAL_TICK_ARRAYS_LEN {
+          return Err(ErrorCode::TooManySupplementalTickArrays.into());
         }
 
-        if parsed_remaining_accounts.additional_tick_arrays_two.is_some() {
+        if parsed_remaining_accounts.supplemental_tick_arrays_two.is_some() {
           return Err(ErrorCode::RemainingAccountsDuplicatedAccountsType.into());
         }
-        parsed_remaining_accounts.additional_tick_arrays_two = Some(accounts);
+        parsed_remaining_accounts.supplemental_tick_arrays_two = Some(accounts);
       }
     }
   }

--- a/programs/whirlpool/src/util/v2/remaining_accounts_utils.rs
+++ b/programs/whirlpool/src/util/v2/remaining_accounts_utils.rs
@@ -1,6 +1,8 @@
 use anchor_lang::prelude::*;
 use crate::errors::ErrorCode;
 
+pub const MAX_ADDITIONAL_TICK_ARRAYS_LEN: usize = 3;
+
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq, Eq)]
 pub enum AccountsType {
     TransferHookA,
@@ -9,7 +11,7 @@ pub enum AccountsType {
     TransferHookInput,
     TransferHookIntermediate,
     TransferHookOutput,
-    //TickArray,
+    AdditionalTickArrays,
     //TickArrayOne,
     //TickArrayTwo,
 }
@@ -33,7 +35,7 @@ pub struct ParsedRemainingAccounts<'info> {
     pub transfer_hook_input: Option<Vec<AccountInfo<'info>>>,
     pub transfer_hook_intermediate: Option<Vec<AccountInfo<'info>>>,
     pub transfer_hook_output: Option<Vec<AccountInfo<'info>>>,
-    //pub tick_array: Option<Vec<AccountInfo<'info>>>,
+    pub additional_tick_arrays: Option<Vec<AccountInfo<'info>>>,
     //pub tick_array_one: Option<Vec<AccountInfo<'info>>>,
     //pub tick_array_two: Option<Vec<AccountInfo<'info>>>,
 }
@@ -106,10 +108,16 @@ pub fn parse_remaining_accounts<'info>(
         }
         parsed_remaining_accounts.transfer_hook_output = Some(accounts);
       }
-      /* 
-      AccountsType::TickArray => {
-        parsed_remaining_accounts.tick_array = Some(accounts);
+      AccountsType::AdditionalTickArrays => {
+        if parsed_remaining_accounts.additional_tick_arrays.is_some() {
+          return Err(ErrorCode::RemainingAccountsDuplicatedAccountsType.into());
+        }
+        if accounts.len() > MAX_ADDITIONAL_TICK_ARRAYS_LEN {
+          return Err(ErrorCode::TooManyAdditionalTickArrays.into());
+        }
+        parsed_remaining_accounts.additional_tick_arrays = Some(accounts);
       }
+      /* 
       AccountsType::TickArrayOne => {
         parsed_remaining_accounts.tick_array_one = Some(accounts);
       }

--- a/sdk/src/artifacts/whirlpool.json
+++ b/sdk/src/artifacts/whirlpool.json
@@ -3551,6 +3551,15 @@
           },
           {
             "name": "TransferHookOutput"
+          },
+          {
+            "name": "SupplementalTickArrays"
+          },
+          {
+            "name": "SupplementalTickArraysOne"
+          },
+          {
+            "name": "SupplementalTickArraysTwo"
           }
         ]
       }
@@ -3826,6 +3835,16 @@
       "code": 6053,
       "name": "RemainingAccountsDuplicatedAccountsType",
       "msg": "Same accounts type is provided more than once"
+    },
+    {
+      "code": 6054,
+      "name": "TooManySupplementalTickArrays",
+      "msg": "Too many supplemental tick arrays provided"
+    },
+    {
+      "code": 6055,
+      "name": "DifferentWhirlpoolTickArrayAccount",
+      "msg": "TickArray account for different whirlpool provided"
     }
   ]
 }

--- a/sdk/src/artifacts/whirlpool.ts
+++ b/sdk/src/artifacts/whirlpool.ts
@@ -3551,6 +3551,15 @@ export type Whirlpool = {
           },
           {
             "name": "TransferHookOutput"
+          },
+          {
+            "name": "SupplementalTickArrays"
+          },
+          {
+            "name": "SupplementalTickArraysOne"
+          },
+          {
+            "name": "SupplementalTickArraysTwo"
           }
         ]
       }
@@ -3826,6 +3835,16 @@ export type Whirlpool = {
       "code": 6053,
       "name": "RemainingAccountsDuplicatedAccountsType",
       "msg": "Same accounts type is provided more than once"
+    },
+    {
+      "code": 6054,
+      "name": "TooManySupplementalTickArrays",
+      "msg": "Too many supplemental tick arrays provided"
+    },
+    {
+      "code": 6055,
+      "name": "DifferentWhirlpoolTickArrayAccount",
+      "msg": "TickArray account for different whirlpool provided"
     }
   ]
 };
@@ -7383,6 +7402,15 @@ export const IDL: Whirlpool = {
           },
           {
             "name": "TransferHookOutput"
+          },
+          {
+            "name": "SupplementalTickArrays"
+          },
+          {
+            "name": "SupplementalTickArraysOne"
+          },
+          {
+            "name": "SupplementalTickArraysTwo"
           }
         ]
       }
@@ -7658,6 +7686,16 @@ export const IDL: Whirlpool = {
       "code": 6053,
       "name": "RemainingAccountsDuplicatedAccountsType",
       "msg": "Same accounts type is provided more than once"
+    },
+    {
+      "code": 6054,
+      "name": "TooManySupplementalTickArrays",
+      "msg": "Too many supplemental tick arrays provided"
+    },
+    {
+      "code": 6055,
+      "name": "DifferentWhirlpoolTickArrayAccount",
+      "msg": "TickArray account for different whirlpool provided"
     }
   ]
 };

--- a/sdk/src/instructions/composites/swap-with-route.ts
+++ b/sdk/src/instructions/composites/swap-with-route.ts
@@ -22,7 +22,6 @@ import {
   PDAUtil,
   SubTradeRoute,
   SwapUtils,
-  TickArrayUtil,
   TradeRoute,
   WhirlpoolContext,
   twoHopSwapQuoteFromSwapQuotes,
@@ -111,14 +110,7 @@ export async function getSwapFromRoute(
     }
   }
 
-  let uninitializedArrays = await TickArrayUtil.getUninitializedArraysString(
-    requiredTickArrays,
-    ctx.fetcher,
-    opts
-  );
-  if (uninitializedArrays) {
-    throw new Error(`TickArray addresses - [${uninitializedArrays}] need to be initialized.`);
-  }
+  // No need to check if TickArrays are initialized after SparseSwap implementation
 
   // Handle non-native mints only first
   requiredAtas.delete(NATIVE_MINT.toBase58());

--- a/sdk/src/instructions/swap-ix.ts
+++ b/sdk/src/instructions/swap-ix.ts
@@ -41,6 +41,7 @@ export type SwapParams = SwapInput & {
  * @param tickArray0 - PublicKey of the tick-array where the Whirlpool's currentTickIndex resides in
  * @param tickArray1 - The next tick-array in the swap direction. If the swap will not reach the next tick-aray, input the same array as tickArray0.
  * @param tickArray2 - The next tick-array in the swap direction after tickArray2. If the swap will not reach the next tick-aray, input the same array as tickArray1.
+ * @param supplementalTickArrays - (V2 only) Optional array of PublicKey for supplemental tick arrays. swap instruction will ignore this parameter.
  */
 export type SwapInput = {
   amount: BN;
@@ -51,6 +52,7 @@ export type SwapInput = {
   tickArray0: PublicKey;
   tickArray1: PublicKey;
   tickArray2: PublicKey;
+  supplementalTickArrays?: PublicKey[];
 };
 
 /**

--- a/sdk/src/instructions/two-hop-swap-ix.ts
+++ b/sdk/src/instructions/two-hop-swap-ix.ts
@@ -58,7 +58,9 @@ export type TwoHopSwapParams = TwoHopSwapInput & {
  * @param tickArrayTwo0 - PublicKey of the tick-array of swap-Two where the Whirlpool's currentTickIndex resides in
  * @param tickArrayTwo1 - The next tick-array in the swap direction of swap-Two. If the swap will not reach the next tick-aray, input the same array as tickArray0.
  * @param tickArrayTwo2 - The next tick-array in the swap direction after tickArray2 of swap-Two. If the swap will not reach the next tick-aray, input the same array as tickArray1.
- */
+ * @param supplementalTickArraysOne - (V2 only) Optional array of PublicKey for supplemental tick arrays of whirlpoolOne. twoHopSwap instruction will ignore this parameter.
+ * @param supplementalTickArraysTwo - (V2 only) Optional array of PublicKey for supplemental tick arrays of whirlpoolTwo. twoHopSwap instruction will ignore this parameter.
+*/
 export type TwoHopSwapInput = {
   amount: BN;
   otherAmountThreshold: BN;
@@ -73,6 +75,8 @@ export type TwoHopSwapInput = {
   tickArrayTwo0: PublicKey;
   tickArrayTwo1: PublicKey;
   tickArrayTwo2: PublicKey;
+  supplementalTickArraysOne?: PublicKey[];
+  supplementalTickArraysTwo?: PublicKey[];
 };
 
 /**

--- a/sdk/src/instructions/v2/swap-ix.ts
+++ b/sdk/src/instructions/v2/swap-ix.ts
@@ -24,7 +24,6 @@ import { RemainingAccountsBuilder, RemainingAccountsType, toSupplementalTickArra
  * @param tokenProgramB - PublicKey for the token program for token B.
  * @param oracle - PublicKey for the oracle account for this Whirlpool.
  * @param tokenAuthority - authority to withdraw tokens from the input token account
- * @param supplementalTickArrays - Optional array of PublicKey for supplemental tick arrays of this whirlpool.
  */
 export type SwapV2Params = SwapInput & {
   whirlpool: PublicKey;
@@ -40,7 +39,6 @@ export type SwapV2Params = SwapInput & {
   tokenProgramB: PublicKey;
   oracle: PublicKey;
   tokenAuthority: PublicKey;
-  supplementalTickArrays?: PublicKey[];
 };
 
 /**

--- a/sdk/src/instructions/v2/two-hop-swap-ix.ts
+++ b/sdk/src/instructions/v2/two-hop-swap-ix.ts
@@ -28,8 +28,6 @@ import { TwoHopSwapInput } from "../two-hop-swap-ix";
  * @param oracleOne - PublicKey for the oracle account for this whirlpoolOne.
  * @param oracleTwo - PublicKey for the oracle account for this whirlpoolTwo.
  * @param tokenAuthority - authority to withdraw tokens from the input token account
- * @param supplementalTickArraysOne - Optional array of PublicKey for supplemental tick arrays of whirlpoolOne.
- * @param supplementalTickArraysTwo - Optional array of PublicKey for supplemental tick arrays of whirlpoolTwo.
  * @param swapInput - Parameters in {@link TwoHopSwapInput}
  */
 export type TwoHopSwapV2Params = TwoHopSwapInput & {
@@ -53,8 +51,6 @@ export type TwoHopSwapV2Params = TwoHopSwapInput & {
   oracleOne: PublicKey;
   oracleTwo: PublicKey;
   tokenAuthority: PublicKey;
-  supplementalTickArraysOne?: PublicKey[];
-  supplementalTickArraysTwo?: PublicKey[];
 };
 
 /**

--- a/sdk/src/instructions/v2/two-hop-swap-ix.ts
+++ b/sdk/src/instructions/v2/two-hop-swap-ix.ts
@@ -4,7 +4,7 @@ import { AccountMeta, PublicKey } from "@solana/web3.js";
 import BN from "bn.js";
 import { Whirlpool } from "../../artifacts/whirlpool";
 import { MEMO_PROGRAM_ADDRESS } from "../../types/public";
-import { RemainingAccountsBuilder, RemainingAccountsType } from "../../utils/remaining-accounts-util";
+import { RemainingAccountsBuilder, RemainingAccountsType, toSupplementalTickArrayAccountMetas } from "../../utils/remaining-accounts-util";
 import { TwoHopSwapInput } from "../two-hop-swap-ix";
 
 /**
@@ -28,6 +28,8 @@ import { TwoHopSwapInput } from "../two-hop-swap-ix";
  * @param oracleOne - PublicKey for the oracle account for this whirlpoolOne.
  * @param oracleTwo - PublicKey for the oracle account for this whirlpoolTwo.
  * @param tokenAuthority - authority to withdraw tokens from the input token account
+ * @param supplementalTickArraysOne - Optional array of PublicKey for supplemental tick arrays of whirlpoolOne.
+ * @param supplementalTickArraysTwo - Optional array of PublicKey for supplemental tick arrays of whirlpoolTwo.
  * @param swapInput - Parameters in {@link TwoHopSwapInput}
  */
 export type TwoHopSwapV2Params = TwoHopSwapInput & {
@@ -51,6 +53,8 @@ export type TwoHopSwapV2Params = TwoHopSwapInput & {
   oracleOne: PublicKey;
   oracleTwo: PublicKey;
   tokenAuthority: PublicKey;
+  supplementalTickArraysOne?: PublicKey[];
+  supplementalTickArraysTwo?: PublicKey[];
 };
 
 /**
@@ -109,12 +113,16 @@ export function twoHopSwapV2Ix(program: Program<Whirlpool>, params: TwoHopSwapV2
     tickArrayTwo2,
     oracleOne,
     oracleTwo,
+    supplementalTickArraysOne,
+    supplementalTickArraysTwo,
   } = params;
 
   const [remainingAccountsInfo, remainingAccounts] = new RemainingAccountsBuilder()
     .addSlice(RemainingAccountsType.TransferHookInput, tokenTransferHookAccountsInput)
     .addSlice(RemainingAccountsType.TransferHookIntermediate, tokenTransferHookAccountsIntermediate)
     .addSlice(RemainingAccountsType.TransferHookOutput, tokenTransferHookAccountsOutput)
+    .addSlice(RemainingAccountsType.SupplementalTickArraysOne, toSupplementalTickArrayAccountMetas(supplementalTickArraysOne))
+    .addSlice(RemainingAccountsType.SupplementalTickArraysTwo, toSupplementalTickArrayAccountMetas(supplementalTickArraysTwo))
     .build();
 
   const ix = program.instruction.twoHopSwapV2(

--- a/sdk/src/prices/calculate-pool-prices.ts
+++ b/sdk/src/prices/calculate-pool-prices.ts
@@ -16,6 +16,7 @@ import { swapQuoteWithParams } from "../quotes/public/swap-quote";
 import { TickArray, WhirlpoolData } from "../types/public";
 import { PoolUtil, PriceMath, SwapUtils } from "../utils/public";
 import { NO_TOKEN_EXTENSION_CONTEXT } from "../utils/public/token-extension-util";
+import { getTickArrayPublicKeysWithStartTickIndex } from "../utils/swap-utils";
 
 function checkLiquidity(
   pool: WhirlpoolData,
@@ -155,7 +156,7 @@ function getTickArrays(
   config = defaultGetPricesConfig
 ): TickArray[] {
   const { programId } = config;
-  const tickArrayPublicKeys = SwapUtils.getTickArrayPublicKeys(
+  const tickArrayAddresses = getTickArrayPublicKeysWithStartTickIndex(
     pool.tickCurrentIndex,
     pool.tickSpacing,
     aToB,
@@ -163,8 +164,8 @@ function getTickArrays(
     address
   );
 
-  return tickArrayPublicKeys.map((tickArrayPublicKey) => {
-    return { address: tickArrayPublicKey, data: tickArrayMap[tickArrayPublicKey.toBase58()] };
+  return tickArrayAddresses.map((a) => {
+    return { address: a.pubkey, startTickIndex: a.startTickIndex, data: tickArrayMap[a.pubkey.toBase58()] };
   });
 }
 

--- a/sdk/src/quotes/public/two-hop-swap-quote.ts
+++ b/sdk/src/quotes/public/two-hop-swap-quote.ts
@@ -51,6 +51,8 @@ export function twoHopSwapQuoteFromSwapQuotes(
     tickArrayTwo0: swapQuoteTwo.tickArray0,
     tickArrayTwo1: swapQuoteTwo.tickArray1,
     tickArrayTwo2: swapQuoteTwo.tickArray2,
+    supplementalTickArraysOne: swapQuoteOne.supplementalTickArrays,
+    supplementalTickArraysTwo: swapQuoteTwo.supplementalTickArrays,
     swapOneEstimates: { ...swapQuoteOne },
     swapTwoEstimates: { ...swapQuoteTwo },
   };

--- a/sdk/src/quotes/swap/tick-array-sequence.ts
+++ b/sdk/src/quotes/swap/tick-array-sequence.ts
@@ -41,6 +41,7 @@ export class TickArraySequence {
       }
       this.sequence.push({
         address: tickArray.address,
+        startTickIndex: tickArray.data.startTickIndex,
         data: tickArray.data,
       });
     }

--- a/sdk/src/types/public/client-types.ts
+++ b/sdk/src/types/public/client-types.ts
@@ -30,5 +30,6 @@ export type WhirlpoolRewardInfo = WhirlpoolRewardInfoData & {
  */
 export type TickArray = {
   address: PublicKey;
+  startTickIndex: number;
   data: TickArrayData | null;
 };

--- a/sdk/src/types/public/constants.ts
+++ b/sdk/src/types/public/constants.ts
@@ -25,7 +25,7 @@ export const ORCA_WHIRLPOOLS_CONFIG_EXTENSION = new PublicKey("777H5H3Tp9U11uRVR
  * Orca's supported tick spacings.
  * @category Constants
  */
-export const ORCA_SUPPORTED_TICK_SPACINGS = [1, 2, 4, 8, 16, 64, 128, 256];
+export const ORCA_SUPPORTED_TICK_SPACINGS = [1, 2, 4, 8, 16, 64, 96, 128, 256];
 
 /**
  * The number of rewards supported by this whirlpool.
@@ -100,6 +100,12 @@ export const MEMO_PROGRAM_ADDRESS = new PublicKey(
  * @category Constants
  */
 export const MAX_SWAP_TICK_ARRAYS = 3;
+
+/**
+ * The maximum number of supplemental tick-arrays that can be provided in a swap.
+ * @category Constants
+ */
+export const MAX_SUPPLEMENTAL_TICK_ARRAYS = 3;
 
 /**
  * The denominator which the protocol fee rate is divided on.

--- a/sdk/src/utils/public/swap-utils.ts
+++ b/sdk/src/utils/public/swap-utils.ts
@@ -2,14 +2,13 @@ import { Address } from "@coral-xyz/anchor";
 import { AddressUtil, Percentage, U64_MAX, ZERO } from "@orca-so/common-sdk";
 import { PublicKey } from "@solana/web3.js";
 import BN from "bn.js";
-import { WhirlpoolContext } from "../..";
+import { TickUtil, WhirlpoolContext } from "../..";
 import {
   WhirlpoolAccountFetchOptions,
   WhirlpoolAccountFetcherInterface,
 } from "../../network/public/fetcher";
 import {
   MAX_SQRT_PRICE,
-  MAX_SWAP_TICK_ARRAYS,
   MIN_SQRT_PRICE,
   SwapInput,
   SwapParams,
@@ -20,8 +19,8 @@ import { Whirlpool } from "../../whirlpool-client";
 import { adjustForSlippage } from "../math/token-math";
 import { PDAUtil } from "./pda-utils";
 import { PoolUtil } from "./pool-utils";
-import { TickUtil } from "./tick-utils";
 import { SwapDirection, TokenType } from "./types";
+import { TickArrayAddress, buildZeroedTickArray, getTickArrayPublicKeysWithStartTickIndex } from "../swap-utils";
 
 /**
  * A request to fetch the tick-arrays that a swap may traverse across.
@@ -96,25 +95,45 @@ export class SwapUtils {
     aToB: boolean,
     programId: PublicKey,
     whirlpoolAddress: PublicKey
-  ) {
-    const shift = aToB ? 0 : tickSpacing;
+  ): PublicKey[] {
+    return getTickArrayPublicKeysWithStartTickIndex(
+      tickCurrentIndex,
+      tickSpacing,
+      aToB,
+      programId,
+      whirlpoolAddress
+    ).map((p) => p.pubkey);
+  }
 
-    let offset = 0;
-    let tickArrayAddresses: PublicKey[] = [];
-    for (let i = 0; i < MAX_SWAP_TICK_ARRAYS; i++) {
-      let startIndex: number;
-      try {
-        startIndex = TickUtil.getStartTickIndex(tickCurrentIndex + shift, tickSpacing, offset);
-      } catch {
-        return tickArrayAddresses;
-      }
-
-      const pda = PDAUtil.getTickArray(programId, whirlpoolAddress, startIndex);
-      tickArrayAddresses.push(pda.publicKey);
-      offset = aToB ? offset - 1 : offset + 1;
+  /**
+   * Given the tickArrays, return the fallback tickArray account that this swap may traverse across.
+   *
+   * @category Whirlpool Utils
+   * @param tickArrays - An array of tickArrays to be used in the swap.
+   * @param tickSpacing - The tickSpacing for the Whirlpool.
+   * @param aToB - The direction of the trade.
+   * @param programId - The Whirlpool programId which the Whirlpool lives on.
+   * @param whirlpoolAddress - PublicKey of the whirlpool to swap on.
+   * @returns A PublicKey for the fallback tickArray account that this swap may traverse across. If the fallback tickArray does not exist, return undefined.
+   */
+  public static getFallbackTickArrayPublicKey(
+    tickArrays: TickArray[],
+    tickSpacing: number,
+    aToB: boolean,
+    programId: PublicKey,
+    whirlpoolAddress: PublicKey,
+  ): PublicKey | undefined {
+    try {
+      const fallbackStartTickIndex = TickUtil.getStartTickIndex(
+        tickArrays[0].startTickIndex,
+        tickSpacing,
+        aToB ? 1 : -1,
+      );
+      const pda = PDAUtil.getTickArray(programId, whirlpoolAddress, fallbackStartTickIndex);
+      return pda.publicKey;
+    } catch {
+      return undefined;
     }
-
-    return tickArrayAddresses;
   }
 
   /**
@@ -162,14 +181,14 @@ export class SwapUtils {
     tickArrayRequests: TickArrayRequest[],
     opts?: WhirlpoolAccountFetchOptions
   ): Promise<TickArray[][]> {
-    let addresses: PublicKey[] = [];
+    let addresses: TickArrayAddress[] = [];
     let requestToIndices = [];
 
     // Each individual tick array request may correspond to more than one tick array
     // so we map each request to a slice of the batch request
     for (let i = 0; i < tickArrayRequests.length; i++) {
       const { tickCurrentIndex, tickSpacing, aToB, whirlpoolAddress } = tickArrayRequests[i];
-      const requestAddresses = SwapUtils.getTickArrayPublicKeys(
+      const requestAddresses = getTickArrayPublicKeysWithStartTickIndex(
         tickCurrentIndex,
         tickSpacing,
         aToB,
@@ -179,7 +198,7 @@ export class SwapUtils {
       requestToIndices.push([addresses.length, addresses.length + requestAddresses.length]);
       addresses.push(...requestAddresses);
     }
-    const data = await fetcher.getTickArrays(addresses, opts);
+    const data = await fetcher.getTickArrays(addresses.map((a) => a.pubkey), opts);
 
     // Re-map from flattened batch data to TickArray[] for request
     return requestToIndices.map((indices) => {
@@ -187,10 +206,29 @@ export class SwapUtils {
       const addressSlice = addresses.slice(start, end);
       const dataSlice = data.slice(start, end);
       return addressSlice.map((addr, index) => ({
-        address: addr,
+        address: addr.pubkey,
+        startTickIndex: addr.startTickIndex,
         data: dataSlice[index],
       }));
     });
+  }
+
+  /**
+   * Given a set of tickArrays, interpolate the tickArrays with zeroed tick data if they are not initialized.
+   * 
+   * @param whirlpoolAddress - PublicKey of the whirlpool to swap on.
+   * @param tickArrays - Fetched tickArrays to interpolate.
+   * @returns An array of TickArray objects with zeroed tick data if they are not initialized.
+   */
+  public static interpolateUninitializedTickArrays(
+    whirlpoolAddress: PublicKey,
+    tickArrays: TickArray[],
+  ): TickArray[] {
+    return tickArrays.map((tickArray) => ({
+      address: tickArray.address,
+      startTickIndex: tickArray.startTickIndex,
+      data: tickArray.data ?? buildZeroedTickArray(whirlpoolAddress, tickArray.startTickIndex),
+    }));
   }
 
   /**

--- a/sdk/src/utils/remaining-accounts-util.ts
+++ b/sdk/src/utils/remaining-accounts-util.ts
@@ -1,4 +1,6 @@
-import { AccountMeta } from "@solana/web3.js";
+import { AccountMeta, PublicKey } from "@solana/web3.js";
+import invariant from "tiny-invariant";
+import { MAX_SUPPLEMENTAL_TICK_ARRAYS } from "../types/public";
 
 export enum RemainingAccountsType {
   TransferHookA = "transferHookA",
@@ -7,9 +9,9 @@ export enum RemainingAccountsType {
   TransferHookInput = "transferHookInput",
   TransferHookIntermediate = "transferHookIntermediate",
   TransferHookOutput = "transferHookOutput",
-  //TickArray = "tickArray",
-  //TickArrayOne = "tickArrayOne",
-  //TickArrayTwo = "tickArrayTwo",
+  SupplementalTickArrays = "supplementalTickArrays",
+  SupplementalTickArraysOne = "supplementalTickArraysOne",
+  SupplementalTickArraysTwo = "supplementalTickArraysTwo",
 }
 
 type RemainingAccountsAnchorType = 
@@ -18,10 +20,10 @@ type RemainingAccountsAnchorType =
   { transferHookReward: {} } |
   { transferHookInput: {} } |
   { transferHookIntermediate: {} } |
-  { transferHookOutput: {} }
-  //{ tickArray: {} } |
-  //{ tickArrayOne: {} } |
-  //{ tickArrayTwo: {} } |
+  { transferHookOutput: {} } |
+  { supplementalTickArrays: {} } |
+  { supplementalTickArraysOne: {} } |
+  { supplementalTickArraysTwo: {} };
 
 export type RemainingAccountsSliceData = {
   accountsType: RemainingAccountsAnchorType;
@@ -59,4 +61,17 @@ export class RemainingAccountsBuilder {
       ? [null, undefined]
       : [{ slices: this.slices }, this.remainingAccounts];
   }
+}
+
+export function toSupplementalTickArrayAccountMetas(
+  tickArrayPubkeys: PublicKey[] | undefined
+): AccountMeta[] | undefined {
+  if (!tickArrayPubkeys) return undefined;
+
+  invariant(tickArrayPubkeys.length <= MAX_SUPPLEMENTAL_TICK_ARRAYS, "Too many supplemental tick arrays provided");
+  return tickArrayPubkeys.map((pubkey) => ({
+    pubkey,
+    isWritable: true,
+    isSigner: false
+  }));
 }

--- a/sdk/src/utils/swap-utils.ts
+++ b/sdk/src/utils/swap-utils.ts
@@ -1,5 +1,8 @@
-import { MathUtil } from "@orca-so/common-sdk";
+import { MathUtil, ZERO } from "@orca-so/common-sdk";
+import { PublicKey } from "@solana/web3.js";
 import BN from "bn.js";
+import { MAX_SWAP_TICK_ARRAYS, TICK_ARRAY_SIZE, TickArrayData, TickData } from "../types/public";
+import { PDAUtil, TickUtil } from "./public";
 
 export function getLowerSqrtPriceFromTokenA(amount: BN, liquidity: BN, sqrtPriceX64: BN): BN {
   const numerator = liquidity.mul(sqrtPriceX64).shln(64);
@@ -25,4 +28,55 @@ export function getLowerSqrtPriceFromTokenB(amount: BN, liquidity: BN, sqrtPrice
 export function getUpperSqrtPriceFromTokenB(amount: BN, liquidity: BN, sqrtPriceX64: BN): BN {
   // always round down (rounding up a negative number)
   return sqrtPriceX64.add(amount.shln(64).div(liquidity));
+}
+
+export type TickArrayAddress = { pubkey: PublicKey; startTickIndex: number };
+
+export function getTickArrayPublicKeysWithStartTickIndex(
+  tickCurrentIndex: number,
+  tickSpacing: number,
+  aToB: boolean,
+  programId: PublicKey,
+  whirlpoolAddress: PublicKey
+): TickArrayAddress[] {
+  const shift = aToB ? 0 : tickSpacing;
+
+  let offset = 0;
+  let tickArrayAddresses: TickArrayAddress[] = [];
+  for (let i = 0; i < MAX_SWAP_TICK_ARRAYS; i++) {
+    let startIndex: number;
+    try {
+      startIndex = TickUtil.getStartTickIndex(tickCurrentIndex + shift, tickSpacing, offset);
+    } catch {
+      return tickArrayAddresses;
+    }
+
+    const pda = PDAUtil.getTickArray(programId, whirlpoolAddress, startIndex);
+    tickArrayAddresses.push({ pubkey: pda.publicKey, startTickIndex: startIndex });
+    offset = aToB ? offset - 1 : offset + 1;
+  }
+
+  return tickArrayAddresses;
+}
+
+export const ZEROED_TICK_DATA: TickData = Object.freeze(({
+  initialized: false,
+  liquidityNet: ZERO,
+  liquidityGross: ZERO,
+  feeGrowthOutsideA: ZERO,
+  feeGrowthOutsideB: ZERO,
+  rewardGrowthsOutside: [ZERO, ZERO, ZERO],
+}));
+
+export const ZEROED_TICKS: TickData[] = Array.from({ length: TICK_ARRAY_SIZE }, () => ZEROED_TICK_DATA);
+
+export function buildZeroedTickArray(
+  whirlpool: PublicKey,
+  startTickIndex: number,
+): TickArrayData {
+  return {
+    startTickIndex,
+    ticks: ZEROED_TICKS,
+    whirlpool,
+  };
 }

--- a/sdk/tests/integration/multi-ix/sparse_swap.test.ts
+++ b/sdk/tests/integration/multi-ix/sparse_swap.test.ts
@@ -1,0 +1,739 @@
+import * as anchor from "@coral-xyz/anchor";
+import { DecimalUtil, MathUtil, Percentage, TransactionBuilder, U64_MAX, ZERO } from "@orca-so/common-sdk";
+import { getAssociatedTokenAddressSync } from "@solana/spl-token";
+import { Keypair, SystemProgram } from "@solana/web3.js";
+import * as assert from "assert";
+import { BN } from "bn.js";
+import Decimal from "decimal.js";
+import { NUM_REWARDS, PDAUtil, POSITION_BUNDLE_SIZE, PoolUtil, PositionBundleData, PriceMath, SwapQuote, SwapUtils, TickUtil, Whirlpool, WhirlpoolClient, WhirlpoolData, WhirlpoolIx, buildWhirlpoolClient, collectFeesQuote, increaseLiquidityQuoteByInputToken, swapQuoteByInputToken, swapQuoteByOutputToken, swapQuoteWithParams, toTx } from "../../../src";
+import { WhirlpoolContext } from "../../../src/context";
+import { IGNORE_CACHE } from "../../../src/network/public/fetcher";
+import { TickSpacing, ZERO_BN, createTokenAccount } from "../../utils";
+import { defaultConfirmOptions } from "../../utils/const";
+import { WhirlpoolTestFixture } from "../../utils/fixture";
+import { initTestPoolWithTokens, initTickArrayRange, initializePositionBundle, openBundledPosition } from "../../utils/init-utils";
+import { NO_TOKEN_EXTENSION_CONTEXT, TokenExtensionUtil } from "../../../src/utils/public/token-extension-util";
+import { buildTickArrayData } from "../../utils/testDataTypes";
+
+
+interface SharedTestContext {
+  provider: anchor.AnchorProvider;
+  program: Whirlpool;
+  whirlpoolCtx: WhirlpoolContext;
+  whirlpoolClient: WhirlpoolClient;
+}
+
+describe("sparse swap tests", () => {
+  const provider = anchor.AnchorProvider.local(undefined, defaultConfirmOptions);
+
+  let testCtx: SharedTestContext;
+  const sleep = (second: number) => new Promise(resolve => setTimeout(resolve, second * 1000))
+
+  before(() => {
+    anchor.setProvider(provider);
+    const program = anchor.workspace.Whirlpool;
+    const whirlpoolCtx = WhirlpoolContext.fromWorkspace(provider, program);
+    const whirlpoolClient = buildWhirlpoolClient(whirlpoolCtx);
+
+    testCtx = {
+      provider,
+      program,
+      whirlpoolCtx,
+      whirlpoolClient,
+    };
+  });
+
+  const tickSpacing64 = 64;
+  const tickSpacing8192 = 8192;
+
+  describe("TickArray order adjustment", () => {
+    it("reverse order(ta2, ta1, ta0 => ta0, ta1, ta2), a to b", async () => {
+      const { poolInitInfo, whirlpoolPda, tokenAccountA, tokenAccountB } =
+        await initTestPoolWithTokens(
+          testCtx.whirlpoolCtx,
+          tickSpacing64,
+          PriceMath.tickIndexToSqrtPriceX64(3000), // tickCurrentIndex = 3000
+          new BN(1_000_000)
+        );
+
+      const pool = await testCtx.whirlpoolClient.getPool(whirlpoolPda.publicKey);
+
+      // [-11264  ][-5632   ][0       ]
+      await (await pool.initTickArrayForTicks([-11264, -5632, 0]))!.buildAndExecute();
+
+      // deposit [-9984, 2944], 100_000_000
+      const depositQuote = increaseLiquidityQuoteByInputToken(
+        poolInitInfo.tokenMintB,
+        DecimalUtil.fromBN(new BN(100_000), 0),
+        -9984,
+        2944,
+        Percentage.fromFraction(0, 100),
+        pool,
+        NO_TOKEN_EXTENSION_CONTEXT,
+      );
+      await (await pool.openPosition(-9984, 2944, depositQuote)).tx.buildAndExecute();
+
+      await pool.refreshData();
+      const swapQuote = await swapQuoteByOutputToken(
+        pool,
+        poolInitInfo.tokenMintB,
+        new BN(99_000),
+        Percentage.fromFraction(0, 100),
+        testCtx.whirlpoolCtx.program.programId,
+        testCtx.whirlpoolCtx.fetcher,
+        IGNORE_CACHE,
+      );
+
+      const params = SwapUtils.getSwapParamsFromQuote(
+        swapQuote,
+        testCtx.whirlpoolCtx,
+        pool,
+        tokenAccountA,
+        tokenAccountB,
+        testCtx.provider.wallet.publicKey
+      );
+
+      assert.ok((await pool.refreshData()).tickCurrentIndex >= 2944);
+
+      await toTx(
+        testCtx.whirlpoolCtx,
+        WhirlpoolIx.swapIx(testCtx.whirlpoolCtx.program, {
+          ...params,
+          // reverse
+          tickArray0: params.tickArray2,
+          tickArray1: params.tickArray1,
+          tickArray2: params.tickArray0,
+        })
+      ).buildAndExecute();
+
+      // 3000 --> less than -5632
+      assert.ok((await pool.refreshData()).tickCurrentIndex < -5632);
+    });
+
+    it("reverse order(ta2, ta1, ta0 => ta0, ta1, ta2), b to a", async () => {
+      const { poolInitInfo, whirlpoolPda, tokenAccountA, tokenAccountB } =
+        await initTestPoolWithTokens(
+          testCtx.whirlpoolCtx,
+          tickSpacing64,
+          PriceMath.tickIndexToSqrtPriceX64(-3000), // tickCurrentIndex = -3000
+          new BN(1_000_000)
+        );
+
+      const pool = await testCtx.whirlpoolClient.getPool(whirlpoolPda.publicKey);
+
+      // [-5632   ][0       ][5632    ]
+      await (await pool.initTickArrayForTicks([-5632, 0, 5632]))!.buildAndExecute();
+
+      // deposit [-2944, 9984], 100_000_000
+      const depositQuote = increaseLiquidityQuoteByInputToken(
+        poolInitInfo.tokenMintA,
+        DecimalUtil.fromBN(new BN(100_000), 0),
+        -2944,
+        9984,
+        Percentage.fromFraction(0, 100),
+        pool,
+        NO_TOKEN_EXTENSION_CONTEXT,
+      );
+      await (await pool.openPosition(-2944, 9984, depositQuote)).tx.buildAndExecute();
+
+      await pool.refreshData();
+      const swapQuote = await swapQuoteByOutputToken(
+        pool,
+        poolInitInfo.tokenMintA,
+        new BN(99_000),
+        Percentage.fromFraction(0, 100),
+        testCtx.whirlpoolCtx.program.programId,
+        testCtx.whirlpoolCtx.fetcher,
+        IGNORE_CACHE,
+      );
+
+      const params = SwapUtils.getSwapParamsFromQuote(
+        swapQuote,
+        testCtx.whirlpoolCtx,
+        pool,
+        tokenAccountB,
+        tokenAccountA,
+        testCtx.provider.wallet.publicKey
+      );
+
+      assert.ok((await pool.refreshData()).tickCurrentIndex <= -2944);
+
+      await toTx(
+        testCtx.whirlpoolCtx,
+        WhirlpoolIx.swapIx(testCtx.whirlpoolCtx.program, {
+          ...params,
+          // reverse
+          tickArray0: params.tickArray2,
+          tickArray1: params.tickArray1,
+          tickArray2: params.tickArray0,
+        })
+      ).buildAndExecute();
+
+      // -3000 --> larger than 5632
+      assert.ok((await pool.refreshData()).tickCurrentIndex > 5632);
+    });
+
+    it("skip ta0(ta0, ta1, ta2 => ta1, ta2), a to b", async () => {
+      const { poolInitInfo, whirlpoolPda, tokenAccountA, tokenAccountB } =
+        await initTestPoolWithTokens(
+          testCtx.whirlpoolCtx,
+          tickSpacing64,
+          PriceMath.tickIndexToSqrtPriceX64(64), // tickCurrentIndex = 64
+          new BN(1_000_000)
+        );
+
+      const pool = await testCtx.whirlpoolClient.getPool(whirlpoolPda.publicKey);
+
+      // [-11264  ][-5632   ][0       ]
+      await (await pool.initTickArrayForTicks([-11264, -5632, 0]))!.buildAndExecute();
+
+      // deposit [-9984, -128], 100_000_000
+      const depositQuote = increaseLiquidityQuoteByInputToken(
+        poolInitInfo.tokenMintB,
+        DecimalUtil.fromBN(new BN(100_000), 0),
+        -9984,
+        -128,
+        Percentage.fromFraction(0, 100),
+        pool,
+        NO_TOKEN_EXTENSION_CONTEXT,
+      );
+      await (await pool.openPosition(-9984, -128, depositQuote)).tx.buildAndExecute();
+
+      await pool.refreshData();
+      const swapQuote = await swapQuoteByOutputToken(
+        pool,
+        poolInitInfo.tokenMintB,
+        new BN(99_000),
+        Percentage.fromFraction(10, 100),
+        testCtx.whirlpoolCtx.program.programId,
+        testCtx.whirlpoolCtx.fetcher,
+        IGNORE_CACHE,
+      );
+
+      const params = SwapUtils.getSwapParamsFromQuote(
+        swapQuote,
+        testCtx.whirlpoolCtx,
+        pool,
+        tokenAccountA,
+        tokenAccountB,
+        testCtx.provider.wallet.publicKey
+      );
+
+      assert.ok((await pool.refreshData()).tickCurrentIndex >= 64);
+
+      // another swap push tickCurrentIndex to less than -128
+      await toTx(
+        testCtx.whirlpoolCtx,
+        WhirlpoolIx.swapIx(testCtx.whirlpoolCtx.program, SwapUtils.getSwapParamsFromQuote(
+          await swapQuoteByOutputToken(
+            pool,
+            poolInitInfo.tokenMintB,
+            new BN(1),
+            Percentage.fromFraction(0, 100),
+            testCtx.whirlpoolCtx.program.programId,
+            testCtx.whirlpoolCtx.fetcher,
+            IGNORE_CACHE,
+          ),
+          testCtx.whirlpoolCtx,
+          pool,
+          tokenAccountA,
+          tokenAccountB,
+          testCtx.provider.wallet.publicKey,
+        )),
+      ).buildAndExecute();
+
+      assert.ok((await pool.refreshData()).tickCurrentIndex <= -128);
+      assert.ok((await pool.refreshData()).tickCurrentIndex > -5632);
+
+      await toTx(
+        testCtx.whirlpoolCtx,
+        WhirlpoolIx.swapIx(testCtx.whirlpoolCtx.program, params),
+      ).buildAndExecute();
+
+      // less than -128 --> less than -5632
+      assert.ok((await pool.refreshData()).tickCurrentIndex < -5632);
+    });
+
+    it("skip ta0, ta1(ta0, ta1, ta2 => ta2), a to b", async () => {
+      const { poolInitInfo, whirlpoolPda, tokenAccountA, tokenAccountB } =
+        await initTestPoolWithTokens(
+          testCtx.whirlpoolCtx,
+          tickSpacing64,
+          PriceMath.tickIndexToSqrtPriceX64(64), // tickCurrentIndex = 64
+          new BN(1_000_000)
+        );
+
+      const pool = await testCtx.whirlpoolClient.getPool(whirlpoolPda.publicKey);
+
+      // [-11264  ][-5632   ][0       ]
+      await (await pool.initTickArrayForTicks([-11264, -5632, 0]))!.buildAndExecute();
+
+      // deposit [-9984, -5760], 100_000_000
+      const depositQuote = increaseLiquidityQuoteByInputToken(
+        poolInitInfo.tokenMintB,
+        DecimalUtil.fromBN(new BN(100_000), 0),
+        -9984,
+        -5760,
+        Percentage.fromFraction(0, 100),
+        pool,
+        NO_TOKEN_EXTENSION_CONTEXT,
+      );
+      await (await pool.openPosition(-9984, -5760, depositQuote)).tx.buildAndExecute();
+
+      await pool.refreshData();
+      const swapQuote = await swapQuoteByOutputToken(
+        pool,
+        poolInitInfo.tokenMintB,
+        new BN(99_000),
+        Percentage.fromFraction(10, 100),
+        testCtx.whirlpoolCtx.program.programId,
+        testCtx.whirlpoolCtx.fetcher,
+        IGNORE_CACHE,
+      );
+
+      const params = SwapUtils.getSwapParamsFromQuote(
+        swapQuote,
+        testCtx.whirlpoolCtx,
+        pool,
+        tokenAccountA,
+        tokenAccountB,
+        testCtx.provider.wallet.publicKey
+      );
+
+      assert.ok((await pool.refreshData()).tickCurrentIndex >= 64);
+
+      // another swap push tickCurrentIndex to less than -5760
+      await toTx(
+        testCtx.whirlpoolCtx,
+        WhirlpoolIx.swapIx(testCtx.whirlpoolCtx.program, SwapUtils.getSwapParamsFromQuote(
+          await swapQuoteByOutputToken(
+            pool,
+            poolInitInfo.tokenMintB,
+            new BN(1),
+            Percentage.fromFraction(0, 100),
+            testCtx.whirlpoolCtx.program.programId,
+            testCtx.whirlpoolCtx.fetcher,
+            IGNORE_CACHE,
+          ),
+          testCtx.whirlpoolCtx,
+          pool,
+          tokenAccountA,
+          tokenAccountB,
+          testCtx.provider.wallet.publicKey,
+        )),
+      ).buildAndExecute();
+
+      assert.ok((await pool.refreshData()).tickCurrentIndex <= -5760);
+      assert.ok((await pool.refreshData()).tickCurrentIndex > -9984);
+
+      await toTx(
+        testCtx.whirlpoolCtx,
+        WhirlpoolIx.swapIx(testCtx.whirlpoolCtx.program, params),
+      ).buildAndExecute();
+
+      // less than -5760 --> less than -5760
+      assert.ok((await pool.refreshData()).tickCurrentIndex < -5760);
+    });
+
+    it("skip ta0(ta0, ta1, ta2 => ta1, ta2), b to a", async () => {
+      const { poolInitInfo, whirlpoolPda, tokenAccountA, tokenAccountB } =
+        await initTestPoolWithTokens(
+          testCtx.whirlpoolCtx,
+          tickSpacing64,
+          PriceMath.tickIndexToSqrtPriceX64(-64), // tickCurrentIndex = -64
+          new BN(1_000_000)
+        );
+
+      const pool = await testCtx.whirlpoolClient.getPool(whirlpoolPda.publicKey);
+
+      // [-5632   ][0       ][5632    ]
+      await (await pool.initTickArrayForTicks([-5632, 0, 5632]))!.buildAndExecute();
+
+      // deposit [128, 9984], 100_000_000
+      const depositQuote = increaseLiquidityQuoteByInputToken(
+        poolInitInfo.tokenMintA,
+        DecimalUtil.fromBN(new BN(100_000), 0),
+        128,
+        9984,
+        Percentage.fromFraction(0, 100),
+        pool,
+        NO_TOKEN_EXTENSION_CONTEXT,
+      );
+      await (await pool.openPosition(128, 9984, depositQuote)).tx.buildAndExecute();
+
+      await pool.refreshData();
+      const swapQuote = await swapQuoteByOutputToken(
+        pool,
+        poolInitInfo.tokenMintA,
+        new BN(99_000),
+        Percentage.fromFraction(10, 100),
+        testCtx.whirlpoolCtx.program.programId,
+        testCtx.whirlpoolCtx.fetcher,
+        IGNORE_CACHE,
+      );
+
+      const params = SwapUtils.getSwapParamsFromQuote(
+        swapQuote,
+        testCtx.whirlpoolCtx,
+        pool,
+        tokenAccountB,
+        tokenAccountA,
+        testCtx.provider.wallet.publicKey
+      );
+
+      assert.ok((await pool.refreshData()).tickCurrentIndex <= -64);
+
+      // another swap push tickCurrentIndex to greater than 128
+      await toTx(
+        testCtx.whirlpoolCtx,
+        WhirlpoolIx.swapIx(testCtx.whirlpoolCtx.program, SwapUtils.getSwapParamsFromQuote(
+          await swapQuoteByOutputToken(
+            pool,
+            poolInitInfo.tokenMintA,
+            new BN(1),
+            Percentage.fromFraction(0, 100),
+            testCtx.whirlpoolCtx.program.programId,
+            testCtx.whirlpoolCtx.fetcher,
+            IGNORE_CACHE,
+          ),
+          testCtx.whirlpoolCtx,
+          pool,
+          tokenAccountB,
+          tokenAccountA,
+          testCtx.provider.wallet.publicKey,
+        )),
+      ).buildAndExecute();
+
+      assert.ok((await pool.refreshData()).tickCurrentIndex >= 128);
+      assert.ok((await pool.refreshData()).tickCurrentIndex < 5632);
+
+      await toTx(
+        testCtx.whirlpoolCtx,
+        WhirlpoolIx.swapIx(testCtx.whirlpoolCtx.program, params),
+      ).buildAndExecute();
+
+      // greater than 128 --> greater than 5632
+      assert.ok((await pool.refreshData()).tickCurrentIndex > 5632);
+    });
+
+    it("skip ta0, ta1(ta0, ta1, ta2 => ta2), b to a", async () => {
+      const { poolInitInfo, whirlpoolPda, tokenAccountA, tokenAccountB } =
+        await initTestPoolWithTokens(
+          testCtx.whirlpoolCtx,
+          tickSpacing64,
+          PriceMath.tickIndexToSqrtPriceX64(-64), // tickCurrentIndex = -64
+          new BN(1_000_000)
+        );
+
+      const pool = await testCtx.whirlpoolClient.getPool(whirlpoolPda.publicKey);
+
+      // [-5632   ][0       ][5632    ]
+      await (await pool.initTickArrayForTicks([-5632, 0, 5632]))!.buildAndExecute();
+
+      // deposit [5760, 9984], 100_000_000
+      const depositQuote = increaseLiquidityQuoteByInputToken(
+        poolInitInfo.tokenMintA,
+        DecimalUtil.fromBN(new BN(100_000), 0),
+        5760,
+        9984,
+        Percentage.fromFraction(0, 100),
+        pool,
+        NO_TOKEN_EXTENSION_CONTEXT,
+      );
+      await (await pool.openPosition(5760, 9984, depositQuote)).tx.buildAndExecute();
+
+      await pool.refreshData();
+      const swapQuote = await swapQuoteByOutputToken(
+        pool,
+        poolInitInfo.tokenMintA,
+        new BN(99_000),
+        Percentage.fromFraction(10, 100),
+        testCtx.whirlpoolCtx.program.programId,
+        testCtx.whirlpoolCtx.fetcher,
+        IGNORE_CACHE,
+      );
+
+      const params = SwapUtils.getSwapParamsFromQuote(
+        swapQuote,
+        testCtx.whirlpoolCtx,
+        pool,
+        tokenAccountB,
+        tokenAccountA,
+        testCtx.provider.wallet.publicKey
+      );
+
+      assert.ok((await pool.refreshData()).tickCurrentIndex <= -64);
+
+      // another swap push tickCurrentIndex to greater than 5760
+      await toTx(
+        testCtx.whirlpoolCtx,
+        WhirlpoolIx.swapIx(testCtx.whirlpoolCtx.program, SwapUtils.getSwapParamsFromQuote(
+          await swapQuoteByOutputToken(
+            pool,
+            poolInitInfo.tokenMintA,
+            new BN(1),
+            Percentage.fromFraction(0, 100),
+            testCtx.whirlpoolCtx.program.programId,
+            testCtx.whirlpoolCtx.fetcher,
+            IGNORE_CACHE,
+          ),
+          testCtx.whirlpoolCtx,
+          pool,
+          tokenAccountB,
+          tokenAccountA,
+          testCtx.provider.wallet.publicKey,
+        )),
+      ).buildAndExecute();
+
+      assert.ok((await pool.refreshData()).tickCurrentIndex >= 5760);
+      assert.ok((await pool.refreshData()).tickCurrentIndex < 9984);
+
+      await toTx(
+        testCtx.whirlpoolCtx,
+        WhirlpoolIx.swapIx(testCtx.whirlpoolCtx.program, params),
+      ).buildAndExecute();
+
+      // greater than 5760 --> greater than 5760
+      assert.ok((await pool.refreshData()).tickCurrentIndex > 5760);
+    });
+
+    it("a to b & b to a with same TickArray list", async () => {
+      const { poolInitInfo, whirlpoolPda, tokenAccountA, tokenAccountB } =
+        await initTestPoolWithTokens(
+          testCtx.whirlpoolCtx,
+          tickSpacing8192,
+          PriceMath.tickIndexToSqrtPriceX64(0),
+          new BN(1_000_000)
+        );
+
+      const pool = await testCtx.whirlpoolClient.getPool(whirlpoolPda.publicKey);
+
+      // [-720896 ][0       ]
+      await (await pool.initTickArrayForTicks([-720896, 0]))!.buildAndExecute();
+
+      // deposit FullRange, 100_000_000
+      const fullrange = TickUtil.getFullRangeTickIndex(tickSpacing8192);
+      const depositQuote = increaseLiquidityQuoteByInputToken(
+        poolInitInfo.tokenMintA,
+        DecimalUtil.fromBN(new BN(100_000), 0),
+        fullrange[0],
+        fullrange[1],
+        Percentage.fromFraction(0, 100),
+        pool,
+        NO_TOKEN_EXTENSION_CONTEXT,
+      );
+      await (await pool.openPosition(fullrange[0], fullrange[1], depositQuote)).tx.buildAndExecute();
+
+      const ta0 = PDAUtil.getTickArray(testCtx.whirlpoolCtx.program.programId, whirlpoolPda.publicKey, -720896).publicKey;
+      const ta1 = PDAUtil.getTickArray(testCtx.whirlpoolCtx.program.programId, whirlpoolPda.publicKey, 0).publicKey;
+
+      // a to b
+      await pool.refreshData();
+      const aToBParams = SwapUtils.getSwapParamsFromQuote(
+        await swapQuoteByOutputToken(
+          pool,
+          poolInitInfo.tokenMintB,
+          new BN(1_000),
+          Percentage.fromFraction(10, 100),
+          testCtx.whirlpoolCtx.program.programId,
+          testCtx.whirlpoolCtx.fetcher,
+          IGNORE_CACHE,
+        ),
+        testCtx.whirlpoolCtx,
+        pool,
+        tokenAccountA,
+        tokenAccountB,
+        testCtx.provider.wallet.publicKey
+      );
+      await toTx(
+        testCtx.whirlpoolCtx,
+        WhirlpoolIx.swapIx(testCtx.whirlpoolCtx.program, {
+          ...aToBParams,
+          // always use ta0, ta1, ta1
+          tickArray0: ta0,
+          tickArray1: ta1,
+          tickArray2: ta1,
+        }),
+      ).buildAndExecute();
+
+      // b to a
+      await pool.refreshData();
+      const bToAParams = SwapUtils.getSwapParamsFromQuote(
+        await swapQuoteByOutputToken(
+          pool,
+          poolInitInfo.tokenMintA,
+          new BN(1_000),
+          Percentage.fromFraction(10, 100),
+          testCtx.whirlpoolCtx.program.programId,
+          testCtx.whirlpoolCtx.fetcher,
+          IGNORE_CACHE,
+        ),
+        testCtx.whirlpoolCtx,
+        pool,
+        tokenAccountB,
+        tokenAccountA,
+        testCtx.provider.wallet.publicKey
+      );
+      await toTx(
+        testCtx.whirlpoolCtx,
+        WhirlpoolIx.swapIx(testCtx.whirlpoolCtx.program, {
+          ...bToAParams,
+          // always use ta0, ta1, ta1
+          tickArray0: ta0,
+          tickArray1: ta1,
+          tickArray2: ta1,
+        }),
+      ).buildAndExecute();
+    });
+  });
+
+  describe("swap through uninitialized TickArrays", () => {
+    // |--------| uninitialized
+    // |********| initialized
+    // S: swap start / T: swap end
+
+    async function buildTestEnvironment() {
+      // ts: 64
+      // liquidity provided from full range
+      const initResult = await initTestPoolWithTokens(
+        testCtx.whirlpoolCtx,
+        tickSpacing64,
+        PriceMath.tickIndexToSqrtPriceX64(2816),
+        new BN(1_000_000_000)
+      );
+      const { poolInitInfo, whirlpoolPda } = initResult;
+
+      const pool = await testCtx.whirlpoolClient.getPool(whirlpoolPda.publicKey);
+      const fullrange = TickUtil.getFullRangeTickIndex(tickSpacing8192);
+
+      await (await pool.initTickArrayForTicks([fullrange[0], fullrange[1]]))!.buildAndExecute();
+
+      // deposit FullRange, 100_000_000
+      const depositQuote = increaseLiquidityQuoteByInputToken(
+        poolInitInfo.tokenMintA,
+        DecimalUtil.fromBN(new BN(100_000_000), 0),
+        fullrange[0],
+        fullrange[1],
+        Percentage.fromFraction(0, 100),
+        pool,
+        NO_TOKEN_EXTENSION_CONTEXT,
+      );
+      await (await pool.openPosition(fullrange[0], fullrange[1], depositQuote)).tx.buildAndExecute();
+
+      const data = (await pool.refreshData());
+      assert.ok(data.tickCurrentIndex == 2816);
+      assert.ok(data.liquidity.gtn(0));
+      return initResult;
+    }
+
+    describe("b to a: 2816 --> 2816 + (64 * 88) * 2", () => {
+      const aToB = false;
+      const initialTickIndex = 2816;
+      const targetTickIndex = 2816 + tickSpacing64 * 88 * 2; // --> 2 tick arrays
+      const targetSqrtPrice = PriceMath.tickIndexToSqrtPriceX64(targetTickIndex);
+
+      async function runSwap(init0: boolean, init1: boolean, init2: boolean): Promise<{ quote: SwapQuote, poolData: WhirlpoolData }> {
+        const { poolInitInfo, tokenAccountA, tokenAccountB } = await buildTestEnvironment();
+
+        const pool = await testCtx.whirlpoolClient.getPool(poolInitInfo.whirlpoolPda.publicKey, IGNORE_CACHE);
+
+        const startTickIndexes = [0, 5632, 11264];
+        const init = [init0, init1, init2];
+
+        // init tick arrays
+        const tickArrayIndexes: number[] = [];
+        init.forEach((v, i) => {
+          if (v) {
+            tickArrayIndexes.push(startTickIndexes[i]);
+          }
+        });
+        if (tickArrayIndexes.length > 0) {
+          await (await pool.initTickArrayForTicks(tickArrayIndexes))!.buildAndExecute();
+        }
+
+        // fetch tick arrays
+        const tickArrays = await SwapUtils.getTickArrays(
+          pool.getData().tickCurrentIndex,
+          pool.getData().tickSpacing,
+          aToB,
+          testCtx.whirlpoolCtx.program.programId,
+          pool.getAddress(),
+          testCtx.whirlpoolCtx.fetcher,
+          IGNORE_CACHE,
+        );
+
+        // padding if needed
+        init.forEach((v, i) => {
+          if (!v) {
+            assert.ok(tickArrays[i].data === null);
+            tickArrays[i].data = buildTickArrayData(startTickIndexes[i], []).data;
+            tickArrays[i].data!.whirlpool = pool.getAddress();
+          } else {
+            assert.ok(tickArrays[i].data !== null);
+          }
+        });
+
+        const quote = await swapQuoteWithParams({
+          whirlpoolData: pool.getData(),
+          amountSpecifiedIsInput: true,
+          aToB,
+          otherAmountThreshold: SwapUtils.getDefaultOtherAmountThreshold(true),
+          tokenAmount: U64_MAX,
+          sqrtPriceLimit: targetSqrtPrice,
+          tickArrays,
+          tokenExtensionCtx: NO_TOKEN_EXTENSION_CONTEXT,
+        }, Percentage.fromFraction(0, 100));
+
+        assert.ok(quote.estimatedAmountIn.gtn(0));
+        assert.ok(quote.estimatedAmountOut.gtn(0));
+
+        assert.ok((await pool.refreshData()).tickCurrentIndex === initialTickIndex);
+        await toTx(
+          testCtx.whirlpoolCtx,
+          WhirlpoolIx.swapIx(testCtx.whirlpoolCtx.program, SwapUtils.getSwapParamsFromQuote(
+            quote,
+            testCtx.whirlpoolCtx,
+            pool,
+            tokenAccountB,
+            tokenAccountA,
+            testCtx.provider.wallet.publicKey,
+          )),
+        ).buildAndExecute(undefined, {skipPreflight: true});
+        assert.ok((await pool.refreshData()).tickCurrentIndex === targetTickIndex);
+
+        return { quote, poolData: pool.getData() };
+      }
+
+      let referenceResult: { quote: SwapQuote, poolData: WhirlpoolData };
+      before(async () => {
+        referenceResult = await runSwap(true, true, true);
+      });
+
+      function runTest(init0: boolean, init1: boolean, init2: boolean) {
+        const ta0 = init0 ? "|****S***|" : "|----S---|";
+        const ta1 = init1 ? "********" : "--------";
+        const ta2 = init2 ? "|****T***|" : "|----T---|";
+
+        it(`${ta0}${ta1}${ta2}`, async () => {
+          const result = await runSwap(init0, init1, init2);
+          assert.ok(result.quote.estimatedAmountIn.eq(referenceResult.quote.estimatedAmountIn));
+          assert.ok(result.quote.estimatedAmountOut.eq(referenceResult.quote.estimatedAmountOut));
+          assert.ok(result.poolData.tickCurrentIndex === referenceResult.poolData.tickCurrentIndex);
+        });
+      }
+
+      for (const init0 of [true, false]) {
+        for (const init1 of [true, false]) {
+          for (const init2 of [true, false]) {
+            runTest(init0, init1, init2);
+          }
+        }
+      }
+    });
+
+    it("a to b: |----T---|********|----S---|", async () => {});
+    it("a to b: |****T***|--------|****S***|", async () => {});
+    it("a to b: |----T---|--------|----S---|", async () => {});
+
+  });
+});

--- a/sdk/tests/integration/multi-ix/sparse_swap.test.ts
+++ b/sdk/tests/integration/multi-ix/sparse_swap.test.ts
@@ -789,7 +789,7 @@ describe("sparse swap tests", () => {
               tickArray2: params.tickArray2,
             })
           ).buildAndExecute(),
-          /0x17a7/ // DifferentWhirlpoolTickArrayAccount
+          /0x17a8/ // DifferentWhirlpoolTickArrayAccount
         );
 
         await assert.rejects(
@@ -802,7 +802,7 @@ describe("sparse swap tests", () => {
               tickArray2: params.tickArray2,
             })
           ).buildAndExecute(),
-          /0x17a7/ // DifferentWhirlpoolTickArrayAccount
+          /0x17a8/ // DifferentWhirlpoolTickArrayAccount
         );
 
         await assert.rejects(
@@ -815,7 +815,7 @@ describe("sparse swap tests", () => {
               tickArray2: anotherWhirlpoolTickArray0, // for another Whirlpool
             })
           ).buildAndExecute(),
-          /0x17a7/ // DifferentWhirlpoolTickArrayAccount
+          /0x17a8/ // DifferentWhirlpoolTickArrayAccount
         );
 
         await assert.rejects(
@@ -834,7 +834,7 @@ describe("sparse swap tests", () => {
               ],
             })
           ).buildAndExecute(),
-          /0x17a7/ // DifferentWhirlpoolTickArrayAccount
+          /0x17a8/ // DifferentWhirlpoolTickArrayAccount
         );
       });
 
@@ -1867,7 +1867,7 @@ describe("sparse swap tests", () => {
               ),
             ],
           }).buildAndExecute(),
-          /0x17a6/ // TooManySupplementalTickArrays
+          /0x17a7/ // TooManySupplementalTickArrays
         );
       });
 
@@ -2399,7 +2399,7 @@ describe("sparse swap tests", () => {
               ),
             ],
           }).buildAndExecute(),
-          /0x17a6/ // TooManySupplementalTickArrays
+          /0x17a7/ // TooManySupplementalTickArrays
         );
 
         // bypass SDK
@@ -2433,7 +2433,7 @@ describe("sparse swap tests", () => {
               ),
             ],
           }).buildAndExecute(),
-          /0x17a6/ // TooManySupplementalTickArrays
+          /0x17a7/ // TooManySupplementalTickArrays
         );
       });
 

--- a/sdk/tests/integration/multi-ix/sparse_swap.test.ts
+++ b/sdk/tests/integration/multi-ix/sparse_swap.test.ts
@@ -1,19 +1,20 @@
 import * as anchor from "@coral-xyz/anchor";
 import { DecimalUtil, MathUtil, Percentage, TransactionBuilder, U64_MAX, ZERO } from "@orca-so/common-sdk";
-import { getAssociatedTokenAddressSync } from "@solana/spl-token";
+import { TOKEN_PROGRAM_ID, getAssociatedTokenAddressSync } from "@solana/spl-token";
 import { Keypair, SystemProgram } from "@solana/web3.js";
 import * as assert from "assert";
 import { BN } from "bn.js";
 import Decimal from "decimal.js";
-import { NUM_REWARDS, PDAUtil, POSITION_BUNDLE_SIZE, PoolUtil, PositionBundleData, PriceMath, SwapQuote, SwapUtils, TickUtil, Whirlpool, WhirlpoolClient, WhirlpoolData, WhirlpoolIx, buildWhirlpoolClient, collectFeesQuote, increaseLiquidityQuoteByInputToken, swapQuoteByInputToken, swapQuoteByOutputToken, swapQuoteWithParams, toTx } from "../../../src";
+import { NUM_REWARDS, PDAUtil, POSITION_BUNDLE_SIZE, PoolUtil, PositionBundleData, PriceMath, SwapQuote, SwapUtils, TickUtil, TwoHopSwapV2Params, Whirlpool, WhirlpoolClient, WhirlpoolData, WhirlpoolIx, buildWhirlpoolClient, collectFeesQuote, increaseLiquidityQuoteByInputToken, swapQuoteByInputToken, swapQuoteByOutputToken, swapQuoteWithParams, toTx } from "../../../src";
 import { WhirlpoolContext } from "../../../src/context";
 import { IGNORE_CACHE } from "../../../src/network/public/fetcher";
 import { TickSpacing, ZERO_BN, createTokenAccount } from "../../utils";
 import { defaultConfirmOptions } from "../../utils/const";
 import { WhirlpoolTestFixture } from "../../utils/fixture";
-import { initTestPoolWithTokens, initTickArrayRange, initializePositionBundle, openBundledPosition } from "../../utils/init-utils";
+import { buildTestAquariums, getDefaultAquarium, initTestPoolWithTokens, initTickArrayRange, initializePositionBundle, openBundledPosition } from "../../utils/init-utils";
 import { NO_TOKEN_EXTENSION_CONTEXT, TokenExtensionUtil } from "../../../src/utils/public/token-extension-util";
 import { buildTickArrayData } from "../../utils/testDataTypes";
+import { TwoHopSwapParams } from "../../../src/instructions";
 
 
 interface SharedTestContext {
@@ -626,13 +627,13 @@ describe("sparse swap tests", () => {
       return initResult;
     }
 
-    describe("b to a: 2816 --> 2816 + (64 * 88) * 2", () => {
+    describe("swap, b to a: 2816 --> 2816 + (64 * 88) * 2", () => {
       const aToB = false;
       const initialTickIndex = 2816;
       const targetTickIndex = 2816 + tickSpacing64 * 88 * 2; // --> 2 tick arrays
       const targetSqrtPrice = PriceMath.tickIndexToSqrtPriceX64(targetTickIndex);
 
-      async function runSwap(init0: boolean, init1: boolean, init2: boolean): Promise<{ quote: SwapQuote, poolData: WhirlpoolData }> {
+      async function runSwap(init0: boolean, init1: boolean, init2: boolean, v2: boolean): Promise<{ quote: SwapQuote, poolData: WhirlpoolData }> {
         const { poolInitInfo, tokenAccountA, tokenAccountB } = await buildTestEnvironment();
 
         const pool = await testCtx.whirlpoolClient.getPool(poolInitInfo.whirlpoolPda.publicKey, IGNORE_CACHE);
@@ -673,7 +674,7 @@ describe("sparse swap tests", () => {
           }
         });
 
-        const quote = await swapQuoteWithParams({
+        const quote = swapQuoteWithParams({
           whirlpoolData: pool.getData(),
           amountSpecifiedIsInput: true,
           aToB,
@@ -687,17 +688,32 @@ describe("sparse swap tests", () => {
         assert.ok(quote.estimatedAmountIn.gtn(0));
         assert.ok(quote.estimatedAmountOut.gtn(0));
 
-        assert.ok((await pool.refreshData()).tickCurrentIndex === initialTickIndex);
-        await toTx(
-          testCtx.whirlpoolCtx,
-          WhirlpoolIx.swapIx(testCtx.whirlpoolCtx.program, SwapUtils.getSwapParamsFromQuote(
+        const params = {
+          ...SwapUtils.getSwapParamsFromQuote(
             quote,
             testCtx.whirlpoolCtx,
             pool,
             tokenAccountB,
             tokenAccountA,
             testCtx.provider.wallet.publicKey,
-          )),
+          ),
+          amountSpecifiedIsInput: true,
+          amount: quote.estimatedAmountIn,
+          otherAmountThreshold: quote.estimatedAmountOut,
+          sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
+          // v2 specific
+          tokenMintA: poolInitInfo.tokenMintA,
+          tokenMintB: poolInitInfo.tokenMintB,
+          tokenProgramA: TOKEN_PROGRAM_ID,
+          tokenProgramB: TOKEN_PROGRAM_ID,
+        };
+
+        assert.ok((await pool.refreshData()).tickCurrentIndex === initialTickIndex);
+        await toTx(
+          testCtx.whirlpoolCtx,
+          !v2
+            ? WhirlpoolIx.swapIx(testCtx.whirlpoolCtx.program, params)
+            : WhirlpoolIx.swapV2Ix(testCtx.whirlpoolCtx.program, params),
         ).buildAndExecute(undefined, {skipPreflight: true});
         assert.ok((await pool.refreshData()).tickCurrentIndex === targetTickIndex);
 
@@ -706,34 +722,392 @@ describe("sparse swap tests", () => {
 
       let referenceResult: { quote: SwapQuote, poolData: WhirlpoolData };
       before(async () => {
-        referenceResult = await runSwap(true, true, true);
+        referenceResult = await runSwap(true, true, true, false);
       });
 
-      function runTest(init0: boolean, init1: boolean, init2: boolean) {
+      function runTest(init0: boolean, init1: boolean, init2: boolean, v2: boolean) {
+        const swap = v2 ? "v2" : "v1";
         const ta0 = init0 ? "|****S***|" : "|----S---|";
         const ta1 = init1 ? "********" : "--------";
         const ta2 = init2 ? "|****T***|" : "|----T---|";
 
-        it(`${ta0}${ta1}${ta2}`, async () => {
-          const result = await runSwap(init0, init1, init2);
+        it(`${swap}: ${ta0}${ta1}${ta2}`, async () => {
+          const result = await runSwap(init0, init1, init2, v2);
           assert.ok(result.quote.estimatedAmountIn.eq(referenceResult.quote.estimatedAmountIn));
           assert.ok(result.quote.estimatedAmountOut.eq(referenceResult.quote.estimatedAmountOut));
           assert.ok(result.poolData.tickCurrentIndex === referenceResult.poolData.tickCurrentIndex);
         });
       }
 
-      for (const init0 of [true, false]) {
-        for (const init1 of [true, false]) {
-          for (const init2 of [true, false]) {
-            runTest(init0, init1, init2);
+      for (const v2 of [false, true]) {
+        for (const init0 of [true, false]) {
+          for (const init1 of [true, false]) {
+            for (const init2 of [true, false]) {
+              runTest(init0, init1, init2, v2);
+            }
           }
         }
       }
     });
 
-    it("a to b: |----T---|********|----S---|", async () => {});
-    it("a to b: |****T***|--------|****S***|", async () => {});
-    it("a to b: |----T---|--------|----S---|", async () => {});
+    describe("swap, a to b: 2816 - (64 * 88) * 2 <-- 2816", () => {
+      const aToB = true;
+      const initialTickIndex = 2816;
+      const targetTickIndex = 2816 - tickSpacing64 * 88 * 2; // <-- 2 tick arrays
+      const targetSqrtPrice = PriceMath.tickIndexToSqrtPriceX64(targetTickIndex);
+
+      async function runSwap(init0: boolean, init1: boolean, init2: boolean, v2: boolean): Promise<{ quote: SwapQuote, poolData: WhirlpoolData }> {
+        const { poolInitInfo, tokenAccountA, tokenAccountB } = await buildTestEnvironment();
+
+        const pool = await testCtx.whirlpoolClient.getPool(poolInitInfo.whirlpoolPda.publicKey, IGNORE_CACHE);
+
+        const startTickIndexes = [0, -5632, -11264];
+        const init = [init0, init1, init2];
+
+        // init tick arrays
+        const tickArrayIndexes: number[] = [];
+        init.forEach((v, i) => {
+          if (v) {
+            tickArrayIndexes.push(startTickIndexes[i]);
+          }
+        });
+        if (tickArrayIndexes.length > 0) {
+          await (await pool.initTickArrayForTicks(tickArrayIndexes))!.buildAndExecute();
+        }
+
+        // fetch tick arrays
+        const tickArrays = await SwapUtils.getTickArrays(
+          pool.getData().tickCurrentIndex,
+          pool.getData().tickSpacing,
+          aToB,
+          testCtx.whirlpoolCtx.program.programId,
+          pool.getAddress(),
+          testCtx.whirlpoolCtx.fetcher,
+          IGNORE_CACHE,
+        );
+
+        // padding if needed
+        init.forEach((v, i) => {
+          if (!v) {
+            assert.ok(tickArrays[i].data === null);
+            tickArrays[i].data = buildTickArrayData(startTickIndexes[i], []).data;
+            tickArrays[i].data!.whirlpool = pool.getAddress();
+          } else {
+            assert.ok(tickArrays[i].data !== null);
+          }
+        });
+
+        const quote = swapQuoteWithParams({
+          whirlpoolData: pool.getData(),
+          amountSpecifiedIsInput: true,
+          aToB,
+          otherAmountThreshold: SwapUtils.getDefaultOtherAmountThreshold(true),
+          tokenAmount: U64_MAX,
+          sqrtPriceLimit: targetSqrtPrice,
+          tickArrays,
+          tokenExtensionCtx: NO_TOKEN_EXTENSION_CONTEXT,
+        }, Percentage.fromFraction(0, 100));
+
+        assert.ok(quote.estimatedAmountIn.gtn(0));
+        assert.ok(quote.estimatedAmountOut.gtn(0));
+
+        const params = {
+          ...SwapUtils.getSwapParamsFromQuote(
+            quote,
+            testCtx.whirlpoolCtx,
+            pool,
+            tokenAccountA,
+            tokenAccountB,
+            testCtx.provider.wallet.publicKey,
+          ),
+          amountSpecifiedIsInput: true,
+          amount: quote.estimatedAmountIn,
+          otherAmountThreshold: quote.estimatedAmountOut,
+          sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
+          // v2 specific
+          tokenMintA: poolInitInfo.tokenMintA,
+          tokenMintB: poolInitInfo.tokenMintB,
+          tokenProgramA: TOKEN_PROGRAM_ID,
+          tokenProgramB: TOKEN_PROGRAM_ID,
+        };
+
+        assert.ok((await pool.refreshData()).tickCurrentIndex === initialTickIndex);
+        await toTx(
+          testCtx.whirlpoolCtx,
+          !v2
+            ? WhirlpoolIx.swapIx(testCtx.whirlpoolCtx.program, params)
+            : WhirlpoolIx.swapV2Ix(testCtx.whirlpoolCtx.program, params),
+        ).buildAndExecute(undefined, {skipPreflight: true});
+        assert.ok((await pool.refreshData()).tickCurrentIndex === targetTickIndex - 1 /* shift */);
+
+        return { quote, poolData: pool.getData() };
+      }
+
+      let referenceResult: { quote: SwapQuote, poolData: WhirlpoolData };
+      before(async () => {
+        referenceResult = await runSwap(true, true, true, false);
+      });
+
+      function runTest(init0: boolean, init1: boolean, init2: boolean, v2: boolean) {
+        const swap = v2 ? "v2" : "v1";
+        const ta0 = init0 ? "|****S***|" : "|----S---|";
+        const ta1 = init1 ? "********" : "--------";
+        const ta2 = init2 ? "|****T***|" : "|----T---|";
+
+        it(`${swap}: ${ta2}${ta1}${ta0}`, async () => {
+          const result = await runSwap(init0, init1, init2, v2);
+          assert.ok(result.quote.estimatedAmountIn.eq(referenceResult.quote.estimatedAmountIn));
+          assert.ok(result.quote.estimatedAmountOut.eq(referenceResult.quote.estimatedAmountOut));
+          assert.ok(result.poolData.tickCurrentIndex === referenceResult.poolData.tickCurrentIndex);
+        });
+      }
+
+      for (const v2 of [false, true]) {
+        for (const init0 of [true, false]) {
+          for (const init1 of [true, false]) {
+            for (const init2 of [true, false]) {
+              runTest(init0, init1, init2, v2);
+            }
+          }
+        }
+      }
+    });
+
+    describe("twoHopSwap, b to a: 2816 --> 2816 + (64 * 88) * 2", () => {
+      const aToB = false;
+      const initialTickIndex = 2816;
+      const targetTickIndex = 2816 + tickSpacing64 * 88 * 2; // --> tick arrays
+      const targetSqrtPrice = PriceMath.tickIndexToSqrtPriceX64(targetTickIndex);
+
+      async function runSwap(init0: boolean, init1: boolean, init2: boolean, v2: boolean): Promise<{
+        quote0: SwapQuote, poolData0: WhirlpoolData,
+        quote1: SwapQuote, poolData1: WhirlpoolData,
+      }> {
+        const aqConfig = getDefaultAquarium();
+
+        // Add a third token and account and a second pool
+        aqConfig.initFeeTierParams = [{ tickSpacing: tickSpacing64 }];
+        aqConfig.initMintParams.push({});
+        aqConfig.initTokenAccParams.push({ mintIndex: 2 });
+        aqConfig.initPoolParams = [
+          { mintIndices: [0, 1], tickSpacing: tickSpacing64, initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(2816) },
+          { mintIndices: [1, 2], tickSpacing: tickSpacing64, initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(2816) },
+        ];
+  
+        // Add tick arrays and positions
+        aqConfig.initTickArrayRangeParams.push({
+          poolIndex: 0,
+          startTickIndex: -444928,
+          arrayCount: 1,
+          aToB,
+        });
+        aqConfig.initTickArrayRangeParams.push({
+          poolIndex: 0,
+          startTickIndex: 439296,
+          arrayCount: 1,
+          aToB,
+        });
+        aqConfig.initTickArrayRangeParams.push({
+          poolIndex: 1,
+          startTickIndex: -444928,
+          arrayCount: 1,
+          aToB,
+        });
+        aqConfig.initTickArrayRangeParams.push({
+          poolIndex: 1,
+          startTickIndex: 439296,
+          arrayCount: 1,
+          aToB,
+        });
+  
+        // pool2(b(2) -> a(1)) --> pool1(b(1) -> a(0)) (so pool0 has smaller liquidity)
+        aqConfig.initPositionParams.push({ poolIndex: 0, fundParams: [
+          {
+            liquidityAmount: new anchor.BN(4_100_000),
+            tickLowerIndex: -443584,
+            tickUpperIndex: 443584,
+          },
+        ]});
+        aqConfig.initPositionParams.push({ poolIndex: 1, fundParams: [
+          {
+            liquidityAmount: new anchor.BN(10_000_000),
+            tickLowerIndex: -443584,
+            tickUpperIndex: 443584,
+          },
+        ]});
+        const aquarium = (await buildTestAquariums(testCtx.whirlpoolCtx, [aqConfig]))[0];
+
+        const startTickIndexes = [0, 5632, 11264];
+        const init = [init0, init1, init2];
+
+        const poolInit0 = aquarium.pools[0];
+        const poolInit1 = aquarium.pools[1];
+
+        const pool0 = await testCtx.whirlpoolClient.getPool(poolInit0.whirlpoolPda.publicKey, IGNORE_CACHE);
+        const pool1 = await testCtx.whirlpoolClient.getPool(poolInit1.whirlpoolPda.publicKey, IGNORE_CACHE);
+
+        // init tick arrays
+        const tickArrayIndexes: number[] = [];
+        init.forEach((v, i) => {
+          if (v) {
+            tickArrayIndexes.push(startTickIndexes[i]);
+          }
+        });
+        if (tickArrayIndexes.length > 0) {
+          await (await pool0.initTickArrayForTicks(tickArrayIndexes))!.buildAndExecute();
+          await (await pool1.initTickArrayForTicks(tickArrayIndexes))!.buildAndExecute();
+        }
+
+        // fetch tick arrays
+        const tickArrays0 = await SwapUtils.getTickArrays(
+          pool0.getData().tickCurrentIndex,
+          pool0.getData().tickSpacing,
+          aToB,
+          testCtx.whirlpoolCtx.program.programId,
+          pool0.getAddress(),
+          testCtx.whirlpoolCtx.fetcher,
+          IGNORE_CACHE,
+        );
+        const tickArrays1 = await SwapUtils.getTickArrays(
+          pool1.getData().tickCurrentIndex,
+          pool1.getData().tickSpacing,
+          aToB,
+          testCtx.whirlpoolCtx.program.programId,
+          pool1.getAddress(),
+          testCtx.whirlpoolCtx.fetcher,
+          IGNORE_CACHE,
+        );
+        // padding if needed
+        init.forEach((v, i) => {
+          if (!v) {
+            assert.ok(tickArrays0[i].data === null);
+            tickArrays0[i].data = buildTickArrayData(startTickIndexes[i], []).data;
+            tickArrays0[i].data!.whirlpool = pool0.getAddress();
+            assert.ok(tickArrays1[i].data === null);
+            tickArrays1[i].data = buildTickArrayData(startTickIndexes[i], []).data;
+            tickArrays1[i].data!.whirlpool = pool1.getAddress();
+          } else {
+            assert.ok(tickArrays0[i].data !== null);
+            assert.ok(tickArrays1[i].data !== null);
+          }
+        });
+
+        const quote1 = swapQuoteWithParams({
+          whirlpoolData: pool1.getData(),
+          amountSpecifiedIsInput: true,
+          aToB,
+          otherAmountThreshold: SwapUtils.getDefaultOtherAmountThreshold(true),
+          tokenAmount: U64_MAX,
+          sqrtPriceLimit: targetSqrtPrice,
+          tickArrays: tickArrays1,
+          tokenExtensionCtx: NO_TOKEN_EXTENSION_CONTEXT,
+        }, Percentage.fromFraction(0, 100));
+
+        const quote0 = swapQuoteWithParams({
+          whirlpoolData: pool0.getData(),
+          amountSpecifiedIsInput: true,
+          aToB,
+          otherAmountThreshold: SwapUtils.getDefaultOtherAmountThreshold(true),
+          tokenAmount: quote1.estimatedAmountOut,
+          sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
+          tickArrays: tickArrays0,
+          tokenExtensionCtx: NO_TOKEN_EXTENSION_CONTEXT,
+        }, Percentage.fromFraction(0, 100));
+
+        assert.ok(quote0.estimatedAmountIn.gtn(0));
+        assert.ok(quote0.estimatedAmountOut.gtn(0));
+        assert.ok(quote1.estimatedAmountIn.gtn(0));
+        assert.ok(quote1.estimatedAmountOut.gtn(0));
+
+        const params = {
+          amount: quote1.estimatedAmountIn,
+          amountSpecifiedIsInput: true,
+          otherAmountThreshold: SwapUtils.getDefaultOtherAmountThreshold(true),
+          aToBOne: aToB,
+          aToBTwo: aToB,
+          oracleOne: PDAUtil.getOracle(testCtx.whirlpoolCtx.program.programId, pool1.getAddress()).publicKey,
+          oracleTwo: PDAUtil.getOracle(testCtx.whirlpoolCtx.program.programId, pool0.getAddress()).publicKey,
+          sqrtPriceLimitOne: SwapUtils.getDefaultSqrtPriceLimit(aToB),
+          sqrtPriceLimitTwo: SwapUtils.getDefaultSqrtPriceLimit(aToB),
+          tickArrayOne0: tickArrays1[0].address,
+          tickArrayOne1: tickArrays1[1].address,
+          tickArrayOne2: tickArrays1[2].address,
+          tickArrayTwo0: tickArrays0[0].address,
+          tickArrayTwo1: tickArrays0[1].address,
+          tickArrayTwo2: tickArrays0[2].address,
+          tokenAuthority: testCtx.provider.wallet.publicKey,
+          whirlpoolOne: pool1.getAddress(),
+          whirlpoolTwo: pool0.getAddress(),
+          // v1 specific
+          tokenOwnerAccountOneA: aquarium.tokenAccounts[1].account,
+          tokenOwnerAccountOneB: aquarium.tokenAccounts[2].account,
+          tokenOwnerAccountTwoA: aquarium.tokenAccounts[0].account,
+          tokenOwnerAccountTwoB: aquarium.tokenAccounts[1].account,
+          tokenVaultOneA: pool1.getData().tokenVaultA,
+          tokenVaultOneB: pool1.getData().tokenVaultB,
+          tokenVaultTwoA: pool0.getData().tokenVaultA,
+          tokenVaultTwoB: pool0.getData().tokenVaultB,
+          // v2 specific
+          tokenOwnerAccountInput: aquarium.tokenAccounts[2].account,
+          tokenOwnerAccountOutput: aquarium.tokenAccounts[0].account,
+          tokenVaultOneInput: pool1.getData().tokenVaultB,
+          tokenVaultOneIntermediate: pool1.getData().tokenVaultA,
+          tokenVaultTwoIntermediate: pool0.getData().tokenVaultB,
+          tokenVaultTwoOutput: pool0.getData().tokenVaultA,
+          tokenMintInput: pool1.getData().tokenMintB,
+          tokenMintIntermediate: pool1.getData().tokenMintA,
+          tokenMintOutput: pool0.getData().tokenMintA,
+          tokenProgramInput: TOKEN_PROGRAM_ID,
+          tokenProgramIntermediate: TOKEN_PROGRAM_ID,
+          tokenProgramOutput: TOKEN_PROGRAM_ID,
+        };
+
+        assert.ok((await pool0.refreshData()).tickCurrentIndex === initialTickIndex);
+        assert.ok((await pool1.refreshData()).tickCurrentIndex === initialTickIndex);
+        await toTx(
+          testCtx.whirlpoolCtx,
+          !v2
+            ? WhirlpoolIx.twoHopSwapIx(testCtx.whirlpoolCtx.program, params)
+            : WhirlpoolIx.twoHopSwapV2Ix(testCtx.whirlpoolCtx.program, params),
+        ).buildAndExecute(undefined, {skipPreflight: true});
+        assert.ok((await pool0.refreshData()).tickCurrentIndex >= targetTickIndex);
+        assert.ok((await pool1.refreshData()).tickCurrentIndex >= targetTickIndex);
+
+        return { quote0, poolData0: pool0.getData(), quote1, poolData1: pool1.getData() };
+      }
+
+      let referenceResult: { quote0: SwapQuote, poolData0: WhirlpoolData, quote1: SwapQuote, poolData1: WhirlpoolData };
+      before(async () => {
+        referenceResult = await runSwap(true, true, true, false);
+      });
+
+      function runTest(init0: boolean, init1: boolean, init2: boolean, v2: boolean) {
+        const swap = v2 ? "v2" : "v1";
+        const ta0 = init0 ? "|****S***|" : "|----S---|";
+        const ta1 = init1 ? "********" : "--------";
+        const ta2 = init2 ? "|****T***|" : "|----T---|";
+
+        it(`${swap}: ${ta0}${ta1}${ta2} -> ${ta0}${ta1}${ta2}`, async () => {
+          const result = await runSwap(init0, init1, init2, v2);
+          assert.ok(result.quote0.estimatedAmountIn.eq(referenceResult.quote0.estimatedAmountIn));
+          assert.ok(result.quote0.estimatedAmountOut.eq(referenceResult.quote0.estimatedAmountOut));
+          assert.ok(result.poolData0.tickCurrentIndex === referenceResult.poolData0.tickCurrentIndex);
+          assert.ok(result.quote1.estimatedAmountIn.eq(referenceResult.quote1.estimatedAmountIn));
+          assert.ok(result.quote1.estimatedAmountOut.eq(referenceResult.quote1.estimatedAmountOut));
+          assert.ok(result.poolData1.tickCurrentIndex === referenceResult.poolData1.tickCurrentIndex);
+        });
+      }
+
+      for (const v2 of [false, true]) {
+        for (const init0 of [true, false]) {
+          for (const init1 of [true, false]) {
+            for (const init2 of [true, false]) {
+              runTest(init0, init1, init2, v2);
+            }
+          }
+        }
+      }  
+    });
 
   });
 });

--- a/sdk/tests/integration/swap.test.ts
+++ b/sdk/tests/integration/swap.test.ts
@@ -392,8 +392,8 @@ describe("swap", () => {
           oracle: oraclePda.publicKey,
         })
       ).buildAndExecute(),
-      // sparse-swap changes error code (has_one constraint -> check in the handler)
-      /0x17a7/ // DifferentWhirlpoolTickArrayAccount
+      // This test case violates the constraint on vault (before tickarray)
+      /0x7d3/ // ConstraintRaw
     );
   });
 
@@ -445,7 +445,8 @@ describe("swap", () => {
           oracle: oraclePda.publicKey,
         })
       ).buildAndExecute(),
-      /0x7d1/ // ConstraintHasOne
+      // sparse-swap changes error code (has_one constraint -> check in the handler)
+      /0x17a7/ // DifferentWhirlpoolTickArrayAccount
     );
 
     // invalid tickArrays[1]
@@ -470,7 +471,7 @@ describe("swap", () => {
           oracle: oraclePda.publicKey,
         })
       ).buildAndExecute(),
-      /0x7d1/ // ConstraintHasOne
+      /0x17a7/ // DifferentWhirlpoolTickArrayAccount
     );
 
     // invalid tickArrays[2]
@@ -495,7 +496,7 @@ describe("swap", () => {
           oracle: oraclePda.publicKey,
         })
       ).buildAndExecute(),
-      /0x7d1/ // ConstraintHasOne
+      /0x17a7/ // DifferentWhirlpoolTickArrayAccount
     );    
   });
 

--- a/sdk/tests/integration/swap.test.ts
+++ b/sdk/tests/integration/swap.test.ts
@@ -446,7 +446,7 @@ describe("swap", () => {
         })
       ).buildAndExecute(),
       // sparse-swap changes error code (has_one constraint -> check in the handler)
-      /0x17a7/ // DifferentWhirlpoolTickArrayAccount
+      /0x17a8/ // DifferentWhirlpoolTickArrayAccount
     );
 
     // invalid tickArrays[1]
@@ -471,7 +471,7 @@ describe("swap", () => {
           oracle: oraclePda.publicKey,
         })
       ).buildAndExecute(),
-      /0x17a7/ // DifferentWhirlpoolTickArrayAccount
+      /0x17a8/ // DifferentWhirlpoolTickArrayAccount
     );
 
     // invalid tickArrays[2]
@@ -496,7 +496,7 @@ describe("swap", () => {
           oracle: oraclePda.publicKey,
         })
       ).buildAndExecute(),
-      /0x17a7/ // DifferentWhirlpoolTickArrayAccount
+      /0x17a8/ // DifferentWhirlpoolTickArrayAccount
     );    
   });
 

--- a/sdk/tests/integration/two_hop_swap.test.ts
+++ b/sdk/tests/integration/two_hop_swap.test.ts
@@ -162,21 +162,23 @@ describe("two-hop swap", () => {
       await rejectParams(
         {
           ...baseIxParams,
-          tickArrayOne0: PublicKey.unique(),
+          // sparse-swap can accept completely uninitialized account as candidate for uninitialized tick arrays.
+          // so now we use token account as clearly invalid account.
+          tickArrayOne0: baseIxParams.tokenVaultOneA,
         },
         /0xbbf/ // AccountOwnedByWrongProgram
       );
       await rejectParams(
         {
           ...baseIxParams,
-          tickArrayOne1: PublicKey.unique(),
+          tickArrayOne1: baseIxParams.tokenVaultOneA,
         },
         /0xbbf/ // AccountOwnedByWrongProgram
       );
       await rejectParams(
         {
           ...baseIxParams,
-          tickArrayOne2: PublicKey.unique(),
+          tickArrayOne2: baseIxParams.tokenVaultOneA,
         },
         /0xbbf/ // AccountOwnedByWrongProgram
       );
@@ -186,21 +188,23 @@ describe("two-hop swap", () => {
       await rejectParams(
         {
           ...baseIxParams,
-          tickArrayTwo0: PublicKey.unique(),
+          // sparse-swap can accept completely uninitialized account as candidate for uninitialized tick arrays.
+          // so now we use token account as clearly invalid account.
+          tickArrayTwo0: baseIxParams.tokenVaultTwoA,
         },
         /0xbbf/ // AccountOwnedByWrongProgram
       );
       await rejectParams(
         {
           ...baseIxParams,
-          tickArrayTwo1: PublicKey.unique(),
+          tickArrayTwo1: baseIxParams.tokenVaultTwoA,
         },
         /0xbbf/ // AccountOwnedByWrongProgram
       );
       await rejectParams(
         {
           ...baseIxParams,
-          tickArrayTwo2: PublicKey.unique(),
+          tickArrayTwo2: baseIxParams.tokenVaultTwoA,
         },
         /0xbbf/ // AccountOwnedByWrongProgram
       );

--- a/sdk/tests/integration/v2/swap_v2.test.ts
+++ b/sdk/tests/integration/v2/swap_v2.test.ts
@@ -519,7 +519,7 @@ describe("swap_v2", () => {
               })
             ).buildAndExecute(),
             // sparse-swap changes error code (has_one constraint -> check in the handler)
-            /0x17a7/ // DifferentWhirlpoolTickArrayAccount
+            /0x17a8/ // DifferentWhirlpoolTickArrayAccount
           );
         });
 

--- a/sdk/tests/integration/v2/swap_v2.test.ts
+++ b/sdk/tests/integration/v2/swap_v2.test.ts
@@ -518,7 +518,8 @@ describe("swap_v2", () => {
                 oracle: oraclePda.publicKey,
               })
             ).buildAndExecute(),
-            /0x7d1/ // ConstraintHasOne
+            // sparse-swap changes error code (has_one constraint -> check in the handler)
+            /0x17a7/ // DifferentWhirlpoolTickArrayAccount
           );
         });
 
@@ -640,10 +641,13 @@ describe("swap_v2", () => {
           const tickArrays = await initTickArrayRange(
             ctx,
             whirlpoolPda.publicKey,
-            33792,
+            // sparse-swap: We didn't provide valid initialized tick arrays.
+            // The current pool tick index is 32190, so we need to provide tick array with start_tick_index 22528.
+            // Using sparse-swap, the validity of provided tick arrays will be evaluated before evaluating trade amount.
+            22528,
             3,
             TickSpacing.Standard,
-            false
+            true,
           );
 
           const oraclePda = PDAUtil.getOracle(ctx.program.programId, whirlpoolPda.publicKey);
@@ -1237,6 +1241,8 @@ describe("swap_v2", () => {
           // TODO: Verify fees and other whirlpool params
         });
 
+        /* using sparse-swap, we can handle uninitialized tick-array. so this test is no longer needed.
+
         it("Error on passing in uninitialized tick-array", async () => {
           const { poolInitInfo, tokenAccountA, tokenAccountB, tickArrays } =
             await initTestPoolWithLiquidityV2(
@@ -1260,7 +1266,7 @@ describe("swap_v2", () => {
           const params: SwapV2Params = {
             amount: new BN(10),
             otherAmountThreshold: ZERO_BN,
-            sqrtPriceLimit: MathUtil.toX64(new Decimal(4294886578)),
+            sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(true),
             amountSpecifiedIsInput: true,
             aToB: true,
             whirlpool: whirlpool,
@@ -1287,6 +1293,7 @@ describe("swap_v2", () => {
             assert.match(error.message, /0xbbf/); // AccountOwnedByWrongProgram
           }
         });
+        */
 
         it("Error if sqrt_price_limit exceeds max", async () => {
           const { poolInitInfo, tokenAccountA, tokenAccountB, tickArrays } =

--- a/sdk/tests/integration/v2/two_hop_swap_v2.test.ts
+++ b/sdk/tests/integration/v2/two_hop_swap_v2.test.ts
@@ -336,21 +336,23 @@ describe("two_hop_swap_v2", () => {
             await rejectParams(
               {
                 ...baseIxParams,
-                tickArrayOne0: PublicKey.unique(),
+                // sparse-swap can accept completely uninitialized account as candidate for uninitialized tick arrays.
+                // so now we use token account as clearly invalid account.
+                tickArrayOne0: baseIxParams.tokenVaultOneInput,
               },
               /0xbbf/ // AccountOwnedByWrongProgram
             );
             await rejectParams(
               {
                 ...baseIxParams,
-                tickArrayOne1: PublicKey.unique(),
+                tickArrayOne1: baseIxParams.tokenVaultOneInput,
               },
               /0xbbf/ // AccountOwnedByWrongProgram
             );
             await rejectParams(
               {
                 ...baseIxParams,
-                tickArrayOne2: PublicKey.unique(),
+                tickArrayOne2: baseIxParams.tokenVaultOneInput,
               },
               /0xbbf/ // AccountOwnedByWrongProgram
             );
@@ -360,21 +362,23 @@ describe("two_hop_swap_v2", () => {
             await rejectParams(
               {
                 ...baseIxParams,
-                tickArrayTwo0: PublicKey.unique(),
+                // sparse-swap can accept completely uninitialized account as candidate for uninitialized tick arrays.
+                // so now we use token account as clearly invalid account.
+                tickArrayTwo0: baseIxParams.tokenVaultTwoOutput,
               },
               /0xbbf/ // AccountOwnedByWrongProgram
             );
             await rejectParams(
               {
                 ...baseIxParams,
-                tickArrayTwo1: PublicKey.unique(),
+                tickArrayTwo1: baseIxParams.tokenVaultTwoOutput,
               },
               /0xbbf/ // AccountOwnedByWrongProgram
             );
             await rejectParams(
               {
                 ...baseIxParams,
-                tickArrayTwo2: PublicKey.unique(),
+                tickArrayTwo2: baseIxParams.tokenVaultTwoOutput,
               },
               /0xbbf/ // AccountOwnedByWrongProgram
             );

--- a/sdk/tests/sdk/whirlpools/swap/swap-array.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/swap-array.test.ts
@@ -81,7 +81,7 @@ describe("swap arrays test", () => {
       adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
     );
     assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-    assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
   });
 
   /**
@@ -106,21 +106,153 @@ describe("swap arrays test", () => {
       ],
     });
 
-    // estimatedEndTickIndex is 4091 (arrayIndex: 0 (not initialized))
+    // SparseSwap makes it possible to execute this swap.
+
     const whirlpoolData = await whirlpool.refreshData();
-    const expectedError = "Swap input value traversed too many arrays.";
-    await assert.rejects(
-      swapQuoteByInputToken(
-        whirlpool,
-        whirlpoolData.tokenMintA,
-        new BN(40_000_000),
-        slippageTolerance,
-        ctx.program.programId,
-        fetcher,
-        IGNORE_CACHE
-      ),
-      (err: Error) => err.message.indexOf(expectedError) != -1
+    const tradeAmount = new BN(40_000_000);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE
     );
+
+    // Verify with an actual swap.
+    // estimatedEndTickIndex is 4091 (arrayIndex: 0 (not initialized))
+    assert.equal(quote.aToB, true);
+    assert.equal(quote.amountSpecifiedIsInput, true);
+    assert.equal(
+      quote.sqrtPriceLimit.toString(),
+      SwapUtils.getDefaultSqrtPriceLimit(true).toString()
+    );
+
+    assert.equal(quote.estimatedEndTickIndex, 4091);
+    assert.equal(
+      quote.otherAmountThreshold.toString(),
+      adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
+    );
+    assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
+
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    const updatedWhirlpoolData = await whirlpool.refreshData();
+    assert.equal(updatedWhirlpoolData.tickCurrentIndex, quote.estimatedEndTickIndex);
+  });
+
+  /**
+   * |xxxxxxxxxxxxxc2xx|xxxxxxxxxxxxxxxxx|------c1-----------|
+   */
+  it("3 sequential arrays, 2nd and 3rd array not initialized, a->b", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 44 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    // SparseSwap makes it possible to execute this swap.
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const tradeAmount = new BN(150_000_000);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE
+    );
+
+    // Verify with an actual swap.
+    // estimatedEndTickIndex is -4522 (arrayIndex: -1 (not initialized))
+    assert.equal(quote.aToB, true);
+    assert.equal(quote.amountSpecifiedIsInput, true);
+    assert.equal(
+      quote.sqrtPriceLimit.toString(),
+      SwapUtils.getDefaultSqrtPriceLimit(true).toString()
+    );
+
+    assert.equal(quote.estimatedEndTickIndex, -4522);
+    assert.equal(
+      quote.otherAmountThreshold.toString(),
+      adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
+    );
+    assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
+
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    const updatedWhirlpoolData = await whirlpool.refreshData();
+    assert.equal(updatedWhirlpoolData.tickCurrentIndex, quote.estimatedEndTickIndex);
+  });
+
+  /**
+   * |xxxxxxxxxxxxxc2xx|xxxxxxxxxxxxxxxxx|xxxxxxc1xxxxxxxxxxx|
+   */
+  it("3 sequential arrays, all array not initialized, a->b", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 44 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    // SparseSwap makes it possible to execute this swap.
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const tradeAmount = new BN(150_000_000);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE
+    );
+
+    // Verify with an actual swap.
+    // estimatedEndTickIndex is -4522 (arrayIndex: -1 (not initialized))
+    assert.equal(quote.aToB, true);
+    assert.equal(quote.amountSpecifiedIsInput, true);
+    assert.equal(
+      quote.sqrtPriceLimit.toString(),
+      SwapUtils.getDefaultSqrtPriceLimit(true).toString()
+    );
+
+    assert.equal(quote.estimatedEndTickIndex, -4522);
+    assert.equal(
+      quote.otherAmountThreshold.toString(),
+      adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
+    );
+    assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
+
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    const updatedWhirlpoolData = await whirlpool.refreshData();
+    assert.equal(updatedWhirlpoolData.tickCurrentIndex, quote.estimatedEndTickIndex);
   });
 
   /**
@@ -170,7 +302,7 @@ describe("swap arrays test", () => {
       adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
     );
     assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-    assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
   });
 
   /**
@@ -195,23 +327,155 @@ describe("swap arrays test", () => {
       ],
     });
 
-    // estimatedEndTickIndex is 556 (arrayIndex: 0 (not initialized))
+    // SparseSwap makes it possible to execute this swap.
+
     const whirlpoolData = await whirlpool.refreshData();
-    const expectedError = "Swap input value traversed too many arrays.";
-    await assert.rejects(
-      swapQuoteByInputToken(
-        whirlpool,
-        whirlpoolData.tokenMintB,
-        new BN(40_000_000),
-        slippageTolerance,
-        ctx.program.programId,
-        fetcher,
-        IGNORE_CACHE
-      ),
-      (err: Error) => err.message.indexOf(expectedError) != -1
+    const tradeAmount = new BN(40_000_000);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE
     );
+
+    // Verify with an actual swap.
+    // estimatedEndTickIndex is 556 (arrayIndex: 0 (not initialized))
+    assert.equal(quote.aToB, false);
+    assert.equal(quote.amountSpecifiedIsInput, true);
+    assert.equal(
+      quote.sqrtPriceLimit.toString(),
+      SwapUtils.getDefaultSqrtPriceLimit(false).toString()
+    );
+
+    assert.equal(quote.estimatedEndTickIndex, 556);
+    assert.equal(
+      quote.otherAmountThreshold.toString(),
+      adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
+    );
+    assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
+
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    const updatedWhirlpoolData = await whirlpool.refreshData();
+    assert.equal(updatedWhirlpoolData.tickCurrentIndex, quote.estimatedEndTickIndex);
   });
 
+  /**
+   * |-------------c1-----|xxxxxxxxxxxxxxxxx|xxc2xxxxxxxxxxxxx|
+   */
+  it("3 sequential arrays, 2nd and 3rd array not initialized, b->a", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -1, offsetIndex: 44 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    // SparseSwap makes it possible to execute this swap.
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const tradeAmount = new BN(150_000_000);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE
+    );
+
+    // Verify with an actual swap.
+    // estimatedEndTickIndex is 7662 (arrayIndex: 1 (not initialized))
+    assert.equal(quote.aToB, false);
+    assert.equal(quote.amountSpecifiedIsInput, true);
+    assert.equal(
+      quote.sqrtPriceLimit.toString(),
+      SwapUtils.getDefaultSqrtPriceLimit(false).toString()
+    );
+
+    assert.equal(quote.estimatedEndTickIndex, 7662);
+    assert.equal(
+      quote.otherAmountThreshold.toString(),
+      adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
+    );
+    assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
+
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    const updatedWhirlpoolData = await whirlpool.refreshData();
+    assert.equal(updatedWhirlpoolData.tickCurrentIndex, quote.estimatedEndTickIndex);
+  });
+
+  /**
+   * |xxxxxxxxxxxxxc1xxxxx|xxxxxxxxxxxxxxxxx|xxc2xxxxxxxxxxxxx|
+   */
+  it("3 sequential arrays, all array not initialized, b->a", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -1, offsetIndex: 44 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    // SparseSwap makes it possible to execute this swap.
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const tradeAmount = new BN(150_000_000);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE
+    );
+
+    // Verify with an actual swap.
+    // estimatedEndTickIndex is 7662 (arrayIndex: 1 (not initialized))
+    assert.equal(quote.aToB, false);
+    assert.equal(quote.amountSpecifiedIsInput, true);
+    assert.equal(
+      quote.sqrtPriceLimit.toString(),
+      SwapUtils.getDefaultSqrtPriceLimit(false).toString()
+    );
+
+    assert.equal(quote.estimatedEndTickIndex, 7662);
+    assert.equal(
+      quote.otherAmountThreshold.toString(),
+      adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
+    );
+    assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
+
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    const updatedWhirlpoolData = await whirlpool.refreshData();
+    assert.equal(updatedWhirlpoolData.tickCurrentIndex, quote.estimatedEndTickIndex);
+  });
+  
   /**
    * |xxxxxxxxxxxxxxxxxxxx|xxxxxxxxxxxxxxxxx|-c2---c1-----------|
    */
@@ -259,7 +523,7 @@ describe("swap arrays test", () => {
       adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
     );
     assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-    assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
   });
 
   /**
@@ -309,7 +573,7 @@ describe("swap arrays test", () => {
       adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
     );
     assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-    assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
   });
 
   /**
@@ -697,7 +961,7 @@ describe("swap arrays test", () => {
       adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
     );
     assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-    assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
   });
 
   /**
@@ -758,7 +1022,7 @@ describe("swap arrays test", () => {
       adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
     );
     assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-    assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
   });
 
   /**
@@ -794,7 +1058,8 @@ describe("swap arrays test", () => {
       whirlpool.getAddress()
     );
 
-    await assert.rejects(
+    // SparseSwap makes it possible to execute this swap.
+    await assert.doesNotReject(
       whirlpool.swap({
         amount: tradeAmount,
         amountSpecifiedIsInput: true,
@@ -802,13 +1067,9 @@ describe("swap arrays test", () => {
         otherAmountThreshold: SwapUtils.getDefaultOtherAmountThreshold(true),
         sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
         tickArray0: tickArrays[0],
-        tickArray1: tickArrays[1],
-        tickArray2: tickArrays[2],
-      }),
-      (err: Error) => {
-        const uninitializedArrays = [tickArrays[1].toBase58(), tickArrays[2].toBase58()].join(", ");
-        return err.message.indexOf(`TickArray addresses - [${uninitializedArrays}] need to be initialized.`) >= 0;
-      }
+        tickArray1: tickArrays[1], // uninitialized TickArray is acceptable
+        tickArray2: tickArrays[2], // uninitialized TickArray is acceptable
+      })
     );
   });
 
@@ -845,7 +1106,8 @@ describe("swap arrays test", () => {
       whirlpool.getAddress()
     );
 
-    await assert.rejects(
+    // SparseSwap makes it possible to execute this swap.
+    await assert.doesNotReject(
       whirlpool.swap({
         amount: tradeAmount,
         amountSpecifiedIsInput: true,
@@ -853,13 +1115,9 @@ describe("swap arrays test", () => {
         otherAmountThreshold: SwapUtils.getDefaultOtherAmountThreshold(true),
         sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
         tickArray0: tickArrays[0],
-        tickArray1: tickArrays[1],
-        tickArray2: tickArrays[2],
-      }),
-      (err: Error) => {
-        const uninitializedArrays = [tickArrays[1].toBase58(), tickArrays[2].toBase58()].join(", ");
-        return err.message.indexOf(`TickArray addresses - [${uninitializedArrays}] need to be initialized.`) >= 0;
-      }
+        tickArray1: tickArrays[1], // uninitialized TickArray is acceptable
+        tickArray2: tickArrays[2], // uninitialized TickArray is acceptable
+      })
     );
   });
 });

--- a/sdk/tests/sdk/whirlpools/swap/swap-with-fallback.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/swap-with-fallback.test.ts
@@ -1,0 +1,834 @@
+import * as anchor from "@coral-xyz/anchor";
+import { Percentage } from "@orca-so/common-sdk";
+import * as assert from "assert";
+import BN from "bn.js";
+import {
+  ORCA_WHIRLPOOL_PROGRAM_ID,
+  PDAUtil,
+  PriceMath,
+  TwoHopSwapV2Params,
+  UseFallbackTickArray,
+  WhirlpoolContext,
+  WhirlpoolIx,
+  buildWhirlpoolClient,
+  swapQuoteByInputToken,
+  toTx,
+  twoHopSwapQuoteFromSwapQuotes,
+} from "../../../../src";
+import { IGNORE_CACHE } from "../../../../src/network/public/fetcher";
+import { TickSpacing } from "../../../utils";
+import { defaultConfirmOptions } from "../../../utils/const";
+import {
+  arrayTickIndexToTickIndex,
+  buildPosition,
+  setupSwapTest
+} from "../../../utils/swap-test-utils";
+import { buildTestAquariums, getDefaultAquarium } from "../../../utils/init-utils";
+import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
+
+describe("swap with fallback test", () => {
+  const provider = anchor.AnchorProvider.local(undefined, defaultConfirmOptions);
+
+  const program = anchor.workspace.Whirlpool;
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
+  const fetcher = ctx.fetcher;
+  const client = buildWhirlpoolClient(ctx);
+  const tickSpacing = TickSpacing.SixtyFour;
+  const slippageTolerance = Percentage.fromFraction(0, 100);
+
+  const SWAP_V1_DISCRIMINATOR = Buffer.from([0xf8, 0xc6, 0x9e, 0x91, 0xe1, 0x75, 0x87, 0xc8]);
+  const SWAP_V2_DISCRIMINATOR = Buffer.from([0x2b, 0x04, 0xed, 0x0b, 0x1a, 0xc9, 0x1e, 0x62]);
+
+  /**
+   * |-5632-----------|0------------c2-|5632---------c1-|11264-----------|
+   */
+  it("a->b, on rightmost quoter, ta1 = ta2", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 77 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+        buildPosition(
+          // b
+          { arrayIndex: 0, offsetIndex: 0 },
+          { arrayIndex: 0, offsetIndex: 87 },
+          tickSpacing,
+          new BN(1)
+        ),
+      ],
+    });
+
+    const taNeg11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -11264).publicKey;
+    const taNeg5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -5632).publicKey;
+    const ta0 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 0).publicKey;
+    const ta5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 5632).publicKey;
+    const ta11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 11264).publicKey;
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const tradeAmount = new BN(50_000_000);
+    const quoteNever = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Never,
+    );
+
+    const estimatedEndTickIndex = 4734; // arrayIndex: 0
+
+    assert.equal(quoteNever.aToB, true);
+    assert.equal(quoteNever.amountSpecifiedIsInput, true);
+    assert.equal(quoteNever.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteNever.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteNever.tickArray0.equals(ta5632));
+    assert.ok(quoteNever.tickArray1.equals(ta0));
+    assert.ok(quoteNever.tickArray2.equals(ta0)); // no fallback tick array
+    assert.ok(quoteNever.supplementalTickArrays === undefined);
+    
+    const quoteAlways = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Always,
+    );
+
+    assert.equal(quoteAlways.aToB, true);
+    assert.equal(quoteAlways.amountSpecifiedIsInput, true);
+    assert.equal(quoteAlways.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteAlways.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteAlways.tickArray0.equals(ta5632));
+    assert.ok(quoteAlways.tickArray1.equals(ta0));
+    assert.ok(quoteAlways.tickArray2.equals(ta11264)); // fallback
+    assert.ok(quoteAlways.supplementalTickArrays === undefined);
+
+    const quoteSituational = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Situational,
+    );
+
+    assert.equal(quoteSituational.aToB, true);
+    assert.equal(quoteSituational.amountSpecifiedIsInput, true);
+    assert.equal(quoteSituational.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteSituational.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteSituational.tickArray0.equals(ta5632));
+    assert.ok(quoteSituational.tickArray1.equals(ta0));
+    assert.ok(quoteSituational.tickArray2.equals(ta11264)); // fallback
+    assert.ok(quoteSituational.supplementalTickArrays === undefined);
+
+    // V1 instruction will be used because we can use tickArray2 as fallback
+    const tx = await whirlpool.swap(quoteAlways);
+    assert.ok(tx.compressIx(true).instructions.some((ix) => 
+      ix.programId.equals(ORCA_WHIRLPOOL_PROGRAM_ID) &&
+      ix.data.subarray(0, 8).equals(SWAP_V1_DISCRIMINATOR)
+    ));    
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quoteAlways)).buildAndExecute());
+  });
+
+  /**
+   * |-5632--------c2-|0---------------|5632---------c1-|11264-----------|
+   */
+  it("a->b, on rightmost quoter, ta1 != ta2 (no room for fallback)", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 77 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+        buildPosition(
+          // b
+          { arrayIndex: 0, offsetIndex: 0 },
+          { arrayIndex: 0, offsetIndex: 87 },
+          tickSpacing,
+          new BN(1)
+        ),
+      ],
+    });
+
+    const taNeg11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -11264).publicKey;
+    const taNeg5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -5632).publicKey;
+    const ta0 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 0).publicKey;
+    const ta5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 5632).publicKey;
+    const ta11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 11264).publicKey;
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const tradeAmount = new BN(120_000_000);
+    const quoteNever = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Never,
+    );
+
+    const estimatedEndTickIndex = -1323; // arrayIndex: -1
+
+    assert.equal(quoteNever.aToB, true);
+    assert.equal(quoteNever.amountSpecifiedIsInput, true);
+    assert.equal(quoteNever.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteNever.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteNever.tickArray0.equals(ta5632));
+    assert.ok(quoteNever.tickArray1.equals(ta0));
+    assert.ok(quoteNever.tickArray2.equals(taNeg5632)); // no fallback tick array
+    assert.ok(quoteNever.supplementalTickArrays === undefined);
+    
+    const quoteAlways = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Always,
+    );
+
+    assert.equal(quoteAlways.aToB, true);
+    assert.equal(quoteAlways.amountSpecifiedIsInput, true);
+    assert.equal(quoteAlways.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteAlways.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteAlways.tickArray0.equals(ta5632));
+    assert.ok(quoteAlways.tickArray1.equals(ta0));
+    assert.ok(quoteAlways.tickArray2.equals(taNeg5632)); // no fallback tick array
+    assert.ok(quoteAlways.supplementalTickArrays?.length === 1);
+    assert.ok(quoteAlways.supplementalTickArrays[0].equals(ta11264)); // fallback in supplemental
+
+    const quoteSituational = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Situational,
+    );
+
+    assert.equal(quoteSituational.aToB, true);
+    assert.equal(quoteSituational.amountSpecifiedIsInput, true);
+    assert.equal(quoteSituational.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteSituational.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteSituational.tickArray0.equals(ta5632));
+    assert.ok(quoteSituational.tickArray1.equals(ta0));
+    assert.ok(quoteSituational.tickArray2.equals(taNeg5632)); // no fallback tick array
+    assert.ok(quoteSituational.supplementalTickArrays?.length === 1);
+    assert.ok(quoteSituational.supplementalTickArrays[0].equals(ta11264)); // fallback in supplemental
+
+    // V2 instruction will be used to use supplemental tick arrays
+    const tx = await whirlpool.swap(quoteAlways);
+    assert.ok(tx.compressIx(true).instructions.some((ix) => 
+      ix.programId.equals(ORCA_WHIRLPOOL_PROGRAM_ID) &&
+      ix.data.subarray(0, 8).equals(SWAP_V2_DISCRIMINATOR)
+    ));
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quoteAlways)).buildAndExecute());
+  });
+
+  /**
+   * |-5632-----------|0------------c2-|5632-c1---------|11264-----------|
+   */
+  it("a->b, not on rightmost quoter, ta1 = ta2", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 44 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+        buildPosition(
+          // b
+          { arrayIndex: 0, offsetIndex: 0 },
+          { arrayIndex: 0, offsetIndex: 87 },
+          tickSpacing,
+          new BN(1)
+        ),
+      ],
+    });
+
+    const taNeg11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -11264).publicKey;
+    const taNeg5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -5632).publicKey;
+    const ta0 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 0).publicKey;
+    const ta5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 5632).publicKey;
+    const ta11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 11264).publicKey;
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const tradeAmount = new BN(50_000_000);
+    const quoteNever = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Never,
+    );
+
+    const estimatedEndTickIndex = 3135; // arrayIndex: 0
+
+    assert.equal(quoteNever.aToB, true);
+    assert.equal(quoteNever.amountSpecifiedIsInput, true);
+    assert.equal(quoteNever.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteNever.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteNever.tickArray0.equals(ta5632));
+    assert.ok(quoteNever.tickArray1.equals(ta0));
+    assert.ok(quoteNever.tickArray2.equals(ta0)); // no fallback tick array
+    assert.ok(quoteNever.supplementalTickArrays === undefined);
+    
+    const quoteAlways = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Always,
+    );
+
+    assert.equal(quoteAlways.aToB, true);
+    assert.equal(quoteAlways.amountSpecifiedIsInput, true);
+    assert.equal(quoteAlways.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteAlways.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteAlways.tickArray0.equals(ta5632));
+    assert.ok(quoteAlways.tickArray1.equals(ta0));
+    assert.ok(quoteAlways.tickArray2.equals(ta11264)); // fallback
+    assert.ok(quoteAlways.supplementalTickArrays === undefined);
+
+    const quoteSituational = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Situational,
+    );
+
+    // no fallback because it is not on the rightmost quoter
+    assert.equal(quoteSituational.aToB, true);
+    assert.equal(quoteSituational.amountSpecifiedIsInput, true);
+    assert.equal(quoteSituational.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteSituational.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteSituational.tickArray0.equals(ta5632));
+    assert.ok(quoteSituational.tickArray1.equals(ta0));
+    assert.ok(quoteSituational.tickArray2.equals(ta0)); // no fallback tick array
+    assert.ok(quoteSituational.supplementalTickArrays === undefined);
+  });
+
+  /**
+   * |-5632-----------|0-c1------------|5632---------c2-|11264-----------|
+   */
+  it("b->a, on leftmost quoter, ta1 = ta2", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 0, offsetIndex: 11 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+        buildPosition(
+          // b
+          { arrayIndex: 1, offsetIndex: 0 },
+          { arrayIndex: 1, offsetIndex: 87 },
+          tickSpacing,
+          new BN(1)
+        ),
+      ],
+    });
+
+    const taNeg11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -11264).publicKey;
+    const taNeg5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -5632).publicKey;
+    const ta0 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 0).publicKey;
+    const ta5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 5632).publicKey;
+    const ta11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 11264).publicKey;
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const tradeAmount = new BN(100_000_000);
+    const quoteNever = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Never,
+    );
+
+    const estimatedEndTickIndex = 7218; // arrayIndex: 1
+
+    assert.equal(quoteNever.aToB, false);
+    assert.equal(quoteNever.amountSpecifiedIsInput, true);
+    assert.equal(quoteNever.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteNever.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteNever.tickArray0.equals(ta0));
+    assert.ok(quoteNever.tickArray1.equals(ta5632));
+    assert.ok(quoteNever.tickArray2.equals(ta5632)); // no fallback tick array
+    assert.ok(quoteNever.supplementalTickArrays === undefined);
+    
+    const quoteAlways = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Always,
+    );
+
+    assert.equal(quoteAlways.aToB, false);
+    assert.equal(quoteAlways.amountSpecifiedIsInput, true);
+    assert.equal(quoteAlways.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteAlways.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteAlways.tickArray0.equals(ta0));
+    assert.ok(quoteAlways.tickArray1.equals(ta5632));
+    assert.ok(quoteAlways.tickArray2.equals(taNeg5632)); // fallback
+    assert.ok(quoteAlways.supplementalTickArrays === undefined);
+
+    const quoteSituational = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Situational,
+    );
+
+    assert.equal(quoteSituational.aToB, false);
+    assert.equal(quoteSituational.amountSpecifiedIsInput, true);
+    assert.equal(quoteSituational.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteSituational.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteSituational.tickArray0.equals(ta0));
+    assert.ok(quoteSituational.tickArray1.equals(ta5632));
+    assert.ok(quoteSituational.tickArray2.equals(taNeg5632)); // fallback
+    assert.ok(quoteSituational.supplementalTickArrays === undefined);
+
+    // V1 instruction will be used because we can use tickArray2 as fallback
+    const tx = await whirlpool.swap(quoteAlways);
+    assert.ok(tx.compressIx(true).instructions.some((ix) => 
+      ix.programId.equals(ORCA_WHIRLPOOL_PROGRAM_ID) &&
+      ix.data.subarray(0, 8).equals(SWAP_V1_DISCRIMINATOR)
+    ));
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quoteAlways)).buildAndExecute());
+  });
+
+  /**
+   * |-5632-----------|0-c1------------|5632------------|11264---c2------|
+   */
+  it("b->a, on leftmost quoter, ta1 != ta2 (no room for fallback)", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 0, offsetIndex: 11 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+        buildPosition(
+          // b
+          { arrayIndex: 1, offsetIndex: 0 },
+          { arrayIndex: 1, offsetIndex: 87 },
+          tickSpacing,
+          new BN(1)
+        ),
+      ],
+    });
+
+    const taNeg11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -11264).publicKey;
+    const taNeg5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -5632).publicKey;
+    const ta0 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 0).publicKey;
+    const ta5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 5632).publicKey;
+    const ta11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 11264).publicKey;
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const tradeAmount = new BN(200_000_000);
+    const quoteNever = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Never,
+    );
+
+    const estimatedEndTickIndex = 12124; // arrayIndex: 2
+
+    assert.equal(quoteNever.aToB, false);
+    assert.equal(quoteNever.amountSpecifiedIsInput, true);
+    assert.equal(quoteNever.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteNever.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteNever.tickArray0.equals(ta0));
+    assert.ok(quoteNever.tickArray1.equals(ta5632));
+    assert.ok(quoteNever.tickArray2.equals(ta11264)); // no fallback tick array
+    assert.ok(quoteNever.supplementalTickArrays === undefined);
+    
+    const quoteAlways = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Always,
+    );
+
+    assert.equal(quoteAlways.aToB, false);
+    assert.equal(quoteAlways.amountSpecifiedIsInput, true);
+    assert.equal(quoteAlways.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteAlways.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteAlways.tickArray0.equals(ta0));
+    assert.ok(quoteAlways.tickArray1.equals(ta5632));
+    assert.ok(quoteAlways.tickArray2.equals(ta11264)); // no fallback tick array
+    assert.ok(quoteAlways.supplementalTickArrays?.length === 1);
+    assert.ok(quoteAlways.supplementalTickArrays[0].equals(taNeg5632)); // fallback in supplemental
+
+    const quoteSituational = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Situational,
+    );
+
+    assert.equal(quoteSituational.aToB, false);
+    assert.equal(quoteSituational.amountSpecifiedIsInput, true);
+    assert.equal(quoteSituational.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteSituational.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteSituational.tickArray0.equals(ta0));
+    assert.ok(quoteSituational.tickArray1.equals(ta5632));
+    assert.ok(quoteSituational.tickArray2.equals(ta11264)); // no fallback tick array
+    assert.ok(quoteSituational.supplementalTickArrays?.length === 1);
+    assert.ok(quoteSituational.supplementalTickArrays[0].equals(taNeg5632)); // fallback in supplemental
+
+    // V2 instruction will be used to use supplemental tick arrays
+    const tx = await whirlpool.swap(quoteAlways);
+    assert.ok(tx.compressIx(true).instructions.some((ix) => 
+      ix.programId.equals(ORCA_WHIRLPOOL_PROGRAM_ID) &&
+      ix.data.subarray(0, 8).equals(SWAP_V2_DISCRIMINATOR)
+    ));
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quoteAlways)).buildAndExecute());
+  });
+
+
+  /**
+   * |-5632-----------|0-------c1------|5632---------c2-|11264-----------|
+   */
+  it("b->a, not on leftmost quoter, ta1 = ta2", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 0, offsetIndex: 44 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+        buildPosition(
+          // b
+          { arrayIndex: 1, offsetIndex: 0 },
+          { arrayIndex: 1, offsetIndex: 87 },
+          tickSpacing,
+          new BN(1)
+        ),
+      ],
+    });
+
+    const taNeg11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -11264).publicKey;
+    const taNeg5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -5632).publicKey;
+    const ta0 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 0).publicKey;
+    const ta5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 5632).publicKey;
+    const ta11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 11264).publicKey;
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const tradeAmount = new BN(100_000_000);
+    const quoteNever = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Never,
+    );
+
+    const estimatedEndTickIndex = 8765; // arrayIndex: 1
+
+    assert.equal(quoteNever.aToB, false);
+    assert.equal(quoteNever.amountSpecifiedIsInput, true);
+    assert.equal(quoteNever.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteNever.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteNever.tickArray0.equals(ta0));
+    assert.ok(quoteNever.tickArray1.equals(ta5632));
+    assert.ok(quoteNever.tickArray2.equals(ta5632)); // no fallback tick array
+    assert.ok(quoteNever.supplementalTickArrays === undefined);
+    
+    const quoteAlways = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Always,
+    );
+
+    assert.equal(quoteAlways.aToB, false);
+    assert.equal(quoteAlways.amountSpecifiedIsInput, true);
+    assert.equal(quoteAlways.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteAlways.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteAlways.tickArray0.equals(ta0));
+    assert.ok(quoteAlways.tickArray1.equals(ta5632));
+    assert.ok(quoteAlways.tickArray2.equals(taNeg5632)); // fallback
+    assert.ok(quoteAlways.supplementalTickArrays === undefined);
+
+    const quoteSituational = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Situational,
+    );
+
+    // no fallback because it is not on the leftmost quoter
+    assert.equal(quoteSituational.aToB, false);
+    assert.equal(quoteSituational.amountSpecifiedIsInput, true);
+    assert.equal(quoteSituational.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteSituational.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteSituational.tickArray0.equals(ta0));
+    assert.ok(quoteSituational.tickArray1.equals(ta5632));
+    assert.ok(quoteSituational.tickArray2.equals(ta5632)); // no fallback tick array
+    assert.ok(quoteSituational.supplementalTickArrays === undefined);
+  });
+
+  it("twoHopSwapQuoteFromSwapQuotes", async () => {
+    const tickSpacing64 = 64;
+    const aToB = false;
+
+    const aqConfig = getDefaultAquarium();
+
+    // Add a third token and account and a second pool
+    aqConfig.initFeeTierParams = [{ tickSpacing: tickSpacing64 }];
+    aqConfig.initMintParams.push({});
+    aqConfig.initTokenAccParams.push({ mintIndex: 2 });
+    aqConfig.initPoolParams = [
+      { mintIndices: [0, 1], tickSpacing: tickSpacing64, initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(2816) },
+      { mintIndices: [1, 2], tickSpacing: tickSpacing64, initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(2816) },
+    ];
+
+    // Add tick arrays and positions
+    aqConfig.initTickArrayRangeParams.push({
+      poolIndex: 0,
+      startTickIndex: -444928,
+      arrayCount: 1,
+      aToB,
+    });
+    aqConfig.initTickArrayRangeParams.push({
+      poolIndex: 0,
+      startTickIndex: 439296,
+      arrayCount: 1,
+      aToB,
+    });
+    aqConfig.initTickArrayRangeParams.push({
+      poolIndex: 1,
+      startTickIndex: -444928,
+      arrayCount: 1,
+      aToB,
+    });
+    aqConfig.initTickArrayRangeParams.push({
+      poolIndex: 1,
+      startTickIndex: 439296,
+      arrayCount: 1,
+      aToB,
+    });
+
+    // pool1(b(2) -> a(1)) --> pool0(b(1) -> a(0)) (so pool0 has smaller liquidity)
+    aqConfig.initPositionParams.push({ poolIndex: 0, fundParams: [
+      {
+        liquidityAmount: new anchor.BN(4_100_000),
+        tickLowerIndex: -443584,
+        tickUpperIndex: 443584,
+      },
+    ]});
+    aqConfig.initPositionParams.push({ poolIndex: 1, fundParams: [
+      {
+        liquidityAmount: new anchor.BN(10_000_000),
+        tickLowerIndex: -443584,
+        tickUpperIndex: 443584,
+      },
+    ]});
+    const aquarium = (await buildTestAquariums(ctx, [aqConfig]))[0];
+
+    const poolInit0 = aquarium.pools[0];
+    const poolInit1 = aquarium.pools[1];
+    const pool0 = await client.getPool(poolInit0.whirlpoolPda.publicKey, IGNORE_CACHE);
+    const pool1 = await client.getPool(poolInit1.whirlpoolPda.publicKey, IGNORE_CACHE);
+
+    // quote1: in 8731861 out 3740488 end tick 14080
+    // quote0: in 3740488 out 1571989 end tick 14462
+
+    const quote1 = await swapQuoteByInputToken(
+      pool1,
+      pool1.getData().tokenMintB,
+      new BN(8731861),
+      Percentage.fromFraction(0, 100),
+      ORCA_WHIRLPOOL_PROGRAM_ID,
+      ctx.fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Always,
+    );
+
+    const quote0 = await swapQuoteByInputToken(
+      pool0,
+      pool0.getData().tokenMintB,
+      quote1.estimatedAmountOut,
+      Percentage.fromFraction(0, 100),
+      ORCA_WHIRLPOOL_PROGRAM_ID,
+      ctx.fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Always,
+    );
+
+    const pool0TaNeg5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, pool0.getAddress(), -5632).publicKey;
+    const pool0Ta0 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, pool0.getAddress(), 0).publicKey;
+    const pool0Ta5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, pool0.getAddress(), 5632).publicKey;
+    const pool0Ta11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, pool0.getAddress(), 11264).publicKey;
+
+    const pool1TaNeg5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, pool1.getAddress(), -5632).publicKey;
+    const pool1Ta0 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, pool1.getAddress(), 0).publicKey;
+    const pool1Ta5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, pool1.getAddress(), 5632).publicKey;
+    const pool1Ta11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, pool1.getAddress(), 11264).publicKey;
+
+    assert.ok(quote1.tickArray0.equals(pool1Ta0));
+    assert.ok(quote1.tickArray1.equals(pool1Ta5632));
+    assert.ok(quote1.tickArray2.equals(pool1Ta11264)); // no room for fallback
+    assert.ok(quote1.supplementalTickArrays?.length === 1);
+    assert.ok(quote1.supplementalTickArrays[0].equals(pool1TaNeg5632)); // fallback in supplemental
+
+    assert.ok(quote0.tickArray0.equals(pool0Ta0));
+    assert.ok(quote0.tickArray1.equals(pool0Ta5632));
+    assert.ok(quote0.tickArray2.equals(pool0Ta11264)); // no room for fallback
+    assert.ok(quote0.supplementalTickArrays?.length === 1);
+    assert.ok(quote0.supplementalTickArrays[0].equals(pool0TaNeg5632)); // fallback in supplemental
+
+    const twoHopQuote = twoHopSwapQuoteFromSwapQuotes(quote1, quote0);
+
+    // verify if the twoHopQuote has supplemental tick arrays
+    assert.ok(twoHopQuote.supplementalTickArraysOne?.length === 1);
+    assert.ok(twoHopQuote.supplementalTickArraysOne[0].equals(pool1TaNeg5632));
+    assert.ok(twoHopQuote.supplementalTickArraysTwo?.length === 1);
+    assert.ok(twoHopQuote.supplementalTickArraysTwo[0].equals(pool0TaNeg5632));
+
+    const params: TwoHopSwapV2Params = {
+      ...twoHopQuote,
+      tokenAuthority: ctx.wallet.publicKey,
+      whirlpoolOne: pool1.getAddress(),
+      whirlpoolTwo: pool0.getAddress(),
+      oracleOne: PDAUtil.getOracle(ctx.program.programId, pool1.getAddress()).publicKey,
+      oracleTwo: PDAUtil.getOracle(ctx.program.programId, pool0.getAddress()).publicKey,
+      tokenProgramInput: TOKEN_PROGRAM_ID,
+      tokenProgramIntermediate: TOKEN_PROGRAM_ID,
+      tokenProgramOutput: TOKEN_PROGRAM_ID,
+      tokenMintInput: pool1.getData().tokenMintB,
+      tokenMintIntermediate: pool1.getData().tokenMintA,
+      tokenMintOutput: pool0.getData().tokenMintA,
+      tokenVaultOneInput: pool1.getData().tokenVaultB,
+      tokenVaultOneIntermediate: pool1.getData().tokenVaultA,
+      tokenVaultTwoIntermediate: pool0.getData().tokenVaultB,
+      tokenVaultTwoOutput: pool0.getData().tokenVaultA,
+      tokenOwnerAccountInput: aquarium.tokenAccounts[2].account,
+      tokenOwnerAccountOutput: aquarium.tokenAccounts[0].account,
+    };
+
+    // verify if the params has supplemental tick arrays
+    assert.ok(params.supplementalTickArraysOne?.length === 1);
+    assert.ok(params.supplementalTickArraysOne[0].equals(pool1TaNeg5632));
+    assert.ok(params.supplementalTickArraysTwo?.length === 1);
+    assert.ok(params.supplementalTickArraysTwo[0].equals(pool0TaNeg5632));
+
+    // execute twoHopSwapV2 with supplemental tick arrays
+    assert.ok((await pool1.refreshData()).tickCurrentIndex !== quote1.estimatedEndTickIndex);
+    assert.ok((await pool0.refreshData()).tickCurrentIndex !== quote0.estimatedEndTickIndex);
+    const tx = toTx(ctx, WhirlpoolIx.twoHopSwapV2Ix(ctx.program, params));
+    await assert.doesNotReject(async () => await tx.buildAndExecute());
+    assert.ok((await pool1.refreshData()).tickCurrentIndex === quote1.estimatedEndTickIndex);
+    assert.ok((await pool0.refreshData()).tickCurrentIndex === quote0.estimatedEndTickIndex);
+  });
+});

--- a/sdk/tests/sdk/whirlpools/swap/v2/swap-array.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/v2/swap-array.test.ts
@@ -113,7 +113,7 @@ describe("swap arrays test (v2)", () => {
           adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
         );
         assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-        assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+        assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
       });
 
       /**
@@ -139,21 +139,155 @@ describe("swap arrays test (v2)", () => {
           ],
         });
 
-        // estimatedEndTickIndex is 4091 (arrayIndex: 0 (not initialized))
+        // SparseSwap makes it possible to execute this swap.
+
         const whirlpoolData = await whirlpool.refreshData();
-        const expectedError = "Swap input value traversed too many arrays.";
-        await assert.rejects(
-          swapQuoteByInputToken(
-            whirlpool,
-            whirlpoolData.tokenMintA,
-            new BN(40_000_000),
-            slippageTolerance,
-            ctx.program.programId,
-            fetcher,
-            IGNORE_CACHE
-          ),
-          (err: Error) => err.message.indexOf(expectedError) != -1
+        const tradeAmount = new BN(40_000_000);
+        const quote = await swapQuoteByInputToken(
+          whirlpool,
+          whirlpoolData.tokenMintA,
+          tradeAmount,
+          slippageTolerance,
+          ctx.program.programId,
+          fetcher,
+          IGNORE_CACHE
         );
+
+        // Verify with an actual swap.
+        // estimatedEndTickIndex is 4091 (arrayIndex: 0 (not initialized))
+        assert.equal(quote.aToB, true);
+        assert.equal(quote.amountSpecifiedIsInput, true);
+        assert.equal(
+          quote.sqrtPriceLimit.toString(),
+          SwapUtils.getDefaultSqrtPriceLimit(true).toString()
+        );
+
+        assert.equal(quote.estimatedEndTickIndex, 4091);
+        assert.equal(
+          quote.otherAmountThreshold.toString(),
+          adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
+        );
+        assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
+
+        await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+        const updatedWhirlpoolData = await whirlpool.refreshData();
+        assert.equal(updatedWhirlpoolData.tickCurrentIndex, quote.estimatedEndTickIndex);
+      });
+
+      /**
+       * |xxxxxxxxxxxxxc2xx|xxxxxxxxxxxxxxxxx|------c1-----------|
+       */
+      it("3 sequential arrays, 2nd and 3rd array not initialized, a->b", async () => {
+        const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 44 }, tickSpacing);
+        const whirlpool = await setupSwapTestV2({
+          ctx,
+          ...tokenTraits,
+          client,
+          tickSpacing,
+          initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+          initArrayStartTicks: [-11264, 5632, 11264],
+          fundedPositions: [
+            buildPosition(
+              // a
+              { arrayIndex: -2, offsetIndex: 44 },
+              { arrayIndex: 2, offsetIndex: 44 },
+              tickSpacing,
+              new BN(250_000_000)
+            ),
+          ],
+        });
+
+        // SparseSwap makes it possible to execute this swap.
+
+        const whirlpoolData = await whirlpool.refreshData();
+        const tradeAmount = new BN(150_000_000);
+        const quote = await swapQuoteByInputToken(
+          whirlpool,
+          whirlpoolData.tokenMintA,
+          tradeAmount,
+          slippageTolerance,
+          ctx.program.programId,
+          fetcher,
+          IGNORE_CACHE
+        );
+
+        // Verify with an actual swap.
+        // estimatedEndTickIndex is -4522 (arrayIndex: -1 (not initialized))
+        assert.equal(quote.aToB, true);
+        assert.equal(quote.amountSpecifiedIsInput, true);
+        assert.equal(
+          quote.sqrtPriceLimit.toString(),
+          SwapUtils.getDefaultSqrtPriceLimit(true).toString()
+        );
+
+        assert.equal(quote.estimatedEndTickIndex, -4522);
+        assert.equal(
+          quote.otherAmountThreshold.toString(),
+          adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
+        );
+        assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
+
+        await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+        const updatedWhirlpoolData = await whirlpool.refreshData();
+        assert.equal(updatedWhirlpoolData.tickCurrentIndex, quote.estimatedEndTickIndex);
+      });
+
+      /**
+       * |xxxxxxxxxxxxxc2xx|xxxxxxxxxxxxxxxxx|xxxxxxc1xxxxxxxxxxx|
+       */
+      it("3 sequential arrays, all array not initialized, a->b", async () => {
+        const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 44 }, tickSpacing);
+        const whirlpool = await setupSwapTestV2({
+          ctx,
+          ...tokenTraits,
+          client,
+          tickSpacing,
+          initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+          initArrayStartTicks: [-11264, 11264],
+          fundedPositions: [
+            buildPosition(
+              // a
+              { arrayIndex: -2, offsetIndex: 44 },
+              { arrayIndex: 2, offsetIndex: 44 },
+              tickSpacing,
+              new BN(250_000_000)
+            ),
+          ],
+        });
+
+        // SparseSwap makes it possible to execute this swap.
+
+        const whirlpoolData = await whirlpool.refreshData();
+        const tradeAmount = new BN(150_000_000);
+        const quote = await swapQuoteByInputToken(
+          whirlpool,
+          whirlpoolData.tokenMintA,
+          tradeAmount,
+          slippageTolerance,
+          ctx.program.programId,
+          fetcher,
+          IGNORE_CACHE
+        );
+
+        // Verify with an actual swap.
+        // estimatedEndTickIndex is -4522 (arrayIndex: -1 (not initialized))
+        assert.equal(quote.aToB, true);
+        assert.equal(quote.amountSpecifiedIsInput, true);
+        assert.equal(
+          quote.sqrtPriceLimit.toString(),
+          SwapUtils.getDefaultSqrtPriceLimit(true).toString()
+        );
+
+        assert.equal(quote.estimatedEndTickIndex, -4522);
+        assert.equal(
+          quote.otherAmountThreshold.toString(),
+          adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
+        );
+        assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
+
+        await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+        const updatedWhirlpoolData = await whirlpool.refreshData();
+        assert.equal(updatedWhirlpoolData.tickCurrentIndex, quote.estimatedEndTickIndex);
       });
 
       /**
@@ -204,7 +338,7 @@ describe("swap arrays test (v2)", () => {
           adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
         );
         assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-        assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+        assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
       });
 
       /**
@@ -230,21 +364,155 @@ describe("swap arrays test (v2)", () => {
           ],
         });
 
-        // estimatedEndTickIndex is 556 (arrayIndex: 0 (not initialized))
+        // SparseSwap makes it possible to execute this swap.
+
         const whirlpoolData = await whirlpool.refreshData();
-        const expectedError = "Swap input value traversed too many arrays.";
-        await assert.rejects(
-          swapQuoteByInputToken(
-            whirlpool,
-            whirlpoolData.tokenMintB,
-            new BN(40_000_000),
-            slippageTolerance,
-            ctx.program.programId,
-            fetcher,
-            IGNORE_CACHE
-          ),
-          (err: Error) => err.message.indexOf(expectedError) != -1
+        const tradeAmount = new BN(40_000_000);
+        const quote = await swapQuoteByInputToken(
+          whirlpool,
+          whirlpoolData.tokenMintB,
+          tradeAmount,
+          slippageTolerance,
+          ctx.program.programId,
+          fetcher,
+          IGNORE_CACHE
         );
+
+        // Verify with an actual swap.
+        // estimatedEndTickIndex is 556 (arrayIndex: 0 (not initialized))
+        assert.equal(quote.aToB, false);
+        assert.equal(quote.amountSpecifiedIsInput, true);
+        assert.equal(
+          quote.sqrtPriceLimit.toString(),
+          SwapUtils.getDefaultSqrtPriceLimit(false).toString()
+        );
+
+        assert.equal(quote.estimatedEndTickIndex, 556);
+        assert.equal(
+          quote.otherAmountThreshold.toString(),
+          adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
+        );
+        assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
+
+        await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+        const updatedWhirlpoolData = await whirlpool.refreshData();
+        assert.equal(updatedWhirlpoolData.tickCurrentIndex, quote.estimatedEndTickIndex);
+      });
+
+      /**
+       * |-------------c1-----|xxxxxxxxxxxxxxxxx|xxc2xxxxxxxxxxxxx|
+       */
+      it("3 sequential arrays, 2nd and 3rd array not initialized, b->a", async () => {
+        const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -1, offsetIndex: 44 }, tickSpacing);
+        const whirlpool = await setupSwapTestV2({
+          ctx,
+          ...tokenTraits,
+          client,
+          tickSpacing,
+          initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+          initArrayStartTicks: [-11264, -5632, 11264],
+          fundedPositions: [
+            buildPosition(
+              // a
+              { arrayIndex: -2, offsetIndex: 44 },
+              { arrayIndex: 2, offsetIndex: 44 },
+              tickSpacing,
+              new BN(250_000_000)
+            ),
+          ],
+        });
+
+        // SparseSwap makes it possible to execute this swap.
+
+        const whirlpoolData = await whirlpool.refreshData();
+        const tradeAmount = new BN(150_000_000);
+        const quote = await swapQuoteByInputToken(
+          whirlpool,
+          whirlpoolData.tokenMintB,
+          tradeAmount,
+          slippageTolerance,
+          ctx.program.programId,
+          fetcher,
+          IGNORE_CACHE
+        );
+
+        // Verify with an actual swap.
+        // estimatedEndTickIndex is 7662 (arrayIndex: 1 (not initialized))
+        assert.equal(quote.aToB, false);
+        assert.equal(quote.amountSpecifiedIsInput, true);
+        assert.equal(
+          quote.sqrtPriceLimit.toString(),
+          SwapUtils.getDefaultSqrtPriceLimit(false).toString()
+        );
+
+        assert.equal(quote.estimatedEndTickIndex, 7662);
+        assert.equal(
+          quote.otherAmountThreshold.toString(),
+          adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
+        );
+        assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
+
+        await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+        const updatedWhirlpoolData = await whirlpool.refreshData();
+        assert.equal(updatedWhirlpoolData.tickCurrentIndex, quote.estimatedEndTickIndex);
+      });
+
+      /**
+       * |xxxxxxxxxxxxxc1xxxxx|xxxxxxxxxxxxxxxxx|xxc2xxxxxxxxxxxxx|
+       */
+      it("3 sequential arrays, all array not initialized, b->a", async () => {
+        const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -1, offsetIndex: 44 }, tickSpacing);
+        const whirlpool = await setupSwapTestV2({
+          ctx,
+          ...tokenTraits,
+          client,
+          tickSpacing,
+          initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+          initArrayStartTicks: [-11264, 11264],
+          fundedPositions: [
+            buildPosition(
+              // a
+              { arrayIndex: -2, offsetIndex: 44 },
+              { arrayIndex: 2, offsetIndex: 44 },
+              tickSpacing,
+              new BN(250_000_000)
+            ),
+          ],
+        });
+
+        // SparseSwap makes it possible to execute this swap.
+
+        const whirlpoolData = await whirlpool.refreshData();
+        const tradeAmount = new BN(150_000_000);
+        const quote = await swapQuoteByInputToken(
+          whirlpool,
+          whirlpoolData.tokenMintB,
+          tradeAmount,
+          slippageTolerance,
+          ctx.program.programId,
+          fetcher,
+          IGNORE_CACHE
+        );
+
+        // Verify with an actual swap.
+        // estimatedEndTickIndex is 7662 (arrayIndex: 1 (not initialized))
+        assert.equal(quote.aToB, false);
+        assert.equal(quote.amountSpecifiedIsInput, true);
+        assert.equal(
+          quote.sqrtPriceLimit.toString(),
+          SwapUtils.getDefaultSqrtPriceLimit(false).toString()
+        );
+
+        assert.equal(quote.estimatedEndTickIndex, 7662);
+        assert.equal(
+          quote.otherAmountThreshold.toString(),
+          adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
+        );
+        assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
+
+        await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+        const updatedWhirlpoolData = await whirlpool.refreshData();
+        assert.equal(updatedWhirlpoolData.tickCurrentIndex, quote.estimatedEndTickIndex);
       });
 
       /**
@@ -295,7 +563,7 @@ describe("swap arrays test (v2)", () => {
           adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
         );
         assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-        assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+        assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
       });
 
       /**
@@ -346,7 +614,7 @@ describe("swap arrays test (v2)", () => {
           adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
         );
         assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-        assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+        assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
       });
 
       /**
@@ -741,7 +1009,7 @@ describe("swap arrays test (v2)", () => {
           adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
         );
         assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-        assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+        assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
       });
 
       /**
@@ -803,7 +1071,7 @@ describe("swap arrays test (v2)", () => {
           adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
         );
         assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-        assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+        assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
       });
 
       /**
@@ -840,7 +1108,8 @@ describe("swap arrays test (v2)", () => {
           whirlpool.getAddress()
         );
 
-        await assert.rejects(
+        // SparseSwap makes it possible to execute this swap.
+        await assert.doesNotReject(
           whirlpool.swap({
             amount: tradeAmount,
             amountSpecifiedIsInput: true,
@@ -848,13 +1117,9 @@ describe("swap arrays test (v2)", () => {
             otherAmountThreshold: SwapUtils.getDefaultOtherAmountThreshold(true),
             sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
             tickArray0: tickArrays[0],
-            tickArray1: tickArrays[1],
-            tickArray2: tickArrays[2],
-          }),
-          (err: Error) => {
-            const uninitializedArrays = [tickArrays[1].toBase58(), tickArrays[2].toBase58()].join(", ");
-            return err.message.indexOf(`TickArray addresses - [${uninitializedArrays}] need to be initialized.`) >= 0;
-          }
+            tickArray1: tickArrays[1], // uninitialized TickArray is acceptable
+            tickArray2: tickArrays[2], // uninitialized TickArray is acceptable
+          })
         );
       });
 
@@ -892,7 +1157,8 @@ describe("swap arrays test (v2)", () => {
           whirlpool.getAddress()
         );
 
-        await assert.rejects(
+        // SparseSwap makes it possible to execute this swap.
+        await assert.doesNotReject(
           whirlpool.swap({
             amount: tradeAmount,
             amountSpecifiedIsInput: true,
@@ -900,13 +1166,9 @@ describe("swap arrays test (v2)", () => {
             otherAmountThreshold: SwapUtils.getDefaultOtherAmountThreshold(true),
             sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
             tickArray0: tickArrays[0],
-            tickArray1: tickArrays[1],
-            tickArray2: tickArrays[2],
-          }),
-          (err: Error) => {
-            const uninitializedArrays = [tickArrays[1].toBase58(), tickArrays[2].toBase58()].join(", ");
-            return err.message.indexOf(`TickArray addresses - [${uninitializedArrays}] need to be initialized.`) >= 0;
-          }
+            tickArray1: tickArrays[1], // uninitialized TickArray is acceptable
+            tickArray2: tickArrays[2], // uninitialized TickArray is acceptable
+          })
         );
       });
     });

--- a/sdk/tests/sdk/whirlpools/utils/swap-utils.test.ts
+++ b/sdk/tests/sdk/whirlpools/utils/swap-utils.test.ts
@@ -1,10 +1,12 @@
 import * as anchor from "@coral-xyz/anchor";
 import { Keypair } from "@solana/web3.js";
 import * as assert from "assert";
-import { PDAUtil, SwapDirection, SwapUtils, TICK_ARRAY_SIZE } from "../../../../src";
+import { ORCA_WHIRLPOOLS_CONFIG, ORCA_WHIRLPOOL_PROGRAM_ID, PDAUtil, SwapDirection, SwapUtils, TICK_ARRAY_SIZE, TickArray, TickArrayData, TickData } from "../../../../src";
 import { WhirlpoolContext } from "../../../../src/context";
 import { defaultConfirmOptions } from "../../../utils/const";
 import { testWhirlpoolData } from "../../../utils/testDataTypes";
+import { BN } from "bn.js";
+import { TickSpacing } from "../../../utils";
 
 describe("SwapUtils tests", () => {
   const provider = anchor.AnchorProvider.local(undefined, defaultConfirmOptions);
@@ -220,4 +222,226 @@ describe("SwapUtils tests", () => {
     });
   });
 
+  describe("interpolateUninitializedTickArrays", () => {
+    const whirlpoolAddress = Keypair.generate().publicKey;
+    const tickSpacing = TickSpacing.Standard;
+    const initializedTick: TickData = {
+      initialized: true,
+      liquidityNet: new BN(100),
+      liquidityGross: new BN(100),
+      feeGrowthOutsideA: new BN(100),
+      feeGrowthOutsideB: new BN(100),
+      rewardGrowthsOutside: [new BN(100), new BN(100), new BN(100)],
+    };
+    const initializedTickArrayData: TickArrayData = {
+      startTickIndex: 0,
+      ticks: Array(TICK_ARRAY_SIZE).fill(initializedTick),
+      whirlpool: whirlpoolAddress,
+    };
+
+    it("no uninitialized tick arrays", async () => {
+      const tickArrays: TickArray[] = [
+        { address: whirlpoolAddress, startTickIndex: tickSpacing * TICK_ARRAY_SIZE * 0, data: initializedTickArrayData },
+        { address: whirlpoolAddress, startTickIndex: tickSpacing * TICK_ARRAY_SIZE * 1, data: initializedTickArrayData },
+        { address: whirlpoolAddress, startTickIndex: tickSpacing * TICK_ARRAY_SIZE * 2, data: initializedTickArrayData },
+      ];
+      const result = SwapUtils.interpolateUninitializedTickArrays(whirlpoolAddress, tickArrays);
+
+      // no change
+      assert.ok(result[0].data === initializedTickArrayData);
+      assert.ok(result[1].data === initializedTickArrayData);
+      assert.ok(result[2].data === initializedTickArrayData);
+    });
+
+    it("1 uninitialized tick arrays", async () => {
+      const tickArrays: TickArray[] = [
+        { address: whirlpoolAddress, startTickIndex: tickSpacing * TICK_ARRAY_SIZE * 0, data: initializedTickArrayData },
+        { address: whirlpoolAddress, startTickIndex: tickSpacing * TICK_ARRAY_SIZE * 1, data: null },
+        { address: whirlpoolAddress, startTickIndex: tickSpacing * TICK_ARRAY_SIZE * 2, data: initializedTickArrayData },
+      ];
+      const result = SwapUtils.interpolateUninitializedTickArrays(whirlpoolAddress, tickArrays);
+
+      // no change
+      assert.ok(result[0].data === initializedTickArrayData);
+      assert.ok(result[1].data !== null && result[1].data.startTickIndex === result[1].startTickIndex);
+      for (let i = 0; i < TICK_ARRAY_SIZE; i++) {
+        const tick = result[1].data.ticks[i];
+        assert.ok(tick.initialized === false);
+        assert.ok(tick.liquidityNet.eqn(0));
+        assert.ok(tick.liquidityGross.eqn(0));
+        assert.ok(tick.feeGrowthOutsideA.eqn(0));
+        assert.ok(tick.feeGrowthOutsideB.eqn(0));
+        assert.ok(tick.rewardGrowthsOutside[0].eqn(0));
+        assert.ok(tick.rewardGrowthsOutside[1].eqn(0));
+        assert.ok(tick.rewardGrowthsOutside[2].eqn(0));
+      }
+      assert.ok(result[2].data === initializedTickArrayData);
+    });
+
+    it("3 uninitialized tick arrays", async () => {
+      const tickArrays: TickArray[] = [
+        { address: whirlpoolAddress, startTickIndex: tickSpacing * TICK_ARRAY_SIZE * 0, data: null },
+        { address: whirlpoolAddress, startTickIndex: tickSpacing * TICK_ARRAY_SIZE * 1, data: null },
+        { address: whirlpoolAddress, startTickIndex: tickSpacing * TICK_ARRAY_SIZE * 2, data: null },
+      ];
+      const result = SwapUtils.interpolateUninitializedTickArrays(whirlpoolAddress, tickArrays);
+
+      for (let i = 0; i < 3; i++) {
+        assert.ok(result[i].data !== null && result[i].data!.startTickIndex === result[i].startTickIndex);
+        for (let j = 0; j < TICK_ARRAY_SIZE; j++) {
+          const tick = result[i].data!.ticks[j];
+          assert.ok(tick.initialized === false);
+          assert.ok(tick.liquidityNet.eqn(0));
+          assert.ok(tick.liquidityGross.eqn(0));
+          assert.ok(tick.feeGrowthOutsideA.eqn(0));
+          assert.ok(tick.feeGrowthOutsideB.eqn(0));
+          assert.ok(tick.rewardGrowthsOutside[0].eqn(0));
+          assert.ok(tick.rewardGrowthsOutside[1].eqn(0));
+          assert.ok(tick.rewardGrowthsOutside[2].eqn(0));
+        }
+      }
+    });
+  });
+
+  describe("getFallbackTickArrayPublicKey", () => {
+    const whirlpoolAddress = Keypair.generate().publicKey;
+  
+    it("ts = 64, a --> b, normal range", async () => {
+      const tickSpacing = 64;
+      const aToB = true;
+
+      // [ta2: -11264 ][ta1: -5632  ][ta0: 0      ][fallback: 5632 ]
+      const tickArrays = await SwapUtils.getTickArrays(128, tickSpacing, aToB, ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolAddress, ctx.fetcher);
+      assert.equal(tickArrays[0].startTickIndex, 0);
+      assert.equal(tickArrays[1].startTickIndex, -5632);
+      assert.equal(tickArrays[2].startTickIndex, -11264);
+
+      const result = SwapUtils.getFallbackTickArrayPublicKey(tickArrays, tickSpacing, aToB, ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolAddress);
+
+      const expected = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolAddress, 5632);
+      assert.ok(result?.toBase58() === expected.publicKey.toBase58());
+    });
+
+    it("ts = 64, a --> b, right most", async () => {
+      const tickSpacing = 64;
+      const aToB = true;
+
+      // [ta2: 428032 ][ta1: 433664 ][ta0: 439296 ] (no fallback)
+      const tickArrays = await SwapUtils.getTickArrays(439296+128, tickSpacing, aToB, ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolAddress, ctx.fetcher);
+      assert.equal(tickArrays[0].startTickIndex, 439296);
+      assert.equal(tickArrays[1].startTickIndex, 433664);
+      assert.equal(tickArrays[2].startTickIndex, 428032);
+
+      const result = SwapUtils.getFallbackTickArrayPublicKey(tickArrays, tickSpacing, aToB, ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolAddress);
+
+      assert.ok(result === undefined);
+    });
+
+    it("ts = 64, a <-- b, normal range", async () => {
+      const tickSpacing = 64;
+      const aToB = false;
+
+      // [fallback: -5632 ][ta0: 0      ][ta1: 5632   ][ta2: 11264  ]
+      const tickArrays = await SwapUtils.getTickArrays(128, tickSpacing, aToB, ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolAddress, ctx.fetcher);
+      assert.equal(tickArrays[0].startTickIndex, 0);
+      assert.equal(tickArrays[1].startTickIndex, 5632);
+      assert.equal(tickArrays[2].startTickIndex, 11264);
+
+      const result = SwapUtils.getFallbackTickArrayPublicKey(tickArrays, tickSpacing, aToB, ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolAddress);
+
+      const expected = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolAddress, -5632);
+      assert.ok(result?.toBase58() === expected.publicKey.toBase58());
+    });
+
+    it("ts = 64, a <-- b, left most", async () => {
+      const tickSpacing = 64;
+      const aToB = false;
+
+      // (no fallback) [ta0: -444928][ta1: -439296][ta2: -433664]
+      const tickArrays = await SwapUtils.getTickArrays(-439296 - 128, tickSpacing, aToB, ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolAddress, ctx.fetcher);
+      assert.equal(tickArrays[0].startTickIndex, -444928);
+      assert.equal(tickArrays[1].startTickIndex, -439296);
+      assert.equal(tickArrays[2].startTickIndex, -433664);
+
+      const result = SwapUtils.getFallbackTickArrayPublicKey(tickArrays, tickSpacing, aToB, ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolAddress);
+
+      assert.ok(result === undefined);
+    });
+
+    it("ts = 64, a <-- b, shifted", async () => {
+      const tickSpacing = 64;
+      const aToB = false;
+
+      // [fallback: -444928][ta0: -439296][ta1: -433664][ta2: -428032]
+      const tickArrays = await SwapUtils.getTickArrays(-439296 - 32, tickSpacing, aToB, ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolAddress, ctx.fetcher);
+      assert.equal(tickArrays[0].startTickIndex, -439296);
+      assert.equal(tickArrays[1].startTickIndex, -433664);
+      assert.equal(tickArrays[2].startTickIndex, -428032);
+
+      const result = SwapUtils.getFallbackTickArrayPublicKey(tickArrays, tickSpacing, aToB, ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolAddress);
+
+      const expected = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolAddress, -444928);
+      assert.ok(result?.toBase58() === expected.publicKey.toBase58());
+    });
+
+    it("ts = 32768, a --> b", async () => {
+      const tickSpacing = 32768;
+      const aToB = true;
+
+      // [ta0: -2883584][fallback: 0 ]
+      const tickArrays = await SwapUtils.getTickArrays(-128, tickSpacing, aToB, ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolAddress, ctx.fetcher);
+      assert.equal(tickArrays[0].startTickIndex, -2883584);
+      assert.equal(tickArrays.length, 1);
+
+      const result = SwapUtils.getFallbackTickArrayPublicKey(tickArrays, tickSpacing, aToB, ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolAddress);
+
+      const expected = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolAddress, 0);
+      assert.ok(result?.toBase58() === expected.publicKey.toBase58());
+    });
+
+    it("ts = 32768, a --> b, rightmost", async () => {
+      const tickSpacing = 32768;
+      const aToB = true;
+
+      // [ta1: -2883584][ta0: 0      ] (no fallback)
+      const tickArrays = await SwapUtils.getTickArrays(128, tickSpacing, aToB, ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolAddress, ctx.fetcher);
+      assert.equal(tickArrays[0].startTickIndex, 0);
+      assert.equal(tickArrays[1].startTickIndex, -2883584);
+      assert.equal(tickArrays.length, 2);
+
+      const result = SwapUtils.getFallbackTickArrayPublicKey(tickArrays, tickSpacing, aToB, ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolAddress);
+
+      assert.ok(result === undefined);
+    });
+
+    it("ts = 32768, a <-- b", async () => {
+      const tickSpacing = 32768;
+      const aToB = false;
+
+      // [fallback: -2883584][ta0: 0       ]
+      const tickArrays = await SwapUtils.getTickArrays(128, tickSpacing, aToB, ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolAddress, ctx.fetcher);
+      assert.equal(tickArrays[0].startTickIndex, 0);
+      assert.equal(tickArrays.length, 1);
+
+      const result = SwapUtils.getFallbackTickArrayPublicKey(tickArrays, tickSpacing, aToB, ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolAddress);
+
+      const expected = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolAddress, -2883584);
+      assert.ok(result?.toBase58() === expected.publicKey.toBase58());
+    });
+
+    it("ts = 32768, a <-- b, leftmost", async () => {
+      const tickSpacing = 32768;
+      const aToB = false;
+
+      // (no fallback) [ta0: -2883584][ta1: 0      ]
+      const tickArrays = await SwapUtils.getTickArrays(-65536, tickSpacing, aToB, ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolAddress, ctx.fetcher);
+      assert.equal(tickArrays[0].startTickIndex, -2883584);
+      assert.equal(tickArrays[1].startTickIndex, 0);
+      assert.equal(tickArrays.length, 2);
+
+      const result = SwapUtils.getFallbackTickArrayPublicKey(tickArrays, tickSpacing, aToB, ORCA_WHIRLPOOL_PROGRAM_ID, whirlpoolAddress);
+
+      assert.ok(result === undefined);
+    });
+  });
 });

--- a/sdk/tests/sdk/whirlpools/utils/tick-array-sequence.test.ts
+++ b/sdk/tests/sdk/whirlpools/utils/tick-array-sequence.test.ts
@@ -1,9 +1,8 @@
 import { TICK_ARRAY_SIZE } from "../../../../src";
 import * as assert from "assert";
 import { TickArraySequence } from "../../../../src/quotes/swap/tick-array-sequence";
-import { buildTickArrayData, testEmptyTickArrray } from "../../../utils/testDataTypes";
+import { buildTickArrayData } from "../../../utils/testDataTypes";
 import { TickArrayIndex } from "../../../../src/quotes/swap/tick-array-index";
-import { Whirlpool } from "../../../../src/artifacts/whirlpool";
 import { SwapErrorCode, WhirlpoolsError } from "../../../../src/errors/errors";
 
 describe("TickArray Sequence tests", () => {

--- a/sdk/tests/utils/testDataTypes.ts
+++ b/sdk/tests/utils/testDataTypes.ts
@@ -60,11 +60,6 @@ export const testTickArrayData: TickArrayData = {
   whirlpool: PublicKey.default,
 };
 
-export const testEmptyTickArrray: TickArray = {
-  address: PublicKey.default,
-  data: null,
-};
-
 export const buildTickArrayData = (startTick: number, initializedOffsets: number[]): TickArray => {
   const result = {
     ticks: Array(TICK_ARRAY_SIZE).fill(testUninitializedTickData),
@@ -79,7 +74,7 @@ export const buildTickArrayData = (startTick: number, initializedOffsets: number
     result.ticks[offset] = testInitializedTickData;
   });
   const randomAddr = Keypair.generate().publicKey;
-  return { address: randomAddr, data: result };
+  return { address: randomAddr, startTickIndex: startTick, data: result };
 };
 
 export async function getTickArrays(
@@ -87,8 +82,8 @@ export async function getTickArrays(
   ctx: WhirlpoolContext,
   whirlpoolKey: PublicKey,
   fetcher: WhirlpoolAccountFetcherInterface
-) {
-  const tickArrayPdas = await startIndices.map((value) =>
+): Promise<TickArray[]> {
+  const tickArrayPdas = startIndices.map((value) =>
     PDAUtil.getTickArray(ctx.program.programId, whirlpoolKey, value)
   );
   const tickArrayAddresses = tickArrayPdas.map((pda) => pda.publicKey);
@@ -96,6 +91,7 @@ export async function getTickArrays(
   return tickArrayAddresses.map((addr, index) => {
     return {
       address: addr,
+      startTickIndex: startIndices[index],
       data: tickArrays[index],
     };
   });


### PR DESCRIPTION
# Problems
## Uninitialised TA problem
- The absence of TickArray causes the trade to stop
- It is difficult to explain the problems caused by uninitialised TickArrays to users.
- It is impractical to initialise a large number of TickArrays in a FullRange pool
- It may be not sustainable to initialize many tickarrays by protocol (~ Orca)

## Problems with the order of TickArrays passed to instructions
It is necessary to provide a TickArray containing `tick_current_index` as `tick_array_0`.
However, if there is a current price near the boundary of the TickArray, this condition may not be met because the price moves; it is a kind of slippage, but even if the slippage is increased, an error occurs in this case.

# Solution
## Accept uninitialized TickArray
swap, swapV2, twoHopSwap, twoHopSwapV2 will accept uninitialized TickArray account address.

These instructions will treat uninitialized TickArray account as if they are zero padded and process trade.

## On-chain TickArray account order adjustment
swap, swapV2, twoHopSwap, twoHopSwapV2 will accept (maybe uninitialized) TickArray account address in any order and sort them as needed.  If instruction receive required TickArray accounts, it should work.

## Additional TickArray accounts
swapV2 and twoHopSwapV2 will accept additional up to 3 TickArray accounts via remaining_accounts.

- This is V2 only because V1 doesn't use remaining_accounts.
- The maximum number of accounts received will be six, but the maximum number of TickArrays used in a single trade will remain the same at three. This means that we can provide a backup TickArray in case prices move." The name "supplemental" comes from this use.

# Implementation Notes
## No breaking change on instruction interface
- There will be no change in the accounts received by v1.
- There are additions to the remaining_accounts that v2 will receive, but these do not affect the current program.

## Switching AccountLoader to UncheckedAccount
AccountLoader can only accept accounts that have been initialized (or at least the owner program has been changed to initialize account).
Therefore, to receive uninitialized accounts, use UncheckedAccount.

The verification that was conventionally done via has_one needs to be done via handler.
Also, the verification done internally by load_mut() needs to be done the same way.

## ProxiedTickArray
Add one abstraction layer, ProxiedTickArray, to minimize changes to the current battle-tested `SwapTickSequence` code.

For TickArrays that have been initialized, the process is delegated to the existing implementation. For uninitialized TickArray, the process is delegated to ZeroedTickArray where all Tick are zero initialized.

### Notes: Heap size limination
Initially, we considered placing the entire 0-initialized TickArray account in the Heap and using RefMut to that account, but the Heap size limit is 32 KB, so we were limited to two accounts at most.

Since twoHopSwapV2 handles a maximum of six uninitialized accounts, this method could not be used.

## On-chain TickArray account order adjustment
First, calculate up to three start_tick_indexes for the required TickArray and verify if a TickArray account with that start_tick_index is provided.

With this method, if an account is provided that has been initialized as it is now, no PDA calculation or pubkey comparison occurs, since matching is possible only by comparing the start_tick_indexes among themselves.

The PDA calculation is only performed if no account with start_tick_index is found among the initialized accounts.

Uninitialized accounts are verified as uninitialized.
The conditions for uninitialization are that SystemProgram is the owner and the data size is 0.

Whether the uninitialized account is a correct TickArray address or not is not verified because it is impossible to verify (we need to find seend for them). However, it is used only if it matches the correct PDA derived using start_tick_index.  So wrong accounts will be simply ignored.
