### PR TITLE
Fix concurrency group for the checks gh actions workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     branches: [main]
 
-concurrency:
-  group: "checks"
-  cancel-in-progress: true
-
 jobs:
 
   build:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build:


### PR DESCRIPTION
This did not behave as intended so removing it again. Basically I thought this would cancel running jobs on a per-branch basis meaning that if you push a new commit to a branch it cancels all in-progress jobs for that branch. This however works on a global-basis meaning that one PR can cancel the workflow run of another PR. I have changed the key to something unique per branch meaning that one branch can only ever cancel in-progress workflows for that specific branch.

Reference: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs