### PR TITLE
Dependabot group program dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,15 @@ updates:
       interval: "daily"
     labels: [ ]
   - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels: [ ]
+    groups:
+      program-dependencies:
+        applies-to: version-updates
+  - package-ecosystem: "cargo"
     directories:
-      - "/"
       - "rust-sdk/*"
       - "ts-sdk/*"
     schedule:


### PR DESCRIPTION
This should create a single PR for dependencies of the program. This will still create separate dependencies for security-updates. If a crate is marked as vulnerable and an update is available this will still be in a separate PR.
