### PR TITLE
bump legacy-sdk version to 0.13.4

### DIFF
--- a/legacy-sdk/whirlpool/package.json
+++ b/legacy-sdk/whirlpool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/whirlpools-sdk",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "Typescript SDK to interact with Orca's Whirlpool program.",
   "license": "Apache-2.0",
   "main": "dist/index.js",


### PR DESCRIPTION
bump & release legacy-sdk version to make SparseSwap feature public.