### PR TITLE
SparseSwap (SDK)

### DIFF
--- a/sdk/src/instructions/composites/swap-async.ts
+++ b/sdk/src/instructions/composites/swap-async.ts
@@ -27,16 +27,8 @@ export async function swapAsync(
   const { wallet, whirlpool, swapInput } = params;
   const { aToB, amount } = swapInput;
   const txBuilder = new TransactionBuilder(ctx.connection, ctx.wallet, ctx.txBuilderOpts);
-  const tickArrayAddresses = [swapInput.tickArray0, swapInput.tickArray1, swapInput.tickArray2];
 
-  let uninitializedArrays = await TickArrayUtil.getUninitializedArraysString(
-    tickArrayAddresses,
-    ctx.fetcher,
-    opts
-  );
-  if (uninitializedArrays) {
-    throw new Error(`TickArray addresses - [${uninitializedArrays}] need to be initialized.`);
-  }
+  // No need to check if TickArrays are initialized after SparseSwap implementation
 
   const data = whirlpool.getData();
   const [resolvedAtaA, resolvedAtaB] = await resolveOrCreateATAs(

--- a/sdk/src/instructions/composites/swap-async.ts
+++ b/sdk/src/instructions/composites/swap-async.ts
@@ -1,6 +1,6 @@
 import { resolveOrCreateATAs, TransactionBuilder, ZERO } from "@orca-so/common-sdk";
 import { PublicKey } from "@solana/web3.js";
-import { SwapUtils, TickArrayUtil, Whirlpool, WhirlpoolContext } from "../..";
+import { SwapUtils, Whirlpool, WhirlpoolContext } from "../..";
 import { WhirlpoolAccountFetchOptions } from "../../network/public/fetcher";
 import { SwapInput, swapIx } from "../swap-ix";
 import { TokenExtensionUtil } from "../../utils/public/token-extension-util";
@@ -64,7 +64,7 @@ export async function swapAsync(
     wallet
   );
   return txBuilder.addInstruction(
-    !TokenExtensionUtil.isV2IxRequiredPool(tokenExtensionCtx)
+    (!TokenExtensionUtil.isV2IxRequiredPool(tokenExtensionCtx) && !params.swapInput.supplementalTickArrays)
       ? swapIx(ctx.program, baseParams)
       : swapV2Ix(ctx.program, {
         ...baseParams,
@@ -82,6 +82,7 @@ export async function swapAsync(
           baseParams.aToB ? baseParams.tokenOwnerAccountB : baseParams.tokenVaultB,
           baseParams.aToB ? baseParams.whirlpool : baseParams.tokenAuthority,
         ),
+        supplementalTickArrays: params.swapInput.supplementalTickArrays,
       })
   );
 }

--- a/sdk/src/instructions/composites/swap-with-route.ts
+++ b/sdk/src/instructions/composites/swap-with-route.ts
@@ -22,7 +22,6 @@ import {
   PDAUtil,
   SubTradeRoute,
   SwapUtils,
-  TickArrayUtil,
   TradeRoute,
   WhirlpoolContext,
   twoHopSwapQuoteFromSwapQuotes,

--- a/sdk/src/instructions/composites/swap-with-route.ts
+++ b/sdk/src/instructions/composites/swap-with-route.ts
@@ -111,14 +111,7 @@ export async function getSwapFromRoute(
     }
   }
 
-  let uninitializedArrays = await TickArrayUtil.getUninitializedArraysString(
-    requiredTickArrays,
-    ctx.fetcher,
-    opts
-  );
-  if (uninitializedArrays) {
-    throw new Error(`TickArray addresses - [${uninitializedArrays}] need to be initialized.`);
-  }
+  // No need to check if TickArrays are initialized after SparseSwap implementation
 
   // Handle non-native mints only first
   requiredAtas.delete(NATIVE_MINT.toBase58());

--- a/sdk/src/instructions/swap-ix.ts
+++ b/sdk/src/instructions/swap-ix.ts
@@ -41,7 +41,7 @@ export type SwapParams = SwapInput & {
  * @param tickArray0 - PublicKey of the tick-array where the Whirlpool's currentTickIndex resides in
  * @param tickArray1 - The next tick-array in the swap direction. If the swap will not reach the next tick-aray, input the same array as tickArray0.
  * @param tickArray2 - The next tick-array in the swap direction after tickArray2. If the swap will not reach the next tick-aray, input the same array as tickArray1.
- * @param supplementalTickArrays - (V2 only) Optional array of PublicKey for supplemental tick arrays. swap and twoHopSwap instruction will ignore this parameter.
+ * @param supplementalTickArrays - (V2 only) Optional array of PublicKey for supplemental tick arrays. swap instruction will ignore this parameter.
  */
 export type SwapInput = {
   amount: BN;

--- a/sdk/src/instructions/swap-ix.ts
+++ b/sdk/src/instructions/swap-ix.ts
@@ -41,6 +41,7 @@ export type SwapParams = SwapInput & {
  * @param tickArray0 - PublicKey of the tick-array where the Whirlpool's currentTickIndex resides in
  * @param tickArray1 - The next tick-array in the swap direction. If the swap will not reach the next tick-aray, input the same array as tickArray0.
  * @param tickArray2 - The next tick-array in the swap direction after tickArray2. If the swap will not reach the next tick-aray, input the same array as tickArray1.
+ * @param supplementalTickArrays - (V2 only) Optional array of PublicKey for supplemental tick arrays. swap and twoHopSwap instruction will ignore this parameter.
  */
 export type SwapInput = {
   amount: BN;
@@ -51,6 +52,7 @@ export type SwapInput = {
   tickArray0: PublicKey;
   tickArray1: PublicKey;
   tickArray2: PublicKey;
+  supplementalTickArrays?: PublicKey[];
 };
 
 /**

--- a/sdk/src/instructions/two-hop-swap-ix.ts
+++ b/sdk/src/instructions/two-hop-swap-ix.ts
@@ -58,7 +58,9 @@ export type TwoHopSwapParams = TwoHopSwapInput & {
  * @param tickArrayTwo0 - PublicKey of the tick-array of swap-Two where the Whirlpool's currentTickIndex resides in
  * @param tickArrayTwo1 - The next tick-array in the swap direction of swap-Two. If the swap will not reach the next tick-aray, input the same array as tickArray0.
  * @param tickArrayTwo2 - The next tick-array in the swap direction after tickArray2 of swap-Two. If the swap will not reach the next tick-aray, input the same array as tickArray1.
- */
+ * @param supplementalTickArraysOne - (V2 only) Optional array of PublicKey for supplemental tick arrays of whirlpoolOne. twoHopSwap instruction will ignore this parameter.
+ * @param supplementalTickArraysTwo - (V2 only) Optional array of PublicKey for supplemental tick arrays of whirlpoolTwo. twoHopSwap instruction will ignore this parameter.
+*/
 export type TwoHopSwapInput = {
   amount: BN;
   otherAmountThreshold: BN;
@@ -73,6 +75,8 @@ export type TwoHopSwapInput = {
   tickArrayTwo0: PublicKey;
   tickArrayTwo1: PublicKey;
   tickArrayTwo2: PublicKey;
+  supplementalTickArraysOne?: PublicKey[];
+  supplementalTickArraysTwo?: PublicKey[];
 };
 
 /**

--- a/sdk/src/instructions/v2/swap-ix.ts
+++ b/sdk/src/instructions/v2/swap-ix.ts
@@ -24,7 +24,6 @@ import { RemainingAccountsBuilder, RemainingAccountsType, toSupplementalTickArra
  * @param tokenProgramB - PublicKey for the token program for token B.
  * @param oracle - PublicKey for the oracle account for this Whirlpool.
  * @param tokenAuthority - authority to withdraw tokens from the input token account
- * @param supplementalTickArrays - Optional array of PublicKey for supplemental tick arrays of this whirlpool.
  */
 export type SwapV2Params = SwapInput & {
   whirlpool: PublicKey;
@@ -40,7 +39,6 @@ export type SwapV2Params = SwapInput & {
   tokenProgramB: PublicKey;
   oracle: PublicKey;
   tokenAuthority: PublicKey;
-  supplementalTickArrays?: PublicKey[];
 };
 
 /**

--- a/sdk/src/instructions/v2/two-hop-swap-ix.ts
+++ b/sdk/src/instructions/v2/two-hop-swap-ix.ts
@@ -28,8 +28,6 @@ import { TwoHopSwapInput } from "../two-hop-swap-ix";
  * @param oracleOne - PublicKey for the oracle account for this whirlpoolOne.
  * @param oracleTwo - PublicKey for the oracle account for this whirlpoolTwo.
  * @param tokenAuthority - authority to withdraw tokens from the input token account
- * @param supplementalTickArraysOne - Optional array of PublicKey for supplemental tick arrays of whirlpoolOne.
- * @param supplementalTickArraysTwo - Optional array of PublicKey for supplemental tick arrays of whirlpoolTwo.
  * @param swapInput - Parameters in {@link TwoHopSwapInput}
  */
 export type TwoHopSwapV2Params = TwoHopSwapInput & {
@@ -53,8 +51,6 @@ export type TwoHopSwapV2Params = TwoHopSwapInput & {
   oracleOne: PublicKey;
   oracleTwo: PublicKey;
   tokenAuthority: PublicKey;
-  supplementalTickArraysOne?: PublicKey[];
-  supplementalTickArraysTwo?: PublicKey[];
 };
 
 /**

--- a/sdk/src/prices/calculate-pool-prices.ts
+++ b/sdk/src/prices/calculate-pool-prices.ts
@@ -16,6 +16,7 @@ import { swapQuoteWithParams } from "../quotes/public/swap-quote";
 import { TickArray, WhirlpoolData } from "../types/public";
 import { PoolUtil, PriceMath, SwapUtils } from "../utils/public";
 import { NO_TOKEN_EXTENSION_CONTEXT } from "../utils/public/token-extension-util";
+import { getTickArrayPublicKeysWithStartTickIndex } from "../utils/swap-utils";
 
 function checkLiquidity(
   pool: WhirlpoolData,
@@ -155,7 +156,7 @@ function getTickArrays(
   config = defaultGetPricesConfig
 ): TickArray[] {
   const { programId } = config;
-  const tickArrayPublicKeys = SwapUtils.getTickArrayPublicKeys(
+  const tickArrayAddresses = getTickArrayPublicKeysWithStartTickIndex(
     pool.tickCurrentIndex,
     pool.tickSpacing,
     aToB,
@@ -163,8 +164,8 @@ function getTickArrays(
     address
   );
 
-  return tickArrayPublicKeys.map((tickArrayPublicKey) => {
-    return { address: tickArrayPublicKey, data: tickArrayMap[tickArrayPublicKey.toBase58()] };
+  return tickArrayAddresses.map((a) => {
+    return { address: a.pubkey, startTickIndex: a.startTickIndex, data: tickArrayMap[a.pubkey.toBase58()] };
   });
 }
 

--- a/sdk/src/quotes/public/swap-quote.ts
+++ b/sdk/src/quotes/public/swap-quote.ts
@@ -1,5 +1,5 @@
 import { Address } from "@coral-xyz/anchor";
-import { AddressUtil, MintWithTokenProgram, Percentage } from "@orca-so/common-sdk";
+import { AddressUtil, Percentage } from "@orca-so/common-sdk";
 import BN from "bn.js";
 import invariant from "tiny-invariant";
 import { SwapInput } from "../../instructions";
@@ -71,7 +71,6 @@ export type SwapQuote = NormalSwapQuote | DevFeeSwapQuote;
  * @param estimatedEndTickIndex - Approximate tick-index the Whirlpool will land on after this swap
  * @param estimatedEndSqrtPrice - Approximate sqrtPrice the Whirlpool will land on after this swap
  * @param estimatedFeeAmount - Approximate feeAmount (all fees) charged on this swap
- * @param fallbackTickArray - Optional. A reserve in case prices move in the opposite direction
  */
 export type SwapEstimates = {
   estimatedAmountIn: BN;
@@ -83,7 +82,6 @@ export type SwapEstimates = {
     deductingFromEstimatedAmountIn: BN;
     deductedFromEstimatedAmountOut: BN;
   };
-  fallbackTickArray?: PublicKey;
 };
 
 /**
@@ -192,7 +190,7 @@ export function swapQuoteWithParams(
       quote.tickArray2 = params.fallbackTickArray;
     } else {
       // no obvious room for fallback, but V2 can use this field
-      quote.fallbackTickArray = params.fallbackTickArray;
+      quote.supplementalTickArrays = [params.fallbackTickArray];
     }
   }
 

--- a/sdk/src/quotes/public/swap-quote.ts
+++ b/sdk/src/quotes/public/swap-quote.ts
@@ -100,10 +100,10 @@ export type NormalSwapQuote = SwapInput & SwapEstimates;
  * @param inputTokenMint - PublicKey for the input token mint to swap with
  * @param tokenAmount - The amount of input token to swap from
  * @param slippageTolerance - The amount of slippage to account for in this quote
- * @param useFallbackTickArray - An enum to specify when to use fallback tick arrays in a swap quote.
-* @param programId - PublicKey for the Whirlpool ProgramId
+ * @param programId - PublicKey for the Whirlpool ProgramId
  * @param cache - WhirlpoolAccountCacheInterface instance object to fetch solana accounts
  * @param opts an {@link WhirlpoolAccountFetchOptions} object to define fetch and cache options when accessing on-chain accounts
+ * @param useFallbackTickArray - An enum to specify when to use fallback tick arrays in a swap quote.
  * @returns a SwapQuote object with slippage adjusted SwapInput parameters & estimates on token amounts, fee & end whirlpool states.
  */
 export async function swapQuoteByInputToken(
@@ -111,10 +111,10 @@ export async function swapQuoteByInputToken(
   inputTokenMint: Address,
   tokenAmount: BN,
   slippageTolerance: Percentage,
-  useFallbackTickArray: UseFallbackTickArray,
   programId: Address,
   fetcher: WhirlpoolAccountFetcherInterface,
-  opts?: WhirlpoolAccountFetchOptions
+  opts?: WhirlpoolAccountFetchOptions,
+  useFallbackTickArray: UseFallbackTickArray = UseFallbackTickArray.Never,
 ): Promise<SwapQuote> {
   const params = await swapQuoteByToken(
     whirlpool,
@@ -140,10 +140,10 @@ export async function swapQuoteByInputToken(
  * @param outputTokenMint - PublicKey for the output token mint to swap into
  * @param tokenAmount - The maximum amount of output token to receive in this swap.
  * @param slippageTolerance - The amount of slippage to account for in this quote
- * @param useFallbackTickArray - An enum to specify when to use fallback tick arrays in a swap quote.
  * @param programId - PublicKey for the Whirlpool ProgramId
  * @param cache - WhirlpoolAccountCacheInterface instance to fetch solana accounts
  * @param opts an {@link WhirlpoolAccountFetchOptions} object to define fetch and cache options when accessing on-chain accounts
+ * @param useFallbackTickArray - An enum to specify when to use fallback tick arrays in a swap quote.
  * @returns a SwapQuote object with slippage adjusted SwapInput parameters & estimates on token amounts, fee & end whirlpool states.
  */
 export async function swapQuoteByOutputToken(
@@ -151,10 +151,10 @@ export async function swapQuoteByOutputToken(
   outputTokenMint: Address,
   tokenAmount: BN,
   slippageTolerance: Percentage,
-  useFallbackTickArray: UseFallbackTickArray,
   programId: Address,
   fetcher: WhirlpoolAccountFetcherInterface,
-  opts?: WhirlpoolAccountFetchOptions
+  opts?: WhirlpoolAccountFetchOptions,
+  useFallbackTickArray: UseFallbackTickArray = UseFallbackTickArray.Never,
 ): Promise<SwapQuote> {
   const params = await swapQuoteByToken(
     whirlpool,

--- a/sdk/src/quotes/public/swap-quote.ts
+++ b/sdk/src/quotes/public/swap-quote.ts
@@ -181,7 +181,7 @@ export function swapQuoteWithParams(
 ): SwapQuote {
   const quote = simulateSwap({
     ...params,
-    tickArrays: SwapUtils.interporateUninitializedTickArrays(PublicKey.default, params.tickArrays),  
+    tickArrays: SwapUtils.interpolateUninitializedTickArrays(PublicKey.default, params.tickArrays),  
   });
 
   if (params.fallbackTickArray) {

--- a/sdk/src/quotes/public/swap-quote.ts
+++ b/sdk/src/quotes/public/swap-quote.ts
@@ -8,13 +8,27 @@ import {
   WhirlpoolAccountFetchOptions,
   WhirlpoolAccountFetcherInterface,
 } from "../../network/public/fetcher";
-import { TickArray, WhirlpoolData } from "../../types/public";
+import { TICK_ARRAY_SIZE, TickArray, WhirlpoolData } from "../../types/public";
 import { PoolUtil, SwapDirection } from "../../utils/public";
 import { SwapUtils } from "../../utils/public/swap-utils";
 import { Whirlpool } from "../../whirlpool-client";
 import { simulateSwap } from "../swap/swap-quote-impl";
 import { DevFeeSwapQuote } from "./dev-fee-swap-quote";
 import { TokenExtensionContextForPool, TokenExtensionUtil } from "../../utils/public/token-extension-util";
+import { PublicKey } from "@solana/web3.js";
+
+/**
+ * An enum to specify when to use fallback tick arrays in a swap quote.
+ * @category Quotes
+ */
+export enum UseFallbackTickArray {
+  // Always try to include fallback tick array in the swap quote
+  Always = "Always",
+  // Never include fallback tick array in the swap quote
+  Never = "Never",
+  // Use fallback tick array only when tickCurrentIndex is the edge (last quoter) of the first tick array
+  Situational = "Situational",
+}
 
 /**
  * @category Quotes
@@ -26,6 +40,8 @@ import { TokenExtensionContextForPool, TokenExtensionUtil } from "../../utils/pu
  * @param amountSpecifiedIsInput - Specifies the token the parameter `amount`represents. If true, the amount represents
  *                                 the input token of the swap.
  * @param tickArrays - An sequential array of tick-array objects in the direction of the trade to swap on
+ * @param tokenExtensionCtx - TokenExtensions info for the whirlpool
+ * @param fallbackTickArray - Optional. A reserve in case prices move in the opposite direction
  */
 export type SwapQuoteParam = {
   whirlpoolData: WhirlpoolData;
@@ -36,6 +52,7 @@ export type SwapQuoteParam = {
   amountSpecifiedIsInput: boolean;
   tickArrays: TickArray[];
   tokenExtensionCtx: TokenExtensionContextForPool;
+  fallbackTickArray?: PublicKey;
 };
 
 /**
@@ -54,6 +71,7 @@ export type SwapQuote = NormalSwapQuote | DevFeeSwapQuote;
  * @param estimatedEndTickIndex - Approximate tick-index the Whirlpool will land on after this swap
  * @param estimatedEndSqrtPrice - Approximate sqrtPrice the Whirlpool will land on after this swap
  * @param estimatedFeeAmount - Approximate feeAmount (all fees) charged on this swap
+ * @param fallbackTickArray - Optional. A reserve in case prices move in the opposite direction
  */
 export type SwapEstimates = {
   estimatedAmountIn: BN;
@@ -65,6 +83,7 @@ export type SwapEstimates = {
     deductingFromEstimatedAmountIn: BN;
     deductedFromEstimatedAmountOut: BN;
   };
+  fallbackTickArray?: PublicKey;
 };
 
 /**
@@ -81,7 +100,8 @@ export type NormalSwapQuote = SwapInput & SwapEstimates;
  * @param inputTokenMint - PublicKey for the input token mint to swap with
  * @param tokenAmount - The amount of input token to swap from
  * @param slippageTolerance - The amount of slippage to account for in this quote
- * @param programId - PublicKey for the Whirlpool ProgramId
+ * @param useFallbackTickArray - An enum to specify when to use fallback tick arrays in a swap quote.
+* @param programId - PublicKey for the Whirlpool ProgramId
  * @param cache - WhirlpoolAccountCacheInterface instance object to fetch solana accounts
  * @param opts an {@link WhirlpoolAccountFetchOptions} object to define fetch and cache options when accessing on-chain accounts
  * @returns a SwapQuote object with slippage adjusted SwapInput parameters & estimates on token amounts, fee & end whirlpool states.
@@ -91,6 +111,7 @@ export async function swapQuoteByInputToken(
   inputTokenMint: Address,
   tokenAmount: BN,
   slippageTolerance: Percentage,
+  useFallbackTickArray: UseFallbackTickArray,
   programId: Address,
   fetcher: WhirlpoolAccountFetcherInterface,
   opts?: WhirlpoolAccountFetchOptions
@@ -100,6 +121,7 @@ export async function swapQuoteByInputToken(
     inputTokenMint,
     tokenAmount,
     true,
+    useFallbackTickArray,
     programId,
     fetcher,
     opts
@@ -118,6 +140,7 @@ export async function swapQuoteByInputToken(
  * @param outputTokenMint - PublicKey for the output token mint to swap into
  * @param tokenAmount - The maximum amount of output token to receive in this swap.
  * @param slippageTolerance - The amount of slippage to account for in this quote
+ * @param useFallbackTickArray - An enum to specify when to use fallback tick arrays in a swap quote.
  * @param programId - PublicKey for the Whirlpool ProgramId
  * @param cache - WhirlpoolAccountCacheInterface instance to fetch solana accounts
  * @param opts an {@link WhirlpoolAccountFetchOptions} object to define fetch and cache options when accessing on-chain accounts
@@ -128,6 +151,7 @@ export async function swapQuoteByOutputToken(
   outputTokenMint: Address,
   tokenAmount: BN,
   slippageTolerance: Percentage,
+  useFallbackTickArray: UseFallbackTickArray,
   programId: Address,
   fetcher: WhirlpoolAccountFetcherInterface,
   opts?: WhirlpoolAccountFetchOptions
@@ -137,6 +161,7 @@ export async function swapQuoteByOutputToken(
     outputTokenMint,
     tokenAmount,
     false,
+    useFallbackTickArray,
     programId,
     fetcher,
     opts
@@ -156,7 +181,20 @@ export function swapQuoteWithParams(
   params: SwapQuoteParam,
   slippageTolerance: Percentage
 ): SwapQuote {
-  const quote = simulateSwap(params);
+  const quote = simulateSwap({
+    ...params,
+    tickArrays: SwapUtils.interporateUninitializedTickArrays(PublicKey.default, params.tickArrays),  
+  });
+
+  if (params.fallbackTickArray) {
+    if (!quote.tickArray2.equals(quote.tickArray1)) {
+      // both V1 and V2 can use this fallback
+      quote.tickArray2 = params.fallbackTickArray;
+    } else {
+      // no obvious room for fallback, but V2 can use this field
+      quote.fallbackTickArray = params.fallbackTickArray;
+    }
+  }
 
   const slippageAdjustedQuote: SwapQuote = {
     ...quote,
@@ -177,6 +215,7 @@ async function swapQuoteByToken(
   inputTokenMint: Address,
   tokenAmount: BN,
   amountSpecifiedIsInput: boolean,
+  useFallbackTickArray: UseFallbackTickArray,
   programId: Address,
   fetcher: WhirlpoolAccountFetcherInterface,
   opts?: WhirlpoolAccountFetchOptions
@@ -200,6 +239,14 @@ async function swapQuoteByToken(
     opts
   );
 
+  const fallbackTickArray = getFallbackTickArray(
+    useFallbackTickArray,
+    tickArrays,
+    aToB,
+    whirlpool,
+    programId,
+  );
+
   const tokenExtensionCtx = await TokenExtensionUtil.buildTokenExtensionContext(fetcher, whirlpoolData, IGNORE_CACHE);
 
   return {
@@ -211,5 +258,49 @@ async function swapQuoteByToken(
     otherAmountThreshold: SwapUtils.getDefaultOtherAmountThreshold(amountSpecifiedIsInput),
     tickArrays,
     tokenExtensionCtx,
+    fallbackTickArray,
   };
+}
+
+function getFallbackTickArray(
+  useFallbackTickArray: UseFallbackTickArray,
+  tickArrays: TickArray[],
+  aToB: boolean,
+  whirlpool: Whirlpool,
+  programId: Address,
+): PublicKey | undefined {
+  if (useFallbackTickArray === UseFallbackTickArray.Never) {
+    return undefined;
+  }
+
+  const fallbackTickArray = SwapUtils.getFallbackTickArrayPublicKey(
+    tickArrays,
+    whirlpool.getData().tickSpacing,
+    aToB,
+    AddressUtil.toPubKey(programId),
+    whirlpool.getAddress(),
+  );
+
+  if (useFallbackTickArray === UseFallbackTickArray.Always || !fallbackTickArray) {
+    return fallbackTickArray;
+  }
+
+  invariant(
+    useFallbackTickArray === UseFallbackTickArray.Situational,
+    `Unexpected UseFallbackTickArray value: ${useFallbackTickArray}`
+  );
+
+  const ticksInArray = whirlpool.getData().tickSpacing * TICK_ARRAY_SIZE;
+  const tickCurrentIndex = whirlpool.getData().tickCurrentIndex;
+  if (aToB) {
+    // A to B (direction is right to left): [    ta2     ][    ta1     ][    ta0  ===]
+    // if tickCurrentIndex is within the rightmost quarter of ta0, use fallbackTickArray
+    const threshold = tickArrays[0].startTickIndex + ticksInArray / 4 * 3;
+    return tickCurrentIndex >= threshold ? fallbackTickArray : undefined;
+  } else {
+    // B to A (direction is left to right): [=== ta0     ][    ta1     ][    ta2     ]
+    // if tickCurrentIndex is within the leftmost quarter of ta0, use fallbackTickArray
+    const threshold = tickArrays[0].startTickIndex + ticksInArray / 4;
+    return tickCurrentIndex <= threshold ? fallbackTickArray : undefined;
+  }
 }

--- a/sdk/src/quotes/public/swap-quote.ts
+++ b/sdk/src/quotes/public/swap-quote.ts
@@ -18,7 +18,7 @@ import { TokenExtensionContextForPool, TokenExtensionUtil } from "../../utils/pu
 import { PublicKey } from "@solana/web3.js";
 
 /**
- * An enum to specify when to use fallback tick arrays in a swap quote.
+ * An enum to specify when to use fallback tick array in a swap quote.
  * @category Quotes
  */
 export enum UseFallbackTickArray {
@@ -101,7 +101,7 @@ export type NormalSwapQuote = SwapInput & SwapEstimates;
  * @param programId - PublicKey for the Whirlpool ProgramId
  * @param cache - WhirlpoolAccountCacheInterface instance object to fetch solana accounts
  * @param opts an {@link WhirlpoolAccountFetchOptions} object to define fetch and cache options when accessing on-chain accounts
- * @param useFallbackTickArray - An enum to specify when to use fallback tick arrays in a swap quote.
+ * @param useFallbackTickArray - An enum to specify when to use fallback tick array in a swap quote.
  * @returns a SwapQuote object with slippage adjusted SwapInput parameters & estimates on token amounts, fee & end whirlpool states.
  */
 export async function swapQuoteByInputToken(
@@ -141,7 +141,7 @@ export async function swapQuoteByInputToken(
  * @param programId - PublicKey for the Whirlpool ProgramId
  * @param cache - WhirlpoolAccountCacheInterface instance to fetch solana accounts
  * @param opts an {@link WhirlpoolAccountFetchOptions} object to define fetch and cache options when accessing on-chain accounts
- * @param useFallbackTickArray - An enum to specify when to use fallback tick arrays in a swap quote.
+ * @param useFallbackTickArray - An enum to specify when to use fallback tick array in a swap quote.
  * @returns a SwapQuote object with slippage adjusted SwapInput parameters & estimates on token amounts, fee & end whirlpool states.
  */
 export async function swapQuoteByOutputToken(

--- a/sdk/src/quotes/public/swap-quote.ts
+++ b/sdk/src/quotes/public/swap-quote.ts
@@ -185,7 +185,7 @@ export function swapQuoteWithParams(
   });
 
   if (params.fallbackTickArray) {
-    if (!quote.tickArray2.equals(quote.tickArray1)) {
+    if (quote.tickArray2.equals(quote.tickArray1)) {
       // both V1 and V2 can use this fallback
       quote.tickArray2 = params.fallbackTickArray;
     } else {

--- a/sdk/src/quotes/public/two-hop-swap-quote.ts
+++ b/sdk/src/quotes/public/two-hop-swap-quote.ts
@@ -51,6 +51,8 @@ export function twoHopSwapQuoteFromSwapQuotes(
     tickArrayTwo0: swapQuoteTwo.tickArray0,
     tickArrayTwo1: swapQuoteTwo.tickArray1,
     tickArrayTwo2: swapQuoteTwo.tickArray2,
+    supplementalTickArraysOne: swapQuoteOne.supplementalTickArrays,
+    supplementalTickArraysTwo: swapQuoteTwo.supplementalTickArrays,
     swapOneEstimates: { ...swapQuoteOne },
     swapTwoEstimates: { ...swapQuoteTwo },
   };

--- a/sdk/src/quotes/swap/tick-array-sequence.ts
+++ b/sdk/src/quotes/swap/tick-array-sequence.ts
@@ -41,6 +41,7 @@ export class TickArraySequence {
       }
       this.sequence.push({
         address: tickArray.address,
+        startTickIndex: tickArray.data.startTickIndex,
         data: tickArray.data,
       });
     }

--- a/sdk/src/types/public/client-types.ts
+++ b/sdk/src/types/public/client-types.ts
@@ -30,5 +30,6 @@ export type WhirlpoolRewardInfo = WhirlpoolRewardInfoData & {
  */
 export type TickArray = {
   address: PublicKey;
+  startTickIndex: number;
   data: TickArrayData | null;
 };

--- a/sdk/src/utils/public/swap-utils.ts
+++ b/sdk/src/utils/public/swap-utils.ts
@@ -220,7 +220,7 @@ export class SwapUtils {
    * @param tickArrays - Fetched tickArrays to interpolate.
    * @returns An array of TickArray objects with zeroed tick data if they are not initialized.
    */
-  public static interporateUninitializedTickArrays(
+  public static interpolateUninitializedTickArrays(
     whirlpoolAddress: PublicKey,
     tickArrays: TickArray[],
   ): TickArray[] {

--- a/sdk/src/utils/swap-utils.ts
+++ b/sdk/src/utils/swap-utils.ts
@@ -1,5 +1,8 @@
-import { MathUtil } from "@orca-so/common-sdk";
+import { MathUtil, ZERO } from "@orca-so/common-sdk";
+import { PublicKey } from "@solana/web3.js";
 import BN from "bn.js";
+import { MAX_SWAP_TICK_ARRAYS, TICK_ARRAY_SIZE, TickArrayData, TickData } from "../types/public";
+import { PDAUtil, TickUtil } from "./public";
 
 export function getLowerSqrtPriceFromTokenA(amount: BN, liquidity: BN, sqrtPriceX64: BN): BN {
   const numerator = liquidity.mul(sqrtPriceX64).shln(64);
@@ -25,4 +28,55 @@ export function getLowerSqrtPriceFromTokenB(amount: BN, liquidity: BN, sqrtPrice
 export function getUpperSqrtPriceFromTokenB(amount: BN, liquidity: BN, sqrtPriceX64: BN): BN {
   // always round down (rounding up a negative number)
   return sqrtPriceX64.add(amount.shln(64).div(liquidity));
+}
+
+export type TickArrayAddress = { pubkey: PublicKey; startTickIndex: number };
+
+export function getTickArrayPublicKeysWithStartTickIndex(
+  tickCurrentIndex: number,
+  tickSpacing: number,
+  aToB: boolean,
+  programId: PublicKey,
+  whirlpoolAddress: PublicKey
+): TickArrayAddress[] {
+  const shift = aToB ? 0 : tickSpacing;
+
+  let offset = 0;
+  let tickArrayAddresses: TickArrayAddress[] = [];
+  for (let i = 0; i < MAX_SWAP_TICK_ARRAYS; i++) {
+    let startIndex: number;
+    try {
+      startIndex = TickUtil.getStartTickIndex(tickCurrentIndex + shift, tickSpacing, offset);
+    } catch {
+      return tickArrayAddresses;
+    }
+
+    const pda = PDAUtil.getTickArray(programId, whirlpoolAddress, startIndex);
+    tickArrayAddresses.push({ pubkey: pda.publicKey, startTickIndex: startIndex });
+    offset = aToB ? offset - 1 : offset + 1;
+  }
+
+  return tickArrayAddresses;
+}
+
+export const ZEROED_TICK_DATA: TickData = Object.freeze(({
+  initialized: false,
+  liquidityNet: ZERO,
+  liquidityGross: ZERO,
+  feeGrowthOutsideA: ZERO,
+  feeGrowthOutsideB: ZERO,
+  rewardGrowthsOutside: [ZERO, ZERO, ZERO],
+}));
+
+export const ZEROED_TICKS: TickData[] = Array.from({ length: TICK_ARRAY_SIZE }, () => ZEROED_TICK_DATA);
+
+export function buildZeroedTickArray(
+  whirlpool: PublicKey,
+  startTickIndex: number,
+): TickArrayData {
+  return {
+    startTickIndex,
+    ticks: ZEROED_TICKS,
+    whirlpool,
+  };
 }

--- a/sdk/tests/sdk/whirlpools/swap/swap-array.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/swap-array.test.ts
@@ -81,7 +81,7 @@ describe("swap arrays test", () => {
       adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
     );
     assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-    assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
   });
 
   /**
@@ -106,21 +106,39 @@ describe("swap arrays test", () => {
       ],
     });
 
-    // estimatedEndTickIndex is 4091 (arrayIndex: 0 (not initialized))
+    // SparseSwap makes it possible to execute this swap.
+
     const whirlpoolData = await whirlpool.refreshData();
-    const expectedError = "Swap input value traversed too many arrays.";
-    await assert.rejects(
-      swapQuoteByInputToken(
-        whirlpool,
-        whirlpoolData.tokenMintA,
-        new BN(40_000_000),
-        slippageTolerance,
-        ctx.program.programId,
-        fetcher,
-        IGNORE_CACHE
-      ),
-      (err: Error) => err.message.indexOf(expectedError) != -1
+    const tradeAmount = new BN(40_000_000);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE
     );
+
+    // Verify with an actual swap.
+    // estimatedEndTickIndex is 4091 (arrayIndex: 0 (not initialized))
+    assert.equal(quote.aToB, true);
+    assert.equal(quote.amountSpecifiedIsInput, true);
+    assert.equal(
+      quote.sqrtPriceLimit.toString(),
+      SwapUtils.getDefaultSqrtPriceLimit(true).toString()
+    );
+
+    assert.equal(quote.estimatedEndTickIndex, 4091);
+    assert.equal(
+      quote.otherAmountThreshold.toString(),
+      adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
+    );
+    assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
+
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    const updatedWhirlpoolData = await whirlpool.refreshData();
+    assert.equal(updatedWhirlpoolData.tickCurrentIndex, quote.estimatedEndTickIndex);
   });
 
   /**
@@ -170,7 +188,7 @@ describe("swap arrays test", () => {
       adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
     );
     assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-    assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
   });
 
   /**
@@ -195,21 +213,39 @@ describe("swap arrays test", () => {
       ],
     });
 
-    // estimatedEndTickIndex is 556 (arrayIndex: 0 (not initialized))
+    // SparseSwap makes it possible to execute this swap.
+
     const whirlpoolData = await whirlpool.refreshData();
-    const expectedError = "Swap input value traversed too many arrays.";
-    await assert.rejects(
-      swapQuoteByInputToken(
-        whirlpool,
-        whirlpoolData.tokenMintB,
-        new BN(40_000_000),
-        slippageTolerance,
-        ctx.program.programId,
-        fetcher,
-        IGNORE_CACHE
-      ),
-      (err: Error) => err.message.indexOf(expectedError) != -1
+    const tradeAmount = new BN(40_000_000);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE
     );
+
+    // Verify with an actual swap.
+    // estimatedEndTickIndex is 556 (arrayIndex: 0 (not initialized))
+    assert.equal(quote.aToB, false);
+    assert.equal(quote.amountSpecifiedIsInput, true);
+    assert.equal(
+      quote.sqrtPriceLimit.toString(),
+      SwapUtils.getDefaultSqrtPriceLimit(false).toString()
+    );
+
+    assert.equal(quote.estimatedEndTickIndex, 556);
+    assert.equal(
+      quote.otherAmountThreshold.toString(),
+      adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
+    );
+    assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
+
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    const updatedWhirlpoolData = await whirlpool.refreshData();
+    assert.equal(updatedWhirlpoolData.tickCurrentIndex, quote.estimatedEndTickIndex);
   });
 
   /**
@@ -259,7 +295,7 @@ describe("swap arrays test", () => {
       adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
     );
     assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-    assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
   });
 
   /**
@@ -309,7 +345,7 @@ describe("swap arrays test", () => {
       adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
     );
     assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-    assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
   });
 
   /**
@@ -697,7 +733,7 @@ describe("swap arrays test", () => {
       adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
     );
     assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-    assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
   });
 
   /**
@@ -758,7 +794,7 @@ describe("swap arrays test", () => {
       adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
     );
     assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-    assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
   });
 
   /**
@@ -794,7 +830,8 @@ describe("swap arrays test", () => {
       whirlpool.getAddress()
     );
 
-    await assert.rejects(
+    // SparseSwap makes it possible to execute this swap.
+    await assert.doesNotReject(
       whirlpool.swap({
         amount: tradeAmount,
         amountSpecifiedIsInput: true,
@@ -802,13 +839,9 @@ describe("swap arrays test", () => {
         otherAmountThreshold: SwapUtils.getDefaultOtherAmountThreshold(true),
         sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
         tickArray0: tickArrays[0],
-        tickArray1: tickArrays[1],
-        tickArray2: tickArrays[2],
-      }),
-      (err: Error) => {
-        const uninitializedArrays = [tickArrays[1].toBase58(), tickArrays[2].toBase58()].join(", ");
-        return err.message.indexOf(`TickArray addresses - [${uninitializedArrays}] need to be initialized.`) >= 0;
-      }
+        tickArray1: tickArrays[1], // uninitialized TickArray is acceptable
+        tickArray2: tickArrays[2], // uninitialized TickArray is acceptable
+      })
     );
   });
 
@@ -845,7 +878,8 @@ describe("swap arrays test", () => {
       whirlpool.getAddress()
     );
 
-    await assert.rejects(
+    // SparseSwap makes it possible to execute this swap.
+    await assert.doesNotReject(
       whirlpool.swap({
         amount: tradeAmount,
         amountSpecifiedIsInput: true,
@@ -853,13 +887,9 @@ describe("swap arrays test", () => {
         otherAmountThreshold: SwapUtils.getDefaultOtherAmountThreshold(true),
         sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
         tickArray0: tickArrays[0],
-        tickArray1: tickArrays[1],
-        tickArray2: tickArrays[2],
-      }),
-      (err: Error) => {
-        const uninitializedArrays = [tickArrays[1].toBase58(), tickArrays[2].toBase58()].join(", ");
-        return err.message.indexOf(`TickArray addresses - [${uninitializedArrays}] need to be initialized.`) >= 0;
-      }
+        tickArray1: tickArrays[1], // uninitialized TickArray is acceptable
+        tickArray2: tickArrays[2], // uninitialized TickArray is acceptable
+      })
     );
   });
 });

--- a/sdk/tests/sdk/whirlpools/swap/swap-array.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/swap-array.test.ts
@@ -142,6 +142,120 @@ describe("swap arrays test", () => {
   });
 
   /**
+   * |xxxxxxxxxxxxxc2xx|xxxxxxxxxxxxxxxxx|------c1-----------|
+   */
+  it("3 sequential arrays, 2nd and 3rd array not initialized, a->b", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 44 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    // SparseSwap makes it possible to execute this swap.
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const tradeAmount = new BN(150_000_000);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE
+    );
+
+    // Verify with an actual swap.
+    // estimatedEndTickIndex is -4522 (arrayIndex: -1 (not initialized))
+    assert.equal(quote.aToB, true);
+    assert.equal(quote.amountSpecifiedIsInput, true);
+    assert.equal(
+      quote.sqrtPriceLimit.toString(),
+      SwapUtils.getDefaultSqrtPriceLimit(true).toString()
+    );
+
+    assert.equal(quote.estimatedEndTickIndex, -4522);
+    assert.equal(
+      quote.otherAmountThreshold.toString(),
+      adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
+    );
+    assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
+
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    const updatedWhirlpoolData = await whirlpool.refreshData();
+    assert.equal(updatedWhirlpoolData.tickCurrentIndex, quote.estimatedEndTickIndex);
+  });
+
+  /**
+   * |xxxxxxxxxxxxxc2xx|xxxxxxxxxxxxxxxxx|xxxxxxc1xxxxxxxxxxx|
+   */
+  it("3 sequential arrays, all array not initialized, a->b", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 44 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    // SparseSwap makes it possible to execute this swap.
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const tradeAmount = new BN(150_000_000);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE
+    );
+
+    // Verify with an actual swap.
+    // estimatedEndTickIndex is -4522 (arrayIndex: -1 (not initialized))
+    assert.equal(quote.aToB, true);
+    assert.equal(quote.amountSpecifiedIsInput, true);
+    assert.equal(
+      quote.sqrtPriceLimit.toString(),
+      SwapUtils.getDefaultSqrtPriceLimit(true).toString()
+    );
+
+    assert.equal(quote.estimatedEndTickIndex, -4522);
+    assert.equal(
+      quote.otherAmountThreshold.toString(),
+      adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
+    );
+    assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
+
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    const updatedWhirlpoolData = await whirlpool.refreshData();
+    assert.equal(updatedWhirlpoolData.tickCurrentIndex, quote.estimatedEndTickIndex);
+  });
+
+  /**
    * |-------------c1--c2-|xxxxxxxxxxxxxxxxx|-------------------|
    */
   it("3 sequential arrays, 2nd array not initialized, use tickArray0 only, b->a", async () => {
@@ -248,6 +362,120 @@ describe("swap arrays test", () => {
     assert.equal(updatedWhirlpoolData.tickCurrentIndex, quote.estimatedEndTickIndex);
   });
 
+  /**
+   * |-------------c1-----|xxxxxxxxxxxxxxxxx|xxc2xxxxxxxxxxxxx|
+   */
+  it("3 sequential arrays, 2nd and 3rd array not initialized, b->a", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -1, offsetIndex: 44 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    // SparseSwap makes it possible to execute this swap.
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const tradeAmount = new BN(150_000_000);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE
+    );
+
+    // Verify with an actual swap.
+    // estimatedEndTickIndex is 7662 (arrayIndex: 1 (not initialized))
+    assert.equal(quote.aToB, false);
+    assert.equal(quote.amountSpecifiedIsInput, true);
+    assert.equal(
+      quote.sqrtPriceLimit.toString(),
+      SwapUtils.getDefaultSqrtPriceLimit(false).toString()
+    );
+
+    assert.equal(quote.estimatedEndTickIndex, 7662);
+    assert.equal(
+      quote.otherAmountThreshold.toString(),
+      adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
+    );
+    assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
+
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    const updatedWhirlpoolData = await whirlpool.refreshData();
+    assert.equal(updatedWhirlpoolData.tickCurrentIndex, quote.estimatedEndTickIndex);
+  });
+
+  /**
+   * |xxxxxxxxxxxxxc1xxxxx|xxxxxxxxxxxxxxxxx|xxc2xxxxxxxxxxxxx|
+   */
+  it("3 sequential arrays, all array not initialized, b->a", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: -1, offsetIndex: 44 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+      ],
+    });
+
+    // SparseSwap makes it possible to execute this swap.
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const tradeAmount = new BN(150_000_000);
+    const quote = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE
+    );
+
+    // Verify with an actual swap.
+    // estimatedEndTickIndex is 7662 (arrayIndex: 1 (not initialized))
+    assert.equal(quote.aToB, false);
+    assert.equal(quote.amountSpecifiedIsInput, true);
+    assert.equal(
+      quote.sqrtPriceLimit.toString(),
+      SwapUtils.getDefaultSqrtPriceLimit(false).toString()
+    );
+
+    assert.equal(quote.estimatedEndTickIndex, 7662);
+    assert.equal(
+      quote.otherAmountThreshold.toString(),
+      adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
+    );
+    assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
+
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+    const updatedWhirlpoolData = await whirlpool.refreshData();
+    assert.equal(updatedWhirlpoolData.tickCurrentIndex, quote.estimatedEndTickIndex);
+  });
+  
   /**
    * |xxxxxxxxxxxxxxxxxxxx|xxxxxxxxxxxxxxxxx|-c2---c1-----------|
    */

--- a/sdk/tests/sdk/whirlpools/swap/swap-with-fallback.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/swap-with-fallback.test.ts
@@ -1,0 +1,834 @@
+import * as anchor from "@coral-xyz/anchor";
+import { Percentage } from "@orca-so/common-sdk";
+import * as assert from "assert";
+import BN from "bn.js";
+import {
+  ORCA_WHIRLPOOL_PROGRAM_ID,
+  PDAUtil,
+  PriceMath,
+  TwoHopSwapV2Params,
+  UseFallbackTickArray,
+  WhirlpoolContext,
+  WhirlpoolIx,
+  buildWhirlpoolClient,
+  swapQuoteByInputToken,
+  toTx,
+  twoHopSwapQuoteFromSwapQuotes,
+} from "../../../../src";
+import { IGNORE_CACHE } from "../../../../src/network/public/fetcher";
+import { TickSpacing } from "../../../utils";
+import { defaultConfirmOptions } from "../../../utils/const";
+import {
+  arrayTickIndexToTickIndex,
+  buildPosition,
+  setupSwapTest
+} from "../../../utils/swap-test-utils";
+import { buildTestAquariums, getDefaultAquarium } from "../../../utils/init-utils";
+import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
+
+describe("swap with fallback test", () => {
+  const provider = anchor.AnchorProvider.local(undefined, defaultConfirmOptions);
+
+  const program = anchor.workspace.Whirlpool;
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
+  const fetcher = ctx.fetcher;
+  const client = buildWhirlpoolClient(ctx);
+  const tickSpacing = TickSpacing.SixtyFour;
+  const slippageTolerance = Percentage.fromFraction(0, 100);
+
+  const SWAP_V1_DISCRIMINATOR = Buffer.from([0xf8, 0xc6, 0x9e, 0x91, 0xe1, 0x75, 0x87, 0xc8]);
+  const SWAP_V2_DISCRIMINATOR = Buffer.from([0x2b, 0x04, 0xed, 0x0b, 0x1a, 0xc9, 0x1e, 0x62]);
+
+  /**
+   * |-5632-----------|0------------c2-|5632---------c1-|11264-----------|
+   */
+  it("a->b, on rightmost quoter, ta1 = ta2", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 77 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+        buildPosition(
+          // b
+          { arrayIndex: 0, offsetIndex: 0 },
+          { arrayIndex: 0, offsetIndex: 87 },
+          tickSpacing,
+          new BN(1)
+        ),
+      ],
+    });
+
+    const taNeg11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -11264).publicKey;
+    const taNeg5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -5632).publicKey;
+    const ta0 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 0).publicKey;
+    const ta5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 5632).publicKey;
+    const ta11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 11264).publicKey;
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const tradeAmount = new BN(50_000_000);
+    const quoteNever = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Never,
+    );
+
+    const estimatedEndTickIndex = 4734; // arrayIndex: 0
+
+    assert.equal(quoteNever.aToB, true);
+    assert.equal(quoteNever.amountSpecifiedIsInput, true);
+    assert.equal(quoteNever.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteNever.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteNever.tickArray0.equals(ta5632));
+    assert.ok(quoteNever.tickArray1.equals(ta0));
+    assert.ok(quoteNever.tickArray2.equals(ta0)); // no fallback tick array
+    assert.ok(quoteNever.supplementalTickArrays === undefined);
+    
+    const quoteAlways = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Always,
+    );
+
+    assert.equal(quoteAlways.aToB, true);
+    assert.equal(quoteAlways.amountSpecifiedIsInput, true);
+    assert.equal(quoteAlways.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteAlways.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteAlways.tickArray0.equals(ta5632));
+    assert.ok(quoteAlways.tickArray1.equals(ta0));
+    assert.ok(quoteAlways.tickArray2.equals(ta11264)); // fallback
+    assert.ok(quoteAlways.supplementalTickArrays === undefined);
+
+    const quoteSituational = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Situational,
+    );
+
+    assert.equal(quoteSituational.aToB, true);
+    assert.equal(quoteSituational.amountSpecifiedIsInput, true);
+    assert.equal(quoteSituational.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteSituational.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteSituational.tickArray0.equals(ta5632));
+    assert.ok(quoteSituational.tickArray1.equals(ta0));
+    assert.ok(quoteSituational.tickArray2.equals(ta11264)); // fallback
+    assert.ok(quoteSituational.supplementalTickArrays === undefined);
+
+    // V1 instruction will be used because we can use tickArray2 as fallback
+    const tx = await whirlpool.swap(quoteAlways);
+    assert.ok(tx.compressIx(true).instructions.some((ix) => 
+      ix.programId.equals(ORCA_WHIRLPOOL_PROGRAM_ID) &&
+      ix.data.subarray(0, 8).equals(SWAP_V1_DISCRIMINATOR)
+    ));    
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quoteAlways)).buildAndExecute());
+  });
+
+  /**
+   * |-5632--------c2-|0---------------|5632---------c1-|11264-----------|
+   */
+  it("a->b, on rightmost quoter, ta1 != ta2 (no room for fallback)", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 77 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+        buildPosition(
+          // b
+          { arrayIndex: 0, offsetIndex: 0 },
+          { arrayIndex: 0, offsetIndex: 87 },
+          tickSpacing,
+          new BN(1)
+        ),
+      ],
+    });
+
+    const taNeg11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -11264).publicKey;
+    const taNeg5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -5632).publicKey;
+    const ta0 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 0).publicKey;
+    const ta5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 5632).publicKey;
+    const ta11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 11264).publicKey;
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const tradeAmount = new BN(120_000_000);
+    const quoteNever = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Never,
+    );
+
+    const estimatedEndTickIndex = -1323; // arrayIndex: -1
+
+    assert.equal(quoteNever.aToB, true);
+    assert.equal(quoteNever.amountSpecifiedIsInput, true);
+    assert.equal(quoteNever.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteNever.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteNever.tickArray0.equals(ta5632));
+    assert.ok(quoteNever.tickArray1.equals(ta0));
+    assert.ok(quoteNever.tickArray2.equals(taNeg5632)); // no fallback tick array
+    assert.ok(quoteNever.supplementalTickArrays === undefined);
+    
+    const quoteAlways = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Always,
+    );
+
+    assert.equal(quoteAlways.aToB, true);
+    assert.equal(quoteAlways.amountSpecifiedIsInput, true);
+    assert.equal(quoteAlways.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteAlways.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteAlways.tickArray0.equals(ta5632));
+    assert.ok(quoteAlways.tickArray1.equals(ta0));
+    assert.ok(quoteAlways.tickArray2.equals(taNeg5632)); // no fallback tick array
+    assert.ok(quoteAlways.supplementalTickArrays?.length === 1);
+    assert.ok(quoteAlways.supplementalTickArrays[0].equals(ta11264)); // fallback in supplemental
+
+    const quoteSituational = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Situational,
+    );
+
+    assert.equal(quoteSituational.aToB, true);
+    assert.equal(quoteSituational.amountSpecifiedIsInput, true);
+    assert.equal(quoteSituational.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteSituational.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteSituational.tickArray0.equals(ta5632));
+    assert.ok(quoteSituational.tickArray1.equals(ta0));
+    assert.ok(quoteSituational.tickArray2.equals(taNeg5632)); // no fallback tick array
+    assert.ok(quoteSituational.supplementalTickArrays?.length === 1);
+    assert.ok(quoteSituational.supplementalTickArrays[0].equals(ta11264)); // fallback in supplemental
+
+    // V2 instruction will be used to use supplemental tick arrays
+    const tx = await whirlpool.swap(quoteAlways);
+    assert.ok(tx.compressIx(true).instructions.some((ix) => 
+      ix.programId.equals(ORCA_WHIRLPOOL_PROGRAM_ID) &&
+      ix.data.subarray(0, 8).equals(SWAP_V2_DISCRIMINATOR)
+    ));
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quoteAlways)).buildAndExecute());
+  });
+
+  /**
+   * |-5632-----------|0------------c2-|5632-c1---------|11264-----------|
+   */
+  it("a->b, not on rightmost quoter, ta1 = ta2", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 1, offsetIndex: 44 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+        buildPosition(
+          // b
+          { arrayIndex: 0, offsetIndex: 0 },
+          { arrayIndex: 0, offsetIndex: 87 },
+          tickSpacing,
+          new BN(1)
+        ),
+      ],
+    });
+
+    const taNeg11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -11264).publicKey;
+    const taNeg5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -5632).publicKey;
+    const ta0 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 0).publicKey;
+    const ta5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 5632).publicKey;
+    const ta11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 11264).publicKey;
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const tradeAmount = new BN(50_000_000);
+    const quoteNever = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Never,
+    );
+
+    const estimatedEndTickIndex = 3135; // arrayIndex: 0
+
+    assert.equal(quoteNever.aToB, true);
+    assert.equal(quoteNever.amountSpecifiedIsInput, true);
+    assert.equal(quoteNever.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteNever.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteNever.tickArray0.equals(ta5632));
+    assert.ok(quoteNever.tickArray1.equals(ta0));
+    assert.ok(quoteNever.tickArray2.equals(ta0)); // no fallback tick array
+    assert.ok(quoteNever.supplementalTickArrays === undefined);
+    
+    const quoteAlways = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Always,
+    );
+
+    assert.equal(quoteAlways.aToB, true);
+    assert.equal(quoteAlways.amountSpecifiedIsInput, true);
+    assert.equal(quoteAlways.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteAlways.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteAlways.tickArray0.equals(ta5632));
+    assert.ok(quoteAlways.tickArray1.equals(ta0));
+    assert.ok(quoteAlways.tickArray2.equals(ta11264)); // fallback
+    assert.ok(quoteAlways.supplementalTickArrays === undefined);
+
+    const quoteSituational = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintA,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Situational,
+    );
+
+    // no fallback because it is not on the rightmost quoter
+    assert.equal(quoteSituational.aToB, true);
+    assert.equal(quoteSituational.amountSpecifiedIsInput, true);
+    assert.equal(quoteSituational.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteSituational.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteSituational.tickArray0.equals(ta5632));
+    assert.ok(quoteSituational.tickArray1.equals(ta0));
+    assert.ok(quoteSituational.tickArray2.equals(ta0)); // no fallback tick array
+    assert.ok(quoteSituational.supplementalTickArrays === undefined);
+  });
+
+  /**
+   * |-5632-----------|0-c1------------|5632---------c2-|11264-----------|
+   */
+  it("b->a, on leftmost quoter, ta1 = ta2", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 0, offsetIndex: 11 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+        buildPosition(
+          // b
+          { arrayIndex: 1, offsetIndex: 0 },
+          { arrayIndex: 1, offsetIndex: 87 },
+          tickSpacing,
+          new BN(1)
+        ),
+      ],
+    });
+
+    const taNeg11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -11264).publicKey;
+    const taNeg5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -5632).publicKey;
+    const ta0 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 0).publicKey;
+    const ta5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 5632).publicKey;
+    const ta11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 11264).publicKey;
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const tradeAmount = new BN(100_000_000);
+    const quoteNever = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Never,
+    );
+
+    const estimatedEndTickIndex = 7218; // arrayIndex: 1
+
+    assert.equal(quoteNever.aToB, false);
+    assert.equal(quoteNever.amountSpecifiedIsInput, true);
+    assert.equal(quoteNever.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteNever.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteNever.tickArray0.equals(ta0));
+    assert.ok(quoteNever.tickArray1.equals(ta5632));
+    assert.ok(quoteNever.tickArray2.equals(ta5632)); // no fallback tick array
+    assert.ok(quoteNever.supplementalTickArrays === undefined);
+    
+    const quoteAlways = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Always,
+    );
+
+    assert.equal(quoteAlways.aToB, false);
+    assert.equal(quoteAlways.amountSpecifiedIsInput, true);
+    assert.equal(quoteAlways.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteAlways.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteAlways.tickArray0.equals(ta0));
+    assert.ok(quoteAlways.tickArray1.equals(ta5632));
+    assert.ok(quoteAlways.tickArray2.equals(taNeg5632)); // fallback
+    assert.ok(quoteAlways.supplementalTickArrays === undefined);
+
+    const quoteSituational = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Situational,
+    );
+
+    assert.equal(quoteSituational.aToB, false);
+    assert.equal(quoteSituational.amountSpecifiedIsInput, true);
+    assert.equal(quoteSituational.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteSituational.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteSituational.tickArray0.equals(ta0));
+    assert.ok(quoteSituational.tickArray1.equals(ta5632));
+    assert.ok(quoteSituational.tickArray2.equals(taNeg5632)); // fallback
+    assert.ok(quoteSituational.supplementalTickArrays === undefined);
+
+    // V1 instruction will be used because we can use tickArray2 as fallback
+    const tx = await whirlpool.swap(quoteAlways);
+    assert.ok(tx.compressIx(true).instructions.some((ix) => 
+      ix.programId.equals(ORCA_WHIRLPOOL_PROGRAM_ID) &&
+      ix.data.subarray(0, 8).equals(SWAP_V1_DISCRIMINATOR)
+    ));
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quoteAlways)).buildAndExecute());
+  });
+
+  /**
+   * |-5632-----------|0-c1------------|5632------------|11264---c2------|
+   */
+  it("b->a, on leftmost quoter, ta1 != ta2 (no room for fallback)", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 0, offsetIndex: 11 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+        buildPosition(
+          // b
+          { arrayIndex: 1, offsetIndex: 0 },
+          { arrayIndex: 1, offsetIndex: 87 },
+          tickSpacing,
+          new BN(1)
+        ),
+      ],
+    });
+
+    const taNeg11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -11264).publicKey;
+    const taNeg5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -5632).publicKey;
+    const ta0 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 0).publicKey;
+    const ta5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 5632).publicKey;
+    const ta11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 11264).publicKey;
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const tradeAmount = new BN(200_000_000);
+    const quoteNever = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Never,
+    );
+
+    const estimatedEndTickIndex = 12124; // arrayIndex: 2
+
+    assert.equal(quoteNever.aToB, false);
+    assert.equal(quoteNever.amountSpecifiedIsInput, true);
+    assert.equal(quoteNever.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteNever.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteNever.tickArray0.equals(ta0));
+    assert.ok(quoteNever.tickArray1.equals(ta5632));
+    assert.ok(quoteNever.tickArray2.equals(ta11264)); // no fallback tick array
+    assert.ok(quoteNever.supplementalTickArrays === undefined);
+    
+    const quoteAlways = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Always,
+    );
+
+    assert.equal(quoteAlways.aToB, false);
+    assert.equal(quoteAlways.amountSpecifiedIsInput, true);
+    assert.equal(quoteAlways.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteAlways.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteAlways.tickArray0.equals(ta0));
+    assert.ok(quoteAlways.tickArray1.equals(ta5632));
+    assert.ok(quoteAlways.tickArray2.equals(ta11264)); // no fallback tick array
+    assert.ok(quoteAlways.supplementalTickArrays?.length === 1);
+    assert.ok(quoteAlways.supplementalTickArrays[0].equals(taNeg5632)); // fallback in supplemental
+
+    const quoteSituational = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Situational,
+    );
+
+    assert.equal(quoteSituational.aToB, false);
+    assert.equal(quoteSituational.amountSpecifiedIsInput, true);
+    assert.equal(quoteSituational.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteSituational.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteSituational.tickArray0.equals(ta0));
+    assert.ok(quoteSituational.tickArray1.equals(ta5632));
+    assert.ok(quoteSituational.tickArray2.equals(ta11264)); // no fallback tick array
+    assert.ok(quoteSituational.supplementalTickArrays?.length === 1);
+    assert.ok(quoteSituational.supplementalTickArrays[0].equals(taNeg5632)); // fallback in supplemental
+
+    // V2 instruction will be used to use supplemental tick arrays
+    const tx = await whirlpool.swap(quoteAlways);
+    assert.ok(tx.compressIx(true).instructions.some((ix) => 
+      ix.programId.equals(ORCA_WHIRLPOOL_PROGRAM_ID) &&
+      ix.data.subarray(0, 8).equals(SWAP_V2_DISCRIMINATOR)
+    ));
+    await assert.doesNotReject(async () => await (await whirlpool.swap(quoteAlways)).buildAndExecute());
+  });
+
+
+  /**
+   * |-5632-----------|0-------c1------|5632---------c2-|11264-----------|
+   */
+  it("b->a, not on leftmost quoter, ta1 = ta2", async () => {
+    const currIndex = arrayTickIndexToTickIndex({ arrayIndex: 0, offsetIndex: 44 }, tickSpacing);
+    const whirlpool = await setupSwapTest({
+      ctx,
+      client,
+      tickSpacing,
+      initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(currIndex),
+      initArrayStartTicks: [-11264, -5632, 0, 5632, 11264],
+      fundedPositions: [
+        buildPosition(
+          // a
+          { arrayIndex: -2, offsetIndex: 44 },
+          { arrayIndex: 2, offsetIndex: 44 },
+          tickSpacing,
+          new BN(250_000_000)
+        ),
+        buildPosition(
+          // b
+          { arrayIndex: 1, offsetIndex: 0 },
+          { arrayIndex: 1, offsetIndex: 87 },
+          tickSpacing,
+          new BN(1)
+        ),
+      ],
+    });
+
+    const taNeg11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -11264).publicKey;
+    const taNeg5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), -5632).publicKey;
+    const ta0 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 0).publicKey;
+    const ta5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 5632).publicKey;
+    const ta11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, whirlpool.getAddress(), 11264).publicKey;
+
+    const whirlpoolData = await whirlpool.refreshData();
+    const tradeAmount = new BN(100_000_000);
+    const quoteNever = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Never,
+    );
+
+    const estimatedEndTickIndex = 8765; // arrayIndex: 1
+
+    assert.equal(quoteNever.aToB, false);
+    assert.equal(quoteNever.amountSpecifiedIsInput, true);
+    assert.equal(quoteNever.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteNever.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteNever.tickArray0.equals(ta0));
+    assert.ok(quoteNever.tickArray1.equals(ta5632));
+    assert.ok(quoteNever.tickArray2.equals(ta5632)); // no fallback tick array
+    assert.ok(quoteNever.supplementalTickArrays === undefined);
+    
+    const quoteAlways = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Always,
+    );
+
+    assert.equal(quoteAlways.aToB, false);
+    assert.equal(quoteAlways.amountSpecifiedIsInput, true);
+    assert.equal(quoteAlways.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteAlways.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteAlways.tickArray0.equals(ta0));
+    assert.ok(quoteAlways.tickArray1.equals(ta5632));
+    assert.ok(quoteAlways.tickArray2.equals(taNeg5632)); // fallback
+    assert.ok(quoteAlways.supplementalTickArrays === undefined);
+
+    const quoteSituational = await swapQuoteByInputToken(
+      whirlpool,
+      whirlpoolData.tokenMintB,
+      tradeAmount,
+      slippageTolerance,
+      ctx.program.programId,
+      fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Situational,
+    );
+
+    // no fallback because it is not on the leftmost quoter
+    assert.equal(quoteSituational.aToB, false);
+    assert.equal(quoteSituational.amountSpecifiedIsInput, true);
+    assert.equal(quoteSituational.estimatedEndTickIndex, estimatedEndTickIndex);
+    assert.equal(quoteSituational.estimatedAmountIn.toString(), tradeAmount);
+    assert.ok(quoteSituational.tickArray0.equals(ta0));
+    assert.ok(quoteSituational.tickArray1.equals(ta5632));
+    assert.ok(quoteSituational.tickArray2.equals(ta5632)); // no fallback tick array
+    assert.ok(quoteSituational.supplementalTickArrays === undefined);
+  });
+
+  it("twoHopSwapQuoteFromSwapQuotes", async () => {
+    const tickSpacing64 = 64;
+    const aToB = false;
+
+    const aqConfig = getDefaultAquarium();
+
+    // Add a third token and account and a second pool
+    aqConfig.initFeeTierParams = [{ tickSpacing: tickSpacing64 }];
+    aqConfig.initMintParams.push({});
+    aqConfig.initTokenAccParams.push({ mintIndex: 2 });
+    aqConfig.initPoolParams = [
+      { mintIndices: [0, 1], tickSpacing: tickSpacing64, initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(2816) },
+      { mintIndices: [1, 2], tickSpacing: tickSpacing64, initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(2816) },
+    ];
+
+    // Add tick arrays and positions
+    aqConfig.initTickArrayRangeParams.push({
+      poolIndex: 0,
+      startTickIndex: -444928,
+      arrayCount: 1,
+      aToB,
+    });
+    aqConfig.initTickArrayRangeParams.push({
+      poolIndex: 0,
+      startTickIndex: 439296,
+      arrayCount: 1,
+      aToB,
+    });
+    aqConfig.initTickArrayRangeParams.push({
+      poolIndex: 1,
+      startTickIndex: -444928,
+      arrayCount: 1,
+      aToB,
+    });
+    aqConfig.initTickArrayRangeParams.push({
+      poolIndex: 1,
+      startTickIndex: 439296,
+      arrayCount: 1,
+      aToB,
+    });
+
+    // pool1(b(2) -> a(1)) --> pool0(b(1) -> a(0)) (so pool0 has smaller liquidity)
+    aqConfig.initPositionParams.push({ poolIndex: 0, fundParams: [
+      {
+        liquidityAmount: new anchor.BN(4_100_000),
+        tickLowerIndex: -443584,
+        tickUpperIndex: 443584,
+      },
+    ]});
+    aqConfig.initPositionParams.push({ poolIndex: 1, fundParams: [
+      {
+        liquidityAmount: new anchor.BN(10_000_000),
+        tickLowerIndex: -443584,
+        tickUpperIndex: 443584,
+      },
+    ]});
+    const aquarium = (await buildTestAquariums(ctx, [aqConfig]))[0];
+
+    const poolInit0 = aquarium.pools[0];
+    const poolInit1 = aquarium.pools[1];
+    const pool0 = await client.getPool(poolInit0.whirlpoolPda.publicKey, IGNORE_CACHE);
+    const pool1 = await client.getPool(poolInit1.whirlpoolPda.publicKey, IGNORE_CACHE);
+
+    // quote1: in 8731861 out 3740488 end tick 14080
+    // quote0: in 3740488 out 1571989 end tick 14462
+
+    const quote1 = await swapQuoteByInputToken(
+      pool1,
+      pool1.getData().tokenMintB,
+      new BN(8731861),
+      Percentage.fromFraction(0, 100),
+      ORCA_WHIRLPOOL_PROGRAM_ID,
+      ctx.fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Always,
+    );
+
+    const quote0 = await swapQuoteByInputToken(
+      pool0,
+      pool0.getData().tokenMintB,
+      quote1.estimatedAmountOut,
+      Percentage.fromFraction(0, 100),
+      ORCA_WHIRLPOOL_PROGRAM_ID,
+      ctx.fetcher,
+      IGNORE_CACHE,
+      UseFallbackTickArray.Always,
+    );
+
+    const pool0TaNeg5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, pool0.getAddress(), -5632).publicKey;
+    const pool0Ta0 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, pool0.getAddress(), 0).publicKey;
+    const pool0Ta5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, pool0.getAddress(), 5632).publicKey;
+    const pool0Ta11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, pool0.getAddress(), 11264).publicKey;
+
+    const pool1TaNeg5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, pool1.getAddress(), -5632).publicKey;
+    const pool1Ta0 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, pool1.getAddress(), 0).publicKey;
+    const pool1Ta5632 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, pool1.getAddress(), 5632).publicKey;
+    const pool1Ta11264 = PDAUtil.getTickArray(ORCA_WHIRLPOOL_PROGRAM_ID, pool1.getAddress(), 11264).publicKey;
+
+    assert.ok(quote1.tickArray0.equals(pool1Ta0));
+    assert.ok(quote1.tickArray1.equals(pool1Ta5632));
+    assert.ok(quote1.tickArray2.equals(pool1Ta11264)); // no room for fallback
+    assert.ok(quote1.supplementalTickArrays?.length === 1);
+    assert.ok(quote1.supplementalTickArrays[0].equals(pool1TaNeg5632)); // fallback in supplemental
+
+    assert.ok(quote0.tickArray0.equals(pool0Ta0));
+    assert.ok(quote0.tickArray1.equals(pool0Ta5632));
+    assert.ok(quote0.tickArray2.equals(pool0Ta11264)); // no room for fallback
+    assert.ok(quote0.supplementalTickArrays?.length === 1);
+    assert.ok(quote0.supplementalTickArrays[0].equals(pool0TaNeg5632)); // fallback in supplemental
+
+    const twoHopQuote = twoHopSwapQuoteFromSwapQuotes(quote1, quote0);
+
+    // verify if the twoHopQuote has supplemental tick arrays
+    assert.ok(twoHopQuote.supplementalTickArraysOne?.length === 1);
+    assert.ok(twoHopQuote.supplementalTickArraysOne[0].equals(pool1TaNeg5632));
+    assert.ok(twoHopQuote.supplementalTickArraysTwo?.length === 1);
+    assert.ok(twoHopQuote.supplementalTickArraysTwo[0].equals(pool0TaNeg5632));
+
+    const params: TwoHopSwapV2Params = {
+      ...twoHopQuote,
+      tokenAuthority: ctx.wallet.publicKey,
+      whirlpoolOne: pool1.getAddress(),
+      whirlpoolTwo: pool0.getAddress(),
+      oracleOne: PDAUtil.getOracle(ctx.program.programId, pool1.getAddress()).publicKey,
+      oracleTwo: PDAUtil.getOracle(ctx.program.programId, pool0.getAddress()).publicKey,
+      tokenProgramInput: TOKEN_PROGRAM_ID,
+      tokenProgramIntermediate: TOKEN_PROGRAM_ID,
+      tokenProgramOutput: TOKEN_PROGRAM_ID,
+      tokenMintInput: pool1.getData().tokenMintB,
+      tokenMintIntermediate: pool1.getData().tokenMintA,
+      tokenMintOutput: pool0.getData().tokenMintA,
+      tokenVaultOneInput: pool1.getData().tokenVaultB,
+      tokenVaultOneIntermediate: pool1.getData().tokenVaultA,
+      tokenVaultTwoIntermediate: pool0.getData().tokenVaultB,
+      tokenVaultTwoOutput: pool0.getData().tokenVaultA,
+      tokenOwnerAccountInput: aquarium.tokenAccounts[2].account,
+      tokenOwnerAccountOutput: aquarium.tokenAccounts[0].account,
+    };
+
+    // verify if the params has supplemental tick arrays
+    assert.ok(params.supplementalTickArraysOne?.length === 1);
+    assert.ok(params.supplementalTickArraysOne[0].equals(pool1TaNeg5632));
+    assert.ok(params.supplementalTickArraysTwo?.length === 1);
+    assert.ok(params.supplementalTickArraysTwo[0].equals(pool0TaNeg5632));
+
+    // execute twoHopSwapV2 with supplemental tick arrays
+    assert.ok((await pool1.refreshData()).tickCurrentIndex !== quote1.estimatedEndTickIndex);
+    assert.ok((await pool0.refreshData()).tickCurrentIndex !== quote0.estimatedEndTickIndex);
+    const tx = toTx(ctx, WhirlpoolIx.twoHopSwapV2Ix(ctx.program, params));
+    await assert.doesNotReject(async () => await tx.buildAndExecute());
+    assert.ok((await pool1.refreshData()).tickCurrentIndex === quote1.estimatedEndTickIndex);
+    assert.ok((await pool0.refreshData()).tickCurrentIndex === quote0.estimatedEndTickIndex);
+  });
+});

