### PR TITLE
Remove unnecessary cloning of transfer hook accounts

### DIFF
--- a/programs/whirlpool/src/util/v2/token.rs
+++ b/programs/whirlpool/src/util/v2/token.rs
@@ -80,7 +80,7 @@ pub fn transfer_from_owner_to_vault_v2<'info>(
             token_vault.to_account_info(),
             authority.to_account_info(),
             amount,
-            &transfer_hook_accounts.clone().unwrap(),
+            transfer_hook_accounts.as_ref().unwrap(),
         )?;
     }
 
@@ -159,7 +159,7 @@ pub fn transfer_from_vault_to_owner_v2<'info>(
             token_vault.to_account_info(),
             whirlpool.to_account_info(),
             amount,
-            &transfer_hook_accounts.clone().unwrap(),
+            transfer_hook_accounts.as_ref().unwrap(),
         )?;
     }
 


### PR DESCRIPTION
### Problem

`transfer_hook_accounts` are cloned and referenced immediately which wastes CU and memory unnecessarily:

https://github.com/orca-so/whirlpools/blob/8c596979c40d0fc4658a819b0fbdbe438a73fcac/programs/whirlpool/src/util/v2/token.rs#L83

https://github.com/orca-so/whirlpools/blob/8c596979c40d0fc4658a819b0fbdbe438a73fcac/programs/whirlpool/src/util/v2/token.rs#L162

### Summary of changes

Remove unnecessary cloning of transfer hook accounts and reference them instead.