### PR TITLE
Disallow non-full-range positions on pools with tick spacing >= 2^15

### DIFF
--- a/programs/whirlpool/src/errors.rs
+++ b/programs/whirlpool/src/errors.rs
@@ -136,7 +136,7 @@ pub enum ErrorCode {
     #[msg("Same accounts type is provided more than once")]
     RemainingAccountsDuplicatedAccountsType, // 0x17a5 (6053)
 
-    #[msg("This whirlpool only supports full-range pools")]
+    #[msg("This whirlpool only supports full-range positions")]
     FullRangeOnlyPool, // 0x17a6 (6054)
 }
 

--- a/programs/whirlpool/src/errors.rs
+++ b/programs/whirlpool/src/errors.rs
@@ -126,7 +126,7 @@ pub enum ErrorCode {
 
     #[msg("Unable to call transfer hook without extra accounts")]
     NoExtraAccountsForTransferHook, // 0x17a2 (6050)
-    
+
     #[msg("Output and input amount mismatch")]
     IntermediateTokenAmountMismatch, // 0x17a3 (6051)
 
@@ -135,6 +135,9 @@ pub enum ErrorCode {
 
     #[msg("Same accounts type is provided more than once")]
     RemainingAccountsDuplicatedAccountsType, // 0x17a5 (6053)
+
+    #[msg("This whirlpool does not support non-full range positions")]
+    NonFullRangePositionDisallowed, // 0x17a6 (6054)
 }
 
 impl From<TryFromIntError> for ErrorCode {

--- a/programs/whirlpool/src/errors.rs
+++ b/programs/whirlpool/src/errors.rs
@@ -136,8 +136,8 @@ pub enum ErrorCode {
     #[msg("Same accounts type is provided more than once")]
     RemainingAccountsDuplicatedAccountsType, // 0x17a5 (6053)
 
-    #[msg("This whirlpool does not support non-full range positions")]
-    NonFullRangePositionDisallowed, // 0x17a6 (6054)
+    #[msg("This whirlpool only supports full-range pools")]
+    FullRangeOnlyPool, // 0x17a6 (6054)
 }
 
 impl From<TryFromIntError> for ErrorCode {

--- a/programs/whirlpool/src/math/tick_math.rs
+++ b/programs/whirlpool/src/math/tick_math.rs
@@ -10,6 +10,8 @@ const BIT_PRECISION: u32 = 14;
 const LOG_B_P_ERR_MARGIN_LOWER_X64: i128 = 184467440737095516i128; // 0.01
 const LOG_B_P_ERR_MARGIN_UPPER_X64: i128 = 15793534762490258745i128; // 2^-precision / log_2_b + 0.01
 
+pub const INFINITY_POOL_SPACING_FLAG: u16 = 32768; // 2^15
+
 /// Derive the sqrt-price from a tick index. The precision of this method is only guarranted
 /// if tick is within the bounds of {max, min} tick-index.
 ///

--- a/programs/whirlpool/src/math/tick_math.rs
+++ b/programs/whirlpool/src/math/tick_math.rs
@@ -10,7 +10,7 @@ const BIT_PRECISION: u32 = 14;
 const LOG_B_P_ERR_MARGIN_LOWER_X64: i128 = 184467440737095516i128; // 0.01
 const LOG_B_P_ERR_MARGIN_UPPER_X64: i128 = 15793534762490258745i128; // 2^-precision / log_2_b + 0.01
 
-pub const INFINITY_POOL_SPACING_FLAG: u16 = 32768; // 2^15
+pub const FULL_RANGE_ONLY_TICK_SPACING_THRESHOLD: u16 = 32768; // 2^15
 
 /// Derive the sqrt-price from a tick index. The precision of this method is only guarranted
 /// if tick is within the bounds of {max, min} tick-index.

--- a/programs/whirlpool/src/state/position.rs
+++ b/programs/whirlpool/src/state/position.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 
-use crate::{errors::ErrorCode, math::INFINITY_POOL_SPACING_FLAG, state::NUM_REWARDS};
+use crate::{errors::ErrorCode, math::FULL_RANGE_ONLY_TICK_SPACING_THRESHOLD, state::NUM_REWARDS};
 
 use super::{Tick, Whirlpool};
 
@@ -69,15 +69,13 @@ impl Position {
             return Err(ErrorCode::InvalidTickIndex.into());
         }
 
-        // On tick spacing >= 2^15, should only be able to open full range positions (infinity pool)
-        if whirlpool.tick_spacing >= INFINITY_POOL_SPACING_FLAG {
+        // On tick spacing >= 2^15, should only be able to open full range positions
+        if whirlpool.tick_spacing >= FULL_RANGE_ONLY_TICK_SPACING_THRESHOLD {
             let (full_range_lower_index, full_range_upper_index) = Tick::full_range_indexes(whirlpool.tick_spacing);
-            // let full_range_lower_index = Tick
-            // Use gt or lt here instead of neq since indexes still need to be on tick spacing
             if tick_lower_index != full_range_lower_index
                 || tick_upper_index != full_range_upper_index
             {
-                return Err(ErrorCode::NonFullRangePositionDisallowed.into());
+                return Err(ErrorCode::FullRangeOnlyPool.into());
             }
         }
 

--- a/programs/whirlpool/src/state/tick.rs
+++ b/programs/whirlpool/src/state/tick.rs
@@ -103,6 +103,12 @@ impl Tick {
         tick_index % tick_spacing as i32 == 0
     }
 
+    pub fn full_range_indexes(tick_spacing: u16) -> (i32, i32) {
+        let lower_index = MIN_TICK_INDEX / tick_spacing as i32 * tick_spacing as i32;
+        let upper_index = MAX_TICK_INDEX / tick_spacing as i32 * tick_spacing as i32;
+        (lower_index, upper_index)
+    }
+
     /// Bound a tick-index value to the max & min index value for this protocol
     ///
     /// # Parameters
@@ -573,6 +579,37 @@ mod check_is_out_of_bounds_tests {
     #[test]
     fn test_max_tick_index_add_1() {
         assert_eq!(Tick::check_is_out_of_bounds(MAX_TICK_INDEX + 1), true);
+    }
+}
+
+#[cfg(test)]
+mod full_range_indexes_tests {
+    use crate::math::INFINITY_POOL_SPACING_FLAG;
+
+    use super::*;
+
+    #[test]
+    fn test_zero_tick_spacing() {
+        assert_eq!(
+            Tick::full_range_indexes(1),
+            (MIN_TICK_INDEX, MAX_TICK_INDEX)
+        );
+    }
+
+    #[test]
+    fn test_standard_tick_spacing() {
+        assert_eq!(
+            Tick::full_range_indexes(128),
+            (-443520, 443520)
+        );
+    }
+
+    #[test]
+    fn test_infinity_tick_spacing() {
+        assert_eq!(
+            Tick::full_range_indexes(INFINITY_POOL_SPACING_FLAG),
+            (-425984, 425984)
+        );
     }
 }
 

--- a/programs/whirlpool/src/state/tick.rs
+++ b/programs/whirlpool/src/state/tick.rs
@@ -584,12 +584,12 @@ mod check_is_out_of_bounds_tests {
 
 #[cfg(test)]
 mod full_range_indexes_tests {
-    use crate::math::INFINITY_POOL_SPACING_FLAG;
+    use crate::math::FULL_RANGE_ONLY_TICK_SPACING_THRESHOLD;
 
     use super::*;
 
     #[test]
-    fn test_zero_tick_spacing() {
+    fn test_min_tick_spacing() {
         assert_eq!(
             Tick::full_range_indexes(1),
             (MIN_TICK_INDEX, MAX_TICK_INDEX)
@@ -605,10 +605,18 @@ mod full_range_indexes_tests {
     }
 
     #[test]
-    fn test_infinity_tick_spacing() {
+    fn test_full_range_only_tick_spacing() {
         assert_eq!(
-            Tick::full_range_indexes(INFINITY_POOL_SPACING_FLAG),
+            Tick::full_range_indexes(FULL_RANGE_ONLY_TICK_SPACING_THRESHOLD),
             (-425984, 425984)
+        );
+    }
+
+    #[test]
+    fn test_max_tick_spacing() {
+        assert_eq!(
+            Tick::full_range_indexes(u16::MAX),
+            (-393210, 393210)
         );
     }
 }

--- a/sdk/src/types/public/constants.ts
+++ b/sdk/src/types/public/constants.ts
@@ -120,3 +120,9 @@ export const FEE_RATE_MUL_VALUE = new BN(1_000_000);
 export const WHIRLPOOL_NFT_UPDATE_AUTH = new PublicKey(
   "3axbTs2z5GBy6usVbNVoqEgZMng3vZvMnAoX29BFfwhr"
 );
+
+/**
+ * The tick spacing (inclusive) at which a whirlpool only supports full-range positions.
+ * @category Constants
+ */
+export const FULL_RANGE_ONLY_TICK_SPACING_THRESHOLD = 32768;

--- a/sdk/src/utils/public/tick-utils.ts
+++ b/sdk/src/utils/public/tick-utils.ts
@@ -7,6 +7,7 @@ import {
   WhirlpoolAccountFetcherInterface,
 } from "../../network/public/fetcher";
 import {
+  FULL_RANGE_ONLY_TICK_SPACING_THRESHOLD,
   MAX_TICK_INDEX,
   MIN_TICK_INDEX,
   TICK_ARRAY_SIZE,
@@ -173,7 +174,7 @@ export class TickUtil {
 
   /**
    * Get the minimum and maximum tick index that can be initialized.
-   * 
+   *
    * @param tickSpacing The tickSpacing for the Whirlpool
    * @returns An array of numbers where the first element is the minimum tick index and the second element is the maximum tick index.
    */
@@ -194,6 +195,15 @@ export class TickUtil {
   public static isFullRange(tickSpacing: number, tickLowerIndex: number, tickUpperIndex: number): boolean {
     const [min, max] = TickUtil.getFullRangeTickIndex(tickSpacing);
     return tickLowerIndex === min && tickUpperIndex === max;
+  }
+
+  /**
+   * Check if a whirlpool is a full-range only pool.
+   * @param tickSpacing The tickSpacing for the Whirlpool
+   * @returns true if the whirlpool is a full-range only pool, false otherwise.
+   */
+  public static isFullRangeOnly(tickSpacing: number): boolean {
+    return tickSpacing >= FULL_RANGE_ONLY_TICK_SPACING_THRESHOLD;
   }
 }
 

--- a/sdk/tests/integration/open_bundled_position.test.ts
+++ b/sdk/tests/integration/open_bundled_position.test.ts
@@ -38,7 +38,7 @@ describe("open_bundled_position", () => {
   const fetcher = ctx.fetcher;
 
   const tickLowerIndex = 0;
-  const tickUpperIndex = 128;
+  const tickUpperIndex = 32768;
   let poolInitInfo: InitPoolParams;
   let whirlpoolPda: PDA;
   let infinityPoolInitInfo: InitPoolParams;
@@ -645,7 +645,7 @@ describe("open_bundled_position", () => {
         tickLowerIndex,
         tickUpperIndex
       ),
-      /0x177a/ // InvalidTickIndex
+      /0x17a6/ // NonFullRangePositionDisallowed
     );
   });
 

--- a/sdk/tests/integration/open_bundled_position.test.ts
+++ b/sdk/tests/integration/open_bundled_position.test.ts
@@ -41,16 +41,16 @@ describe("open_bundled_position", () => {
   const tickUpperIndex = 32768;
   let poolInitInfo: InitPoolParams;
   let whirlpoolPda: PDA;
-  let infinityPoolInitInfo: InitPoolParams;
-  let infinityWhirlpoolPda: PDA;
+  let fullRangeOnlyPoolInitInfo: InitPoolParams;
+  let fullRangeOnlyWhirlpoolPda: PDA;
   const funderKeypair = anchor.web3.Keypair.generate();
 
   before(async () => {
     poolInitInfo = (await initTestPool(ctx, TickSpacing.Standard)).poolInitInfo;
     whirlpoolPda = poolInitInfo.whirlpoolPda;
 
-    infinityPoolInitInfo = (await initTestPool(ctx, TickSpacing.Infinity)).poolInitInfo;
-    infinityWhirlpoolPda = infinityPoolInitInfo.whirlpoolPda;
+    fullRangeOnlyPoolInitInfo = (await initTestPool(ctx, TickSpacing.FullRangeOnly)).poolInitInfo;
+    fullRangeOnlyWhirlpoolPda = fullRangeOnlyPoolInitInfo.whirlpoolPda;
 
     await systemTransferTx(provider, funderKeypair.publicKey, ONE_SOL).buildAndExecute();
   });
@@ -211,15 +211,15 @@ describe("open_bundled_position", () => {
     checkBitmap(positionBundle, bundleIndexes);
   });
 
-  it("successfully opens bundled position for infinity pool", async () => {
+  it("successfully opens bundled position for full-range only pool", async () => {
     const positionBundleInfo = await initializePositionBundle(ctx, ctx.wallet.publicKey);
 
-    const [lowerTickIndex, upperTickIndex] = TickUtil.getFullRangeTickIndex(TickSpacing.Infinity);
+    const [lowerTickIndex, upperTickIndex] = TickUtil.getFullRangeTickIndex(TickSpacing.FullRangeOnly);
 
     const bundleIndex = 0;
     const positionInitInfo = await openBundledPosition(
       ctx,
-      infinityWhirlpoolPda.publicKey,
+      fullRangeOnlyWhirlpoolPda.publicKey,
       positionBundleInfo.positionBundleMintKeypair.publicKey,
       bundleIndex,
       lowerTickIndex,
@@ -633,7 +633,7 @@ describe("open_bundled_position", () => {
     });
   });
 
-  it("fail when opening a non-full range position in an infinity pool", async () => {
+  it("fail when opening a non-full range position in an full-range only pool", async () => {
     const positionBundleInfo = await initializePositionBundle(ctx, ctx.wallet.publicKey);
     const bundleIndex = 0;
     await assert.rejects(
@@ -645,7 +645,7 @@ describe("open_bundled_position", () => {
         tickLowerIndex,
         tickUpperIndex
       ),
-      /0x17a6/ // NonFullRangePositionDisallowed
+      /0x17a6/ // FullRangeOnlyPool
     );
   });
 

--- a/sdk/tests/integration/open_bundled_position.test.ts
+++ b/sdk/tests/integration/open_bundled_position.test.ts
@@ -11,6 +11,7 @@ import {
   POSITION_BUNDLE_SIZE,
   PositionBundleData,
   PositionData,
+  TickUtil,
   toTx,
   WhirlpoolContext,
   WhirlpoolIx
@@ -40,11 +41,17 @@ describe("open_bundled_position", () => {
   const tickUpperIndex = 128;
   let poolInitInfo: InitPoolParams;
   let whirlpoolPda: PDA;
+  let infinityPoolInitInfo: InitPoolParams;
+  let infinityWhirlpoolPda: PDA;
   const funderKeypair = anchor.web3.Keypair.generate();
 
   before(async () => {
     poolInitInfo = (await initTestPool(ctx, TickSpacing.Standard)).poolInitInfo;
     whirlpoolPda = poolInitInfo.whirlpoolPda;
+
+    infinityPoolInitInfo = (await initTestPool(ctx, TickSpacing.Infinity)).poolInitInfo;
+    infinityWhirlpoolPda = infinityPoolInitInfo.whirlpoolPda;
+
     await systemTransferTx(provider, funderKeypair.publicKey, ONE_SOL).buildAndExecute();
   });
 
@@ -85,9 +92,9 @@ describe("open_bundled_position", () => {
     });
   }
 
-  function checkPositionAccountContents(position: PositionData, mint: PublicKey) {
-    assert.strictEqual(position.tickLowerIndex, tickLowerIndex);
-    assert.strictEqual(position.tickUpperIndex, tickUpperIndex);
+  function checkPositionAccountContents(position: PositionData, mint: PublicKey, lowerTick: number = tickLowerIndex, upperTick: number = tickUpperIndex) {
+    assert.strictEqual(position.tickLowerIndex, lowerTick);
+    assert.strictEqual(position.tickUpperIndex, upperTick);
     assert.ok(position.whirlpool.equals(poolInitInfo.whirlpoolPda.publicKey));
     assert.ok(position.positionMint.equals(mint));
     assert.ok(position.liquidity.eq(ZERO_BN));
@@ -202,6 +209,29 @@ describe("open_bundled_position", () => {
 
     const positionBundle = (await fetcher.getPositionBundle(positionBundleInfo.positionBundlePda.publicKey, IGNORE_CACHE)) as PositionBundleData;
     checkBitmap(positionBundle, bundleIndexes);
+  });
+
+  it("successfully opens bundled position for infinity pool", async () => {
+    const positionBundleInfo = await initializePositionBundle(ctx, ctx.wallet.publicKey);
+
+    const [lowerTickIndex, upperTickIndex] = TickUtil.getFullRangeTickIndex(TickSpacing.Infinity);
+
+    const bundleIndex = 0;
+    const positionInitInfo = await openBundledPosition(
+      ctx,
+      infinityWhirlpoolPda.publicKey,
+      positionBundleInfo.positionBundleMintKeypair.publicKey,
+      bundleIndex,
+      lowerTickIndex,
+      upperTickIndex
+    );
+    const { bundledPositionPda } = positionInitInfo.params;
+
+    const position = (await fetcher.getPosition(bundledPositionPda.publicKey)) as PositionData;
+    checkPositionAccountContents(position, positionBundleInfo.positionBundleMintKeypair.publicKey, lowerTickIndex, upperTickIndex);
+
+    const positionBundle = (await fetcher.getPositionBundle(positionBundleInfo.positionBundlePda.publicKey, IGNORE_CACHE)) as PositionBundleData;
+    checkBitmap(positionBundle, [bundleIndex]);
   });
 
   describe("invalid bundle index", () => {
@@ -601,6 +631,22 @@ describe("open_bundled_position", () => {
       const positionBundle = await fetcher.getPositionBundle(positionBundleInfo.positionBundlePda.publicKey, IGNORE_CACHE);
       checkBitmapIsOpened(positionBundle!, 0);
     });
+  });
+
+  it("fail when opening a non-full range position in an infinity pool", async () => {
+    const positionBundleInfo = await initializePositionBundle(ctx, ctx.wallet.publicKey);
+    const bundleIndex = 0;
+    await assert.rejects(
+      openBundledPosition(
+        ctx,
+        whirlpoolPda.publicKey,
+        positionBundleInfo.positionBundleMintKeypair.publicKey,
+        bundleIndex,
+        tickLowerIndex,
+        tickUpperIndex
+      ),
+      /0x177a/ // InvalidTickIndex
+    );
   });
 
 });

--- a/sdk/tests/integration/open_position.test.ts
+++ b/sdk/tests/integration/open_position.test.ts
@@ -42,16 +42,16 @@ describe("open_position", () => {
   const tickUpperIndex = 32768;
   let poolInitInfo: InitPoolParams;
   let whirlpoolPda: PDA;
-  let infinityPoolInitInfo: InitPoolParams;
-  let infinityWhirlpoolPda: PDA;
+  let fullRangeOnlyPoolInitInfo: InitPoolParams;
+  let fullRangeOnlyWhirlpoolPda: PDA;
   const funderKeypair = anchor.web3.Keypair.generate();
 
   before(async () => {
     poolInitInfo = (await initTestPool(ctx, TickSpacing.Standard)).poolInitInfo;
     whirlpoolPda = poolInitInfo.whirlpoolPda;
 
-    infinityPoolInitInfo = (await initTestPool(ctx, TickSpacing.Infinity)).poolInitInfo;
-    infinityWhirlpoolPda = infinityPoolInitInfo.whirlpoolPda;
+    fullRangeOnlyPoolInitInfo = (await initTestPool(ctx, TickSpacing.FullRangeOnly)).poolInitInfo;
+    fullRangeOnlyWhirlpoolPda = fullRangeOnlyPoolInitInfo.whirlpoolPda;
 
     const { params, mint } = await generateDefaultOpenPositionParams(
       ctx,
@@ -89,12 +89,12 @@ describe("open_position", () => {
     // TODO: Add tests for rewards
   });
 
-  it("successfully open position and verify position address contents for infinity pool", async () => {
-    const [lowerTickIndex, upperTickIndex] = TickUtil.getFullRangeTickIndex(TickSpacing.Infinity);
+  it("successfully open position and verify position address contents for full-range only pool", async () => {
+    const [lowerTickIndex, upperTickIndex] = TickUtil.getFullRangeTickIndex(TickSpacing.FullRangeOnly);
 
     const positionInitInfo = await openPosition(
       ctx,
-      infinityWhirlpoolPda.publicKey,
+      fullRangeOnlyWhirlpoolPda.publicKey,
       lowerTickIndex,
       upperTickIndex
     );
@@ -104,7 +104,7 @@ describe("open_position", () => {
 
     assert.strictEqual(position.tickLowerIndex, lowerTickIndex);
     assert.strictEqual(position.tickUpperIndex, upperTickIndex);
-    assert.ok(position.whirlpool.equals(infinityPoolInitInfo.whirlpoolPda.publicKey));
+    assert.ok(position.whirlpool.equals(fullRangeOnlyPoolInitInfo.whirlpoolPda.publicKey));
     assert.ok(position.positionMint.equals(positionMintAddress));
     assert.ok(position.liquidity.eq(ZERO_BN));
     assert.ok(position.feeGrowthCheckpointA.eq(ZERO_BN));
@@ -242,17 +242,17 @@ describe("open_position", () => {
     );
   });
 
-  it("fail when opening a non-full range position in an infinity pool", async () => {
+  it("fail when opening a non-full range position in an full-range only pool", async () => {
     await assert.rejects(
       openPosition(
         ctx,
-        infinityWhirlpoolPda.publicKey,
+        fullRangeOnlyWhirlpoolPda.publicKey,
         tickLowerIndex,
         tickUpperIndex,
         provider.wallet.publicKey,
         funderKeypair
       ),
-      /0x17a6/ // NonFullRangePositionDisallowed
+      /0x17a6/ // FullRangeOnlyPool
     );
   });
 });

--- a/sdk/tests/integration/open_position.test.ts
+++ b/sdk/tests/integration/open_position.test.ts
@@ -11,6 +11,7 @@ import {
   OpenPositionParams,
   PDAUtil,
   PositionData,
+  TickUtil,
   WhirlpoolContext,
   WhirlpoolIx,
   toTx
@@ -41,11 +42,16 @@ describe("open_position", () => {
   const tickUpperIndex = 128;
   let poolInitInfo: InitPoolParams;
   let whirlpoolPda: PDA;
+  let infinityPoolInitInfo: InitPoolParams;
+  let infinityWhirlpoolPda: PDA;
   const funderKeypair = anchor.web3.Keypair.generate();
 
   before(async () => {
     poolInitInfo = (await initTestPool(ctx, TickSpacing.Standard)).poolInitInfo;
     whirlpoolPda = poolInitInfo.whirlpoolPda;
+
+    infinityPoolInitInfo = (await initTestPool(ctx, TickSpacing.Infinity)).poolInitInfo;
+    infinityWhirlpoolPda = infinityPoolInitInfo.whirlpoolPda;
 
     const { params, mint } = await generateDefaultOpenPositionParams(
       ctx,
@@ -81,6 +87,30 @@ describe("open_position", () => {
     assert.ok(position.feeOwedB.eq(ZERO_BN));
 
     // TODO: Add tests for rewards
+  });
+
+  it("successfully open position and verify position address contents for infinity pool", async () => {
+    const [lowerTickIndex, upperTickIndex] = TickUtil.getFullRangeTickIndex(TickSpacing.Infinity);
+
+    const positionInitInfo = await openPosition(
+      ctx,
+      infinityWhirlpoolPda.publicKey,
+      lowerTickIndex,
+      upperTickIndex
+    );
+    const { positionPda, positionMintAddress } = positionInitInfo.params;
+
+    const position = (await fetcher.getPosition(positionPda.publicKey)) as PositionData;
+
+    assert.strictEqual(position.tickLowerIndex, lowerTickIndex);
+    assert.strictEqual(position.tickUpperIndex, upperTickIndex);
+    assert.ok(position.whirlpool.equals(infinityPoolInitInfo.whirlpoolPda.publicKey));
+    assert.ok(position.positionMint.equals(positionMintAddress));
+    assert.ok(position.liquidity.eq(ZERO_BN));
+    assert.ok(position.feeGrowthCheckpointA.eq(ZERO_BN));
+    assert.ok(position.feeGrowthCheckpointB.eq(ZERO_BN));
+    assert.ok(position.feeOwedA.eq(ZERO_BN));
+    assert.ok(position.feeOwedB.eq(ZERO_BN));
   });
 
   it("succeeds when funder is different than account paying for transaction fee", async () => {
@@ -209,6 +239,20 @@ describe("open_position", () => {
         .addSigner(positionMintKeypair)
         .buildAndExecute(),
       /0x0/
+    );
+  });
+
+  it("fail when opening a non-full range position in an infinity pool", async () => {
+    await assert.rejects(
+      openPosition(
+        ctx,
+        infinityWhirlpoolPda.publicKey,
+        tickLowerIndex,
+        tickUpperIndex,
+        provider.wallet.publicKey,
+        funderKeypair
+      ),
+      /0x177a/ // InvalidTickIndex
     );
   });
 });

--- a/sdk/tests/integration/open_position.test.ts
+++ b/sdk/tests/integration/open_position.test.ts
@@ -39,7 +39,7 @@ describe("open_position", () => {
   let defaultParams: OpenPositionParams;
   let defaultMint: Keypair;
   const tickLowerIndex = 0;
-  const tickUpperIndex = 128;
+  const tickUpperIndex = 32768;
   let poolInitInfo: InitPoolParams;
   let whirlpoolPda: PDA;
   let infinityPoolInitInfo: InitPoolParams;
@@ -56,8 +56,8 @@ describe("open_position", () => {
     const { params, mint } = await generateDefaultOpenPositionParams(
       ctx,
       whirlpoolPda.publicKey,
-      0,
-      128,
+      tickLowerIndex,
+      tickUpperIndex,
       provider.wallet.publicKey
     );
     defaultParams = params;
@@ -252,7 +252,7 @@ describe("open_position", () => {
         provider.wallet.publicKey,
         funderKeypair
       ),
-      /0x177a/ // InvalidTickIndex
+      /0x17a6/ // NonFullRangePositionDisallowed
     );
   });
 });

--- a/sdk/tests/integration/open_position_with_metadata.test.ts
+++ b/sdk/tests/integration/open_position_with_metadata.test.ts
@@ -48,16 +48,16 @@ describe("open_position_with_metadata", () => {
   const tickUpperIndex = 32768;
   let poolInitInfo: InitPoolParams;
   let whirlpoolPda: PDA;
-  let infinityPoolInitInfo: InitPoolParams;
-  let infinityWhirlpoolPda: PDA;
+  let fullRangeOnlyPoolInitInfo: InitPoolParams;
+  let fullRangeOnlyWhirlpoolPda: PDA;
   const funderKeypair = anchor.web3.Keypair.generate();
 
   before(async () => {
     poolInitInfo = (await initTestPool(ctx, TickSpacing.Standard)).poolInitInfo;
     whirlpoolPda = poolInitInfo.whirlpoolPda;
 
-    infinityPoolInitInfo = (await initTestPool(ctx, TickSpacing.Infinity)).poolInitInfo;
-    infinityWhirlpoolPda = infinityPoolInitInfo.whirlpoolPda;
+    fullRangeOnlyPoolInitInfo = (await initTestPool(ctx, TickSpacing.FullRangeOnly)).poolInitInfo;
+    fullRangeOnlyWhirlpoolPda = fullRangeOnlyPoolInitInfo.whirlpoolPda;
 
     const { params, mint } = await generateDefaultOpenPositionParams(
       ctx,
@@ -110,12 +110,12 @@ describe("open_position_with_metadata", () => {
     // TODO: Add tests for rewards
   });
 
-  it("successfully opens position and verify position address contents for infinity pool", async () => {
-    const [lowerTickIndex, upperTickIndex] = TickUtil.getFullRangeTickIndex(TickSpacing.Infinity);
+  it("successfully opens position and verify position address contents for full-range only pool", async () => {
+    const [lowerTickIndex, upperTickIndex] = TickUtil.getFullRangeTickIndex(TickSpacing.FullRangeOnly);
 
     const positionInitInfo = await openPositionWithMetadata(
       ctx,
-      infinityWhirlpoolPda.publicKey,
+      fullRangeOnlyWhirlpoolPda.publicKey,
       lowerTickIndex,
       upperTickIndex
     );
@@ -124,7 +124,7 @@ describe("open_position_with_metadata", () => {
 
     assert.strictEqual(position.tickLowerIndex, lowerTickIndex);
     assert.strictEqual(position.tickUpperIndex, upperTickIndex);
-    assert.ok(position.whirlpool.equals(infinityPoolInitInfo.whirlpoolPda.publicKey));
+    assert.ok(position.whirlpool.equals(fullRangeOnlyPoolInitInfo.whirlpoolPda.publicKey));
     assert.ok(position.positionMint.equals(positionMintAddress));
     assert.ok(position.liquidity.eq(ZERO_BN));
     assert.ok(position.feeGrowthCheckpointA.eq(ZERO_BN));
@@ -376,17 +376,17 @@ describe("open_position_with_metadata", () => {
     });
   });
 
-  it("fail when opening a non-full range position in an infinity pool", async () => {
+  it("fail when opening a non-full range position in an full-range only pool", async () => {
     await assert.rejects(
       openPositionWithMetadata(
         ctx,
-        infinityWhirlpoolPda.publicKey,
+        fullRangeOnlyWhirlpoolPda.publicKey,
         tickLowerIndex,
         tickUpperIndex,
         provider.wallet.publicKey,
         funderKeypair
       ),
-      /0x17a6/ // NonFullRangePositionDisallowed
+      /0x17a6/ // FullRangeOnlyPool
     );
   });
 });

--- a/sdk/tests/integration/open_position_with_metadata.test.ts
+++ b/sdk/tests/integration/open_position_with_metadata.test.ts
@@ -45,7 +45,7 @@ describe("open_position_with_metadata", () => {
   let defaultParams: Required<OpenPositionParams & { metadataPda: PDA }>;
   let defaultMint: Keypair;
   const tickLowerIndex = 0;
-  const tickUpperIndex = 128;
+  const tickUpperIndex = 32768;
   let poolInitInfo: InitPoolParams;
   let whirlpoolPda: PDA;
   let infinityPoolInitInfo: InitPoolParams;
@@ -62,8 +62,8 @@ describe("open_position_with_metadata", () => {
     const { params, mint } = await generateDefaultOpenPositionParams(
       ctx,
       whirlpoolPda.publicKey,
-      0,
-      128,
+      tickLowerIndex,
+      tickUpperIndex,
       provider.wallet.publicKey
     );
     defaultParams = params;
@@ -386,7 +386,7 @@ describe("open_position_with_metadata", () => {
         provider.wallet.publicKey,
         funderKeypair
       ),
-      /0x177a/ // InvalidTickIndex
+      /0x17a6/ // NonFullRangePositionDisallowed
     );
   });
 });

--- a/sdk/tests/integration/open_position_with_metadata.test.ts
+++ b/sdk/tests/integration/open_position_with_metadata.test.ts
@@ -13,6 +13,7 @@ import {
   OpenPositionWithMetadataBumpsData,
   PDAUtil,
   PositionData,
+  TickUtil,
   WhirlpoolContext,
   WhirlpoolIx,
   toTx
@@ -47,11 +48,16 @@ describe("open_position_with_metadata", () => {
   const tickUpperIndex = 128;
   let poolInitInfo: InitPoolParams;
   let whirlpoolPda: PDA;
+  let infinityPoolInitInfo: InitPoolParams;
+  let infinityWhirlpoolPda: PDA;
   const funderKeypair = anchor.web3.Keypair.generate();
 
   before(async () => {
     poolInitInfo = (await initTestPool(ctx, TickSpacing.Standard)).poolInitInfo;
     whirlpoolPda = poolInitInfo.whirlpoolPda;
+
+    infinityPoolInitInfo = (await initTestPool(ctx, TickSpacing.Infinity)).poolInitInfo;
+    infinityWhirlpoolPda = infinityPoolInitInfo.whirlpoolPda;
 
     const { params, mint } = await generateDefaultOpenPositionParams(
       ctx,
@@ -102,6 +108,31 @@ describe("open_position_with_metadata", () => {
 
     await checkMetadata(metadataPda, position.positionMint);
     // TODO: Add tests for rewards
+  });
+
+  it("successfully opens position and verify position address contents for infinity pool", async () => {
+    const [lowerTickIndex, upperTickIndex] = TickUtil.getFullRangeTickIndex(TickSpacing.Infinity);
+
+    const positionInitInfo = await openPositionWithMetadata(
+      ctx,
+      infinityWhirlpoolPda.publicKey,
+      lowerTickIndex,
+      upperTickIndex
+    );
+    const { positionPda, metadataPda, positionMintAddress } = positionInitInfo.params;
+    const position = (await fetcher.getPosition(positionPda.publicKey)) as PositionData;
+
+    assert.strictEqual(position.tickLowerIndex, lowerTickIndex);
+    assert.strictEqual(position.tickUpperIndex, upperTickIndex);
+    assert.ok(position.whirlpool.equals(infinityPoolInitInfo.whirlpoolPda.publicKey));
+    assert.ok(position.positionMint.equals(positionMintAddress));
+    assert.ok(position.liquidity.eq(ZERO_BN));
+    assert.ok(position.feeGrowthCheckpointA.eq(ZERO_BN));
+    assert.ok(position.feeGrowthCheckpointB.eq(ZERO_BN));
+    assert.ok(position.feeOwedA.eq(ZERO_BN));
+    assert.ok(position.feeOwedB.eq(ZERO_BN));
+
+    await checkMetadata(metadataPda, position.positionMint);
   });
 
   it("succeeds when funder is different than account paying for transaction fee", async () => {
@@ -343,5 +374,19 @@ describe("open_position_with_metadata", () => {
         /0x7dc/
       );
     });
+  });
+
+  it("fail when opening a non-full range position in an infinity pool", async () => {
+    await assert.rejects(
+      openPositionWithMetadata(
+        ctx,
+        infinityWhirlpoolPda.publicKey,
+        tickLowerIndex,
+        tickUpperIndex,
+        provider.wallet.publicKey,
+        funderKeypair
+      ),
+      /0x177a/ // InvalidTickIndex
+    );
   });
 });

--- a/sdk/tests/sdk/whirlpools/utils/tick-utils.test.ts
+++ b/sdk/tests/sdk/whirlpools/utils/tick-utils.test.ts
@@ -58,4 +58,18 @@ describe("TickUtil tests", () => {
       }
     });
   });
+
+  describe("isFullRangeOnly", () => {
+    it("returns true for tickSpacing = 32768", async () => {
+      assert.strictEqual(TickUtil.isFullRangeOnly(32768), true);
+    });
+
+    it("returns true for tickSpacing > 32768", async () => {
+      assert.strictEqual(TickUtil.isFullRangeOnly(32769), true);
+    });
+
+    it("returns false for tickSpacing < 32768", async () => {
+      assert.strictEqual(TickUtil.isFullRangeOnly(32767), false);
+    });
+  });
 });

--- a/sdk/tests/utils/index.ts
+++ b/sdk/tests/utils/index.ts
@@ -9,5 +9,5 @@ export enum TickSpacing {
   ThirtyTwo = 32,
   SixtyFour = 64,
   Standard = 128,
-  Infinity = 32768,
+  FullRangeOnly = 32768,
 }

--- a/sdk/tests/utils/index.ts
+++ b/sdk/tests/utils/index.ts
@@ -9,4 +9,5 @@ export enum TickSpacing {
   ThirtyTwo = 32,
   SixtyFour = 64,
   Standard = 128,
+  Infinity = 32768,
 }


### PR DESCRIPTION
* Added check to disallow non-full-range positions on pools with tick spacing >= 2^15
* Added tests for `open_position`, `open_position_with_metadata` and `open_bundled_position`