--- a/sdk/tests/sdk/whirlpools/swap/v2/swap-array.test.ts
+++ b/sdk/tests/sdk/whirlpools/swap/v2/swap-array.test.ts
@@ -113,7 +113,7 @@ describe("swap arrays test (v2)", () => {
           adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
         );
         assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-        assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+        assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
       });
 
       /**
@@ -139,21 +139,39 @@ describe("swap arrays test (v2)", () => {
           ],
         });
 
-        // estimatedEndTickIndex is 4091 (arrayIndex: 0 (not initialized))
+        // SparseSwap makes it possible to execute this swap.
+
         const whirlpoolData = await whirlpool.refreshData();
-        const expectedError = "Swap input value traversed too many arrays.";
-        await assert.rejects(
-          swapQuoteByInputToken(
-            whirlpool,
-            whirlpoolData.tokenMintA,
-            new BN(40_000_000),
-            slippageTolerance,
-            ctx.program.programId,
-            fetcher,
-            IGNORE_CACHE
-          ),
-          (err: Error) => err.message.indexOf(expectedError) != -1
+        const tradeAmount = new BN(40_000_000);
+        const quote = await swapQuoteByInputToken(
+          whirlpool,
+          whirlpoolData.tokenMintA,
+          tradeAmount,
+          slippageTolerance,
+          ctx.program.programId,
+          fetcher,
+          IGNORE_CACHE
         );
+
+        // Verify with an actual swap.
+        // estimatedEndTickIndex is 4091 (arrayIndex: 0 (not initialized))
+        assert.equal(quote.aToB, true);
+        assert.equal(quote.amountSpecifiedIsInput, true);
+        assert.equal(
+          quote.sqrtPriceLimit.toString(),
+          SwapUtils.getDefaultSqrtPriceLimit(true).toString()
+        );
+
+        assert.equal(quote.estimatedEndTickIndex, 4091);
+        assert.equal(
+          quote.otherAmountThreshold.toString(),
+          adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
+        );
+        assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
+
+        await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+        const updatedWhirlpoolData = await whirlpool.refreshData();
+        assert.equal(updatedWhirlpoolData.tickCurrentIndex, quote.estimatedEndTickIndex);
       });
 
       /**
@@ -204,7 +222,7 @@ describe("swap arrays test (v2)", () => {
           adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
         );
         assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-        assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+        assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
       });
 
       /**
@@ -230,21 +248,39 @@ describe("swap arrays test (v2)", () => {
           ],
         });
 
-        // estimatedEndTickIndex is 556 (arrayIndex: 0 (not initialized))
+        // SparseSwap makes it possible to execute this swap.
+
         const whirlpoolData = await whirlpool.refreshData();
-        const expectedError = "Swap input value traversed too many arrays.";
-        await assert.rejects(
-          swapQuoteByInputToken(
-            whirlpool,
-            whirlpoolData.tokenMintB,
-            new BN(40_000_000),
-            slippageTolerance,
-            ctx.program.programId,
-            fetcher,
-            IGNORE_CACHE
-          ),
-          (err: Error) => err.message.indexOf(expectedError) != -1
+        const tradeAmount = new BN(40_000_000);
+        const quote = await swapQuoteByInputToken(
+          whirlpool,
+          whirlpoolData.tokenMintB,
+          tradeAmount,
+          slippageTolerance,
+          ctx.program.programId,
+          fetcher,
+          IGNORE_CACHE
         );
+
+        // Verify with an actual swap.
+        // estimatedEndTickIndex is 556 (arrayIndex: 0 (not initialized))
+        assert.equal(quote.aToB, false);
+        assert.equal(quote.amountSpecifiedIsInput, true);
+        assert.equal(
+          quote.sqrtPriceLimit.toString(),
+          SwapUtils.getDefaultSqrtPriceLimit(false).toString()
+        );
+
+        assert.equal(quote.estimatedEndTickIndex, 556);
+        assert.equal(
+          quote.otherAmountThreshold.toString(),
+          adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
+        );
+        assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
+
+        await assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+        const updatedWhirlpoolData = await whirlpool.refreshData();
+        assert.equal(updatedWhirlpoolData.tickCurrentIndex, quote.estimatedEndTickIndex);
       });
 
       /**
@@ -295,7 +331,7 @@ describe("swap arrays test (v2)", () => {
           adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
         );
         assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-        assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+        assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
       });
 
       /**
@@ -346,7 +382,7 @@ describe("swap arrays test (v2)", () => {
           adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
         );
         assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-        assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+        assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
       });
 
       /**
@@ -741,7 +777,7 @@ describe("swap arrays test (v2)", () => {
           adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
         );
         assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-        assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+        assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
       });
 
       /**
@@ -803,7 +839,7 @@ describe("swap arrays test (v2)", () => {
           adjustForSlippage(quote.estimatedAmountOut, slippageTolerance, false).toString()
         );
         assert.equal(quote.estimatedAmountIn.toString(), tradeAmount);
-        assert.doesNotThrow(async () => await (await whirlpool.swap(quote)).buildAndExecute());
+        assert.doesNotReject(async () => await (await whirlpool.swap(quote)).buildAndExecute());
       });
 
       /**
@@ -840,7 +876,8 @@ describe("swap arrays test (v2)", () => {
           whirlpool.getAddress()
         );
 
-        await assert.rejects(
+        // SparseSwap makes it possible to execute this swap.
+        await assert.doesNotReject(
           whirlpool.swap({
             amount: tradeAmount,
             amountSpecifiedIsInput: true,
@@ -848,13 +885,9 @@ describe("swap arrays test (v2)", () => {
             otherAmountThreshold: SwapUtils.getDefaultOtherAmountThreshold(true),
             sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
             tickArray0: tickArrays[0],
-            tickArray1: tickArrays[1],
-            tickArray2: tickArrays[2],
-          }),
-          (err: Error) => {
-            const uninitializedArrays = [tickArrays[1].toBase58(), tickArrays[2].toBase58()].join(", ");
-            return err.message.indexOf(`TickArray addresses - [${uninitializedArrays}] need to be initialized.`) >= 0;
-          }
+            tickArray1: tickArrays[1], // uninitialized TickArray is acceptable
+            tickArray2: tickArrays[2], // uninitialized TickArray is acceptable
+          })
         );
       });
 
@@ -892,7 +925,8 @@ describe("swap arrays test (v2)", () => {
           whirlpool.getAddress()
         );
 
-        await assert.rejects(
+        // SparseSwap makes it possible to execute this swap.
+        await assert.doesNotReject(
           whirlpool.swap({
             amount: tradeAmount,
             amountSpecifiedIsInput: true,
@@ -900,13 +934,9 @@ describe("swap arrays test (v2)", () => {
             otherAmountThreshold: SwapUtils.getDefaultOtherAmountThreshold(true),
             sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(aToB),
             tickArray0: tickArrays[0],
-            tickArray1: tickArrays[1],
-            tickArray2: tickArrays[2],
-          }),
-          (err: Error) => {
-            const uninitializedArrays = [tickArrays[1].toBase58(), tickArrays[2].toBase58()].join(", ");
-            return err.message.indexOf(`TickArray addresses - [${uninitializedArrays}] need to be initialized.`) >= 0;
-          }
+            tickArray1: tickArrays[1], // uninitialized TickArray is acceptable
+            tickArray2: tickArrays[2], // uninitialized TickArray is acceptable
+          })
         );
       });
     });

--- a/sdk/tests/sdk/whirlpools/utils/swap-utils.test.ts
+++ b/sdk/tests/sdk/whirlpools/utils/swap-utils.test.ts
@@ -222,7 +222,7 @@ describe("SwapUtils tests", () => {
     });
   });
 
-  describe("interporateUninitializedTickArrays", () => {
+  describe("interpolateUninitializedTickArrays", () => {
     const whirlpoolAddress = Keypair.generate().publicKey;
     const tickSpacing = TickSpacing.Standard;
     const initializedTick: TickData = {
@@ -245,7 +245,7 @@ describe("SwapUtils tests", () => {
         { address: whirlpoolAddress, startTickIndex: tickSpacing * TICK_ARRAY_SIZE * 1, data: initializedTickArrayData },
         { address: whirlpoolAddress, startTickIndex: tickSpacing * TICK_ARRAY_SIZE * 2, data: initializedTickArrayData },
       ];
-      const result = SwapUtils.interporateUninitializedTickArrays(whirlpoolAddress, tickArrays);
+      const result = SwapUtils.interpolateUninitializedTickArrays(whirlpoolAddress, tickArrays);
 
       // no change
       assert.ok(result[0].data === initializedTickArrayData);
@@ -259,7 +259,7 @@ describe("SwapUtils tests", () => {
         { address: whirlpoolAddress, startTickIndex: tickSpacing * TICK_ARRAY_SIZE * 1, data: null },
         { address: whirlpoolAddress, startTickIndex: tickSpacing * TICK_ARRAY_SIZE * 2, data: initializedTickArrayData },
       ];
-      const result = SwapUtils.interporateUninitializedTickArrays(whirlpoolAddress, tickArrays);
+      const result = SwapUtils.interpolateUninitializedTickArrays(whirlpoolAddress, tickArrays);
 
       // no change
       assert.ok(result[0].data === initializedTickArrayData);
@@ -284,7 +284,7 @@ describe("SwapUtils tests", () => {
         { address: whirlpoolAddress, startTickIndex: tickSpacing * TICK_ARRAY_SIZE * 1, data: null },
         { address: whirlpoolAddress, startTickIndex: tickSpacing * TICK_ARRAY_SIZE * 2, data: null },
       ];
-      const result = SwapUtils.interporateUninitializedTickArrays(whirlpoolAddress, tickArrays);
+      const result = SwapUtils.interpolateUninitializedTickArrays(whirlpoolAddress, tickArrays);
 
       for (let i = 0; i < 3; i++) {
         assert.ok(result[i].data !== null && result[i].data!.startTickIndex === result[i].startTickIndex);

--- a/sdk/tests/sdk/whirlpools/utils/tick-array-sequence.test.ts
+++ b/sdk/tests/sdk/whirlpools/utils/tick-array-sequence.test.ts
@@ -1,9 +1,8 @@
 import { TICK_ARRAY_SIZE } from "../../../../src";
 import * as assert from "assert";
 import { TickArraySequence } from "../../../../src/quotes/swap/tick-array-sequence";
-import { buildTickArrayData, testEmptyTickArrray } from "../../../utils/testDataTypes";
+import { buildTickArrayData } from "../../../utils/testDataTypes";
 import { TickArrayIndex } from "../../../../src/quotes/swap/tick-array-index";
-import { Whirlpool } from "../../../../src/artifacts/whirlpool";
 import { SwapErrorCode, WhirlpoolsError } from "../../../../src/errors/errors";
 
 describe("TickArray Sequence tests", () => {

--- a/sdk/tests/utils/testDataTypes.ts
+++ b/sdk/tests/utils/testDataTypes.ts
@@ -60,11 +60,6 @@ export const testTickArrayData: TickArrayData = {
   whirlpool: PublicKey.default,
 };
 
-export const testEmptyTickArrray: TickArray = {
-  address: PublicKey.default,
-  data: null,
-};
-
 export const buildTickArrayData = (startTick: number, initializedOffsets: number[]): TickArray => {
   const result = {
     ticks: Array(TICK_ARRAY_SIZE).fill(testUninitializedTickData),
@@ -79,7 +74,7 @@ export const buildTickArrayData = (startTick: number, initializedOffsets: number
     result.ticks[offset] = testInitializedTickData;
   });
   const randomAddr = Keypair.generate().publicKey;
-  return { address: randomAddr, data: result };
+  return { address: randomAddr, startTickIndex: startTick, data: result };
 };
 
 export async function getTickArrays(
@@ -87,8 +82,8 @@ export async function getTickArrays(
   ctx: WhirlpoolContext,
   whirlpoolKey: PublicKey,
   fetcher: WhirlpoolAccountFetcherInterface
-) {
-  const tickArrayPdas = await startIndices.map((value) =>
+): Promise<TickArray[]> {
+  const tickArrayPdas = startIndices.map((value) =>
     PDAUtil.getTickArray(ctx.program.programId, whirlpoolKey, value)
   );
   const tickArrayAddresses = tickArrayPdas.map((pda) => pda.publicKey);
@@ -96,6 +91,7 @@ export async function getTickArrays(
   return tickArrayAddresses.map((addr, index) => {
     return {
       address: addr,
+      startTickIndex: startIndices[index],
       data: tickArrays[index],
     };
   });


### PR DESCRIPTION
This PR introduces the benefits provided by SparseSwap into SDK.

## We no longer need to stop quote right before uninitialized tickarray
The swapQuoteX function gets the estimate without any concern for the existence of uninitialized TickArrays.
Whirlpool.swap and the swapAsync behind it no longer pre-verify whether a TickArray is initialized or not.

To enjoy the benefit of not having to worry about uninitialized TickArrays by default, the SDK interpolate uninitialized TickArrays with zeroed data in swapQuoteWithParams function.
As a result, functions that use swapQuoteWithParams, such as sqapQuoteByInputToken, also benefit.

- `swapQuoteByInputToken` --> `swapQuoteWithParams`
- `swapQuoteByOutputToken` --> `swapQuoteWithParams`
- `swapQuoteWithParams` (direct use)

## User can insert fallback tickarray if they want
On the other hand, the behavior of supplemental tick arrays and preliminary additions to previous tick arrays are disabled by default. (`UseFallbackTickArray.Never`)
This is to prevent breaking changes on the function interface.

If users want to add a fallback, they must explicitly use `UseFallbackTickArray.Always` or `UseFallbackTickArray.Situational`.

```
export async function swapQuoteByInputToken(
  whirlpool: Whirlpool,
  inputTokenMint: Address,
  tokenAmount: BN,
  slippageTolerance: Percentage,
  programId: Address,
  fetcher: WhirlpoolAccountFetcherInterface,
  opts?: WhirlpoolAccountFetchOptions,
  useFallbackTickArray: UseFallbackTickArray = UseFallbackTickArray.Never, 👈
): Promise<SwapQuote> {
```

### UseFallbackTickArray.Situational
Add a TickArray in the opposite direction as a fallback only if the price is at the end 1/4 of the current TickArray.

```
b to a
[  fallback  ][//p///      ta0   ][      ta1   ][      ta2   ]  ---> fallback will be added
[  fallback  ][//////  p   ta0   ][      ta1   ][      ta2   ]  ---> fallback will NOT be added

a to b
[   ta2      ][   ta1      ][   ta0             //p///][  fallback  ]  ---> fallback will be added
[   ta2      ][   ta1      ][   ta0        p    //////][  fallback  ]  ---> fallback will NOT be added
```

1/4 is fixed value. Devs who want to tune the behavior shoud use `swapQuoteWithparams` and `SwapUtils.getFallbackTickArrayPublicKey` directly.

### How to add fallback tick array
If only one or two tickarrays are used in a trade (ta1=ta2), add it as ta2. (it is safe way because ta2 is dup of ta1)
This way is prefer because V1 users can also benefit.

On the other hand, if three TickArrays are used, it is added to the estimate as `supplementalTickArrays` and used only in the V2 instruction.

`Whirlpool.swap` uses V2 if the pool uses TokenExtension or if `supplementalTickArrays` is not empty.