### PR TITLE
Reject partial fill in ExactOut if sqrt_price_limit = 0

### DIFF
--- a/legacy-sdk/whirlpool/tests/integration/multi-ix/splash_pool.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/multi-ix/splash_pool.test.ts
@@ -1,20 +1,12 @@
 import * as anchor from "@coral-xyz/anchor";
-import { DecimalUtil, Percentage, U64_MAX } from "@orca-so/common-sdk";
-import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
-import type { AccountMeta, PublicKey } from "@solana/web3.js";
-import { Keypair } from "@solana/web3.js";
+import { DecimalUtil, Percentage } from "@orca-so/common-sdk";
+import type { PublicKey } from "@solana/web3.js";
 import * as assert from "assert";
 import BN from "bn.js";
 import type {
-  SwapQuote,
-  TwoHopSwapV2Params,
   WhirlpoolClient,
-  WhirlpoolData,
 } from "../../../src";
 import {
-  MAX_SQRT_PRICE,
-  MEMO_PROGRAM_ADDRESS,
-  MIN_SQRT_PRICE,
   MIN_SQRT_PRICE_BN,
   PDAUtil,
   PriceMath,
@@ -23,26 +15,16 @@ import {
   WhirlpoolIx,
   buildWhirlpoolClient,
   increaseLiquidityQuoteByInputToken,
-  swapQuoteByInputToken,
   swapQuoteByOutputToken,
-  swapQuoteWithParams,
   toTx,
 } from "../../../src";
 import { WhirlpoolContext } from "../../../src/context";
 import { IGNORE_CACHE } from "../../../src/network/public/fetcher";
 import { defaultConfirmOptions } from "../../utils/const";
 import {
-  buildTestAquariums,
-  getDefaultAquarium,
   initTestPoolWithTokens,
 } from "../../utils/init-utils";
 import { NO_TOKEN_EXTENSION_CONTEXT } from "../../../src/utils/public/token-extension-util";
-import { buildTickArrayData } from "../../utils/testDataTypes";
-import type { SwapV2Params } from "../../../src/instructions";
-import {
-  RemainingAccountsBuilder,
-  RemainingAccountsType,
-} from "../../../src/utils/remaining-accounts-util";
 import { getTokenBalance } from "../../utils";
 
 interface SharedTestContext {

--- a/legacy-sdk/whirlpool/tests/integration/multi-ix/splash_pool.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/multi-ix/splash_pool.test.ts
@@ -1,0 +1,217 @@
+import * as anchor from "@coral-xyz/anchor";
+import { DecimalUtil, Percentage, U64_MAX } from "@orca-so/common-sdk";
+import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
+import type { AccountMeta, PublicKey } from "@solana/web3.js";
+import { Keypair } from "@solana/web3.js";
+import * as assert from "assert";
+import BN from "bn.js";
+import type {
+  SwapQuote,
+  TwoHopSwapV2Params,
+  WhirlpoolClient,
+  WhirlpoolData,
+} from "../../../src";
+import {
+  MAX_SQRT_PRICE,
+  MEMO_PROGRAM_ADDRESS,
+  MIN_SQRT_PRICE,
+  MIN_SQRT_PRICE_BN,
+  PDAUtil,
+  PriceMath,
+  SwapUtils,
+  TickUtil,
+  WhirlpoolIx,
+  buildWhirlpoolClient,
+  increaseLiquidityQuoteByInputToken,
+  swapQuoteByInputToken,
+  swapQuoteByOutputToken,
+  swapQuoteWithParams,
+  toTx,
+} from "../../../src";
+import { WhirlpoolContext } from "../../../src/context";
+import { IGNORE_CACHE } from "../../../src/network/public/fetcher";
+import { defaultConfirmOptions } from "../../utils/const";
+import {
+  buildTestAquariums,
+  getDefaultAquarium,
+  initTestPoolWithTokens,
+} from "../../utils/init-utils";
+import { NO_TOKEN_EXTENSION_CONTEXT } from "../../../src/utils/public/token-extension-util";
+import { buildTickArrayData } from "../../utils/testDataTypes";
+import type { SwapV2Params } from "../../../src/instructions";
+import {
+  RemainingAccountsBuilder,
+  RemainingAccountsType,
+} from "../../../src/utils/remaining-accounts-util";
+import { getTokenBalance } from "../../utils";
+
+interface SharedTestContext {
+  provider: anchor.AnchorProvider;
+  whirlpoolCtx: WhirlpoolContext;
+  whirlpoolClient: WhirlpoolClient;
+}
+
+describe("splash pool tests", () => {
+  const provider = anchor.AnchorProvider.local(
+    undefined,
+    defaultConfirmOptions,
+  );
+
+  let testCtx: SharedTestContext;
+
+  before(() => {
+    anchor.setProvider(provider);
+    const program = anchor.workspace.Whirlpool;
+    const whirlpoolCtx = WhirlpoolContext.fromWorkspace(provider, program);
+    const whirlpoolClient = buildWhirlpoolClient(whirlpoolCtx);
+
+    testCtx = {
+      provider,
+      whirlpoolCtx,
+      whirlpoolClient,
+    };
+  });
+
+  // TODO: add u64 related test cases when we update the math logic
+
+  const tickSpacingSplash128 = 32768 + 128;
+
+  async function getTokenBalances(tokenAccountA: PublicKey, tokenAccountB: PublicKey): Promise<[BN, BN]> {
+    const tokenVaultA = new anchor.BN(
+      await getTokenBalance(
+        provider,
+        tokenAccountA,
+      ),
+    );
+    const tokenVaultB = new anchor.BN(
+      await getTokenBalance(
+        provider,
+        tokenAccountB,
+      ),
+    );
+    return [tokenVaultA, tokenVaultB];
+  }
+
+  it("ExactOut Sandwitch attack senario", async () => {
+    const { poolInitInfo, whirlpoolPda, tokenAccountA, tokenAccountB } =
+    await initTestPoolWithTokens(
+      testCtx.whirlpoolCtx,
+      tickSpacingSplash128,
+      PriceMath.tickIndexToSqrtPriceX64(0), // 1 B/A
+      new BN(2_000_000_000),
+    );
+
+    const pool = await testCtx.whirlpoolClient.getPool(
+      whirlpoolPda.publicKey,
+    );
+
+    // [-2,894,848   ][0            ][
+    await (await pool.initTickArrayForTicks([
+      // SplashPool has only 2 TickArrays for negative and positive ticks
+      -1, +1
+    ]))!.buildAndExecute();
+
+    const fullRange = TickUtil.getFullRangeTickIndex(pool.getData().tickSpacing);
+
+    // create 2 position (small & large)
+    const depositQuoteSmall = increaseLiquidityQuoteByInputToken(
+      poolInitInfo.tokenMintB,
+      DecimalUtil.fromBN(new BN(1), 0), // very thin liquidity
+      fullRange[0],
+      fullRange[1],
+      Percentage.fromFraction(0, 100),
+      pool,
+      NO_TOKEN_EXTENSION_CONTEXT,
+    );
+    const small = await pool.openPosition(fullRange[0], fullRange[1], depositQuoteSmall);
+    await small.tx.buildAndExecute();
+
+    const depositQuoteLarge = increaseLiquidityQuoteByInputToken(
+      poolInitInfo.tokenMintB,
+      DecimalUtil.fromBN(new BN(1_000_000_000), 0), // extremely larger than small position
+      fullRange[0],
+      fullRange[1],
+      Percentage.fromFraction(0, 100),
+      pool,
+      NO_TOKEN_EXTENSION_CONTEXT,
+    );
+    const large = await pool.openPosition(fullRange[0], fullRange[1], depositQuoteLarge);
+    await large.tx.buildAndExecute();
+
+    await pool.refreshData();
+
+    const preLiquidity = pool.getData().liquidity;
+
+    // get quote with small and large position liquidity
+    const swapQuote = await swapQuoteByOutputToken(
+      pool,
+      poolInitInfo.tokenMintB,
+      new BN(800_000_000),
+      Percentage.fromFraction(0, 100),
+      testCtx.whirlpoolCtx.program.programId,
+      testCtx.whirlpoolCtx.fetcher,
+      IGNORE_CACHE,
+    );
+
+    const params = SwapUtils.getSwapParamsFromQuote(
+      swapQuote,
+      testCtx.whirlpoolCtx,
+      pool,
+      tokenAccountA,
+      tokenAccountB,
+      testCtx.provider.wallet.publicKey,
+    );
+
+    // close large position
+    const largePosition = PDAUtil.getPosition(testCtx.whirlpoolCtx.program.programId, large.positionMint).publicKey;
+
+    const closeTx = await pool.closePosition(
+      largePosition,
+      Percentage.fromFraction(0, 100),
+    );
+    for (const tx of closeTx) {
+      await tx.buildAndExecute();
+    }
+
+    // liquidity should be decreased
+    await pool.refreshData();
+    const postLiquidity = pool.getData().liquidity;
+    assert.ok(preLiquidity.gt(postLiquidity));
+
+    const [preA, preB] = await getTokenBalances(tokenAccountA, tokenAccountB);
+
+    // with sqrtPriceLimit = 0, partial fill will be rejected
+    // so trade will be protected from sandwich attack if sqrtPriceLimit = 0 is used.
+    await assert.rejects(
+      toTx(
+        testCtx.whirlpoolCtx,
+        WhirlpoolIx.swapIx(testCtx.whirlpoolCtx.program, {
+          ...params,
+          sqrtPriceLimit: new BN(0),
+        }),
+      ).buildAndExecute(),
+      /0x17a9/, // PartialFillError
+    );
+
+    // with sqrtPriceLimit != 0, partial fill will be allowed
+    await toTx(
+      testCtx.whirlpoolCtx,
+      WhirlpoolIx.swapIx(testCtx.whirlpoolCtx.program, {
+        ...params,
+        sqrtPriceLimit: MIN_SQRT_PRICE_BN,
+      }),
+    ).buildAndExecute();
+
+    const [postA, postB] = await getTokenBalances(tokenAccountA, tokenAccountB);
+
+    await pool.refreshData();
+
+    // input (partial) 
+    assert.ok(preA.sub(postA).lt(swapQuote.estimatedAmountIn));
+    // output (partial)
+    assert.ok(postB.sub(preB).lt(swapQuote.estimatedAmountOut));
+    // hit min
+    assert.ok(pool.getData().sqrtPrice.eq(MIN_SQRT_PRICE_BN));
+  });
+
+});

--- a/legacy-sdk/whirlpool/tests/integration/swap.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/swap.test.ts
@@ -1,6 +1,7 @@
 import * as anchor from "@coral-xyz/anchor";
 import { web3 } from "@coral-xyz/anchor";
-import { MathUtil, PDA, Percentage } from "@orca-so/common-sdk";
+import { MathUtil,  Percentage } from "@orca-so/common-sdk";
+import type { PDA } from "@orca-so/common-sdk";
 import * as assert from "assert";
 import BN from "bn.js";
 import Decimal from "decimal.js";
@@ -33,7 +34,7 @@ import {
   initTickArrayRange,
   withdrawPositions,
 } from "../utils/init-utils";
-import { PublicKey } from "@solana/web3.js";
+import type { PublicKey } from "@solana/web3.js";
 
 describe("swap", () => {
   const provider = anchor.AnchorProvider.local(
@@ -2229,8 +2230,6 @@ describe("swap", () => {
         IGNORE_CACHE,
       );
 
-      const [preA, preB] = await getTokenBalances();
-  
       await assert.rejects(
         toTx(
           ctx,
@@ -2474,8 +2473,6 @@ describe("swap", () => {
         fetcher,
         IGNORE_CACHE,
       );
-
-      const [preA, preB] = await getTokenBalances();
   
       await assert.rejects(
         toTx(

--- a/legacy-sdk/whirlpool/tests/integration/two_hop_swap.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/two_hop_swap.test.ts
@@ -1037,6 +1037,7 @@ describe("two-hop swap", () => {
           ctx,
           WhirlpoolIx.twoHopSwapIx(ctx.program, {
             ...twoHopQuote,
+            sqrtPriceLimitOne: MIN_SQRT_PRICE_BN, // Partial fill is allowed
             sqrtPriceLimitTwo: new BN(0), // Partial fill is NOT allowed
             ...getParamsFromPools([pools[0], pools[1]], tokenAccounts),
             tokenAuthority: ctx.wallet.publicKey,
@@ -1049,6 +1050,7 @@ describe("two-hop swap", () => {
         ctx,
         WhirlpoolIx.twoHopSwapIx(ctx.program, {
           ...twoHopQuote,
+          sqrtPriceLimitOne: MIN_SQRT_PRICE_BN, // Partial fill is allowed
           sqrtPriceLimitTwo: MIN_SQRT_PRICE_BN, // Partial fill is allowed
           ...getParamsFromPools([pools[0], pools[1]], tokenAccounts),
           tokenAuthority: ctx.wallet.publicKey,
@@ -1130,6 +1132,7 @@ describe("two-hop swap", () => {
           WhirlpoolIx.twoHopSwapIx(ctx.program, {
             ...twoHopQuote,
             sqrtPriceLimitOne: new BN(0), // Partial fill is NOT allowed
+            sqrtPriceLimitTwo: MIN_SQRT_PRICE_BN, // Partial fill is allowed
             ...getParamsFromPools([pools[0], pools[1]], tokenAccounts),
             tokenAuthority: ctx.wallet.publicKey,
           }),
@@ -1212,7 +1215,8 @@ describe("two-hop swap", () => {
           ctx,
           WhirlpoolIx.twoHopSwapIx(ctx.program, {
             ...twoHopQuote,
-            sqrtPriceLimitTwo: new BN(0), // Partial fill is NOT allowed
+            sqrtPriceLimitOne: MIN_SQRT_PRICE_BN, // Partial fill is allowed
+            sqrtPriceLimitTwo: MIN_SQRT_PRICE_BN, // Partial fill is allowed
             ...getParamsFromPools([pools[0], pools[1]], tokenAccounts),
             tokenAuthority: ctx.wallet.publicKey,
           }),
@@ -1431,6 +1435,7 @@ describe("two-hop swap", () => {
           ctx,
           WhirlpoolIx.twoHopSwapIx(ctx.program, {
             ...twoHopQuote,
+            sqrtPriceLimitOne: MIN_SQRT_PRICE_BN, // Partial fill is allowed
             sqrtPriceLimitTwo: PriceMath.tickIndexToSqrtPriceX64(1002), // Partial fill
             ...getParamsFromPools([pools[0], pools[1]], tokenAccounts),
             tokenAuthority: ctx.wallet.publicKey,

--- a/legacy-sdk/whirlpool/tests/integration/two_hop_swap.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/two_hop_swap.test.ts
@@ -658,7 +658,7 @@ describe("two-hop swap", () => {
     );
   });
 
-  it("swaps [2] with two-hop swap, amount_specified_is_input=true, second swap price limit", async () => {
+  it("fails swaps [2] with two-hop swap, amount_specified_is_input=true, second swap price limit", async () => {
     const aquarium = (await buildTestAquariums(ctx, [aqConfig]))[0];
     const { tokenAccounts, mintKeys, pools } = aquarium;
 
@@ -701,21 +701,17 @@ describe("two-hop swap", () => {
 
     const twoHopQuote = twoHopSwapQuoteFromSwapQuotes(quote, quote2);
 
-    await toTx(
-      ctx,
-      WhirlpoolIx.twoHopSwapIx(ctx.program, {
-        ...twoHopQuote,
-        ...getParamsFromPools([pools[0], pools[1]], tokenAccounts),
-        tokenAuthority: ctx.wallet.publicKey,
-      }),
-    ).buildAndExecute();
-
-    whirlpoolOne = await client.getPool(whirlpoolOneKey, IGNORE_CACHE);
-    whirlpoolTwo = await client.getPool(whirlpoolTwoKey, IGNORE_CACHE);
-
-    assert.equal(
-      whirlpoolTwo.getData().sqrtPrice.eq(quote2.sqrtPriceLimit),
-      true,
+    // output amount of swapOne must be equal to input amount of swapTwo
+    await assert.rejects(
+      toTx(
+        ctx,
+        WhirlpoolIx.twoHopSwapIx(ctx.program, {
+          ...twoHopQuote,
+          ...getParamsFromPools([pools[0], pools[1]], tokenAccounts),
+          tokenAuthority: ctx.wallet.publicKey,
+        }),
+      ).buildAndExecute(),
+      /0x17a3/, // IntermediateTokenAmountMismatch
     );
   });
 

--- a/legacy-sdk/whirlpool/tests/integration/two_hop_swap.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/two_hop_swap.test.ts
@@ -870,7 +870,7 @@ describe("two-hop swap", () => {
       let whirlpoolOne = await client.getPool(whirlpoolOneKey, IGNORE_CACHE);
       let whirlpoolTwo = await client.getPool(whirlpoolTwoKey, IGNORE_CACHE);
 
-      const [inputToken, intermediaryToken, outputToken] = mintKeys;
+      const [_inputToken, intermediaryToken, outputToken] = mintKeys;
   
       const quoteSecond = await swapQuoteByOutputToken(
         whirlpoolTwo,
@@ -960,7 +960,7 @@ describe("two-hop swap", () => {
       let whirlpoolOne = await client.getPool(whirlpoolOneKey, IGNORE_CACHE);
       let whirlpoolTwo = await client.getPool(whirlpoolTwoKey, IGNORE_CACHE);
 
-      const [inputToken, intermediaryToken, outputToken] = mintKeys;
+      const [_inputToken, intermediaryToken, outputToken] = mintKeys;
   
       // 1 --> 1
       const quoteSecond = await swapQuoteByOutputToken(
@@ -1043,7 +1043,7 @@ describe("two-hop swap", () => {
       let whirlpoolOne = await client.getPool(whirlpoolOneKey, IGNORE_CACHE);
       let whirlpoolTwo = await client.getPool(whirlpoolTwoKey, IGNORE_CACHE);
 
-      const [inputToken, intermediaryToken, outputToken] = mintKeys;
+      const [_inputToken, intermediaryToken, outputToken] = mintKeys;
   
       // 1 --> 1
       const quoteSecond = await swapQuoteByOutputToken(
@@ -1126,7 +1126,7 @@ describe("two-hop swap", () => {
       let whirlpoolOne = await client.getPool(whirlpoolOneKey, IGNORE_CACHE);
       let whirlpoolTwo = await client.getPool(whirlpoolTwoKey, IGNORE_CACHE);
 
-      const [inputToken, intermediaryToken, outputToken] = mintKeys;
+      const [inputToken, intermediaryToken, _outputToken] = mintKeys;
         
       // 1000000 --> 1103339
       const quoteFirst = await swapQuoteByInputToken(

--- a/legacy-sdk/whirlpool/tests/integration/v2/collect_fees_v2.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v2/collect_fees_v2.test.ts
@@ -1187,7 +1187,7 @@ describe("collect_fees_v2", () => {
             tokenVaultB: tokenVaultBKeypair.publicKey,
           }),
         ).buildAndExecute(),
-        /0x7d3/, // ConstraintRaw
+        /0x7dc/ // ConstraintAddress
       );
     });
 
@@ -1241,7 +1241,7 @@ describe("collect_fees_v2", () => {
             tokenVaultB: tokenVaultBKeypair.publicKey,
           }),
         ).buildAndExecute(),
-        /0x7d3/, // ConstraintRaw
+        /0x7dc/ // ConstraintAddress
       );
     });
 
@@ -1349,7 +1349,7 @@ describe("collect_fees_v2", () => {
             tokenVaultB: tokenVaultBKeypair.publicKey,
           }),
         ).buildAndExecute(),
-        /0x7d3/, // ConstraintRaw
+        /0x7dc/ // ConstraintAddress
       );
     });
 
@@ -1403,7 +1403,7 @@ describe("collect_fees_v2", () => {
             tokenVaultB: tokenVaultBKeypair.publicKey,
           }),
         ).buildAndExecute(),
-        /0x7d3/, // ConstraintRaw
+        /0x7dc/ // ConstraintAddress
       );
     });
 

--- a/legacy-sdk/whirlpool/tests/integration/v2/swap_v2.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v2/swap_v2.test.ts
@@ -1,7 +1,7 @@
 import * as anchor from "@coral-xyz/anchor";
 import { web3 } from "@coral-xyz/anchor";
 import { MathUtil, Percentage } from "@orca-so/common-sdk";
-import { PDA } from "@orca-so/common-sdk";
+import type { PDA } from "@orca-so/common-sdk";
 import * as assert from "assert";
 import { BN } from "bn.js";
 import Decimal from "decimal.js";

--- a/legacy-sdk/whirlpool/tests/integration/v2/swap_v2.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v2/swap_v2.test.ts
@@ -1,14 +1,16 @@
 import * as anchor from "@coral-xyz/anchor";
 import { web3 } from "@coral-xyz/anchor";
-import { MathUtil, Percentage } from "@orca-so/common-sdk";
+import { MathUtil, PDA, Percentage } from "@orca-so/common-sdk";
 import * as assert from "assert";
 import { BN } from "bn.js";
 import Decimal from "decimal.js";
-import type { SwapV2Params, TickArrayData, WhirlpoolData } from "../../../src";
+import type { InitPoolV2Params, SwapV2Params, TickArrayData, WhirlpoolData } from "../../../src";
 import {
   MAX_SQRT_PRICE,
+  MAX_SQRT_PRICE_BN,
   METADATA_PROGRAM_ADDRESS,
   MIN_SQRT_PRICE,
+  MIN_SQRT_PRICE_BN,
   PDAUtil,
   PriceMath,
   SwapUtils,
@@ -16,6 +18,9 @@ import {
   TickUtil,
   WhirlpoolContext,
   WhirlpoolIx,
+  buildWhirlpoolClient,
+  swapQuoteByInputToken,
+  swapQuoteByOutputToken,
   swapQuoteWithParams,
   toTx,
 } from "../../../src";
@@ -43,6 +48,7 @@ import {
 } from "../../utils/v2/init-utils-v2";
 import { createMintV2 } from "../../utils/v2/token-2022";
 import { TokenExtensionUtil } from "../../../src/utils/public/token-extension-util";
+import { PublicKey } from "@solana/web3.js";
 
 describe("swap_v2", () => {
   const provider = anchor.AnchorProvider.local(
@@ -2349,6 +2355,549 @@ describe("swap_v2", () => {
           //console.log(await getTokenBalance(provider, poolInitInfo.tokenVaultBKeypair.publicKey));
         });
       });
+    });
+
+    describe("partial fill, b to a", () => {
+      const tickSpacing = 128;
+      const aToB = false;
+      const client = buildWhirlpoolClient(ctx);
+
+      let poolInitInfo: InitPoolV2Params;
+      let whirlpoolPda: PDA;
+      let tokenAccountA: PublicKey;
+      let tokenAccountB: PublicKey;
+      let whirlpoolKey: PublicKey;
+      let oraclePda: PDA;
+
+      beforeEach(async () => {
+        const init =
+          await initTestPoolWithTokensV2(
+            ctx,
+            {isToken2022: true},
+            {isToken2022: true},
+            tickSpacing,
+            PriceMath.tickIndexToSqrtPriceX64(439296 + 1),
+            new BN("10000000000000000000000")
+        );
+
+        poolInitInfo = init.poolInitInfo;
+        whirlpoolPda = poolInitInfo.whirlpoolPda;
+        tokenAccountA = init.tokenAccountA;
+        tokenAccountB = init.tokenAccountB;
+        whirlpoolKey = poolInitInfo.whirlpoolPda.publicKey;
+        oraclePda = PDAUtil.getOracle(ctx.program.programId, whirlpoolKey);
+
+        await initTickArrayRange(
+          ctx,
+          whirlpoolPda.publicKey,
+          439296, // right most TickArray
+          1,
+          tickSpacing,
+          aToB,
+        );
+    
+        // a: 1 (round up)
+        // b: 223379095563402706 (to get 1, need >= 223379095563402706)
+        const fundParams: FundedPositionV2Params[] = [
+          {
+            liquidityAmount: new anchor.BN(10_000_000_000),
+            tickLowerIndex: 439424,
+            tickUpperIndex: 439552,
+          },
+        ];
+    
+        await fundPositionsV2(
+          ctx,
+          poolInitInfo,
+          tokenAccountA,
+          tokenAccountB,
+          fundParams,
+        );
+      });
+
+      async function getTokenBalances(): Promise<[anchor.BN, anchor.BN]> {
+        const tokenVaultA = new anchor.BN(
+          await getTokenBalance(
+            provider,
+            tokenAccountA,
+          ),
+        );
+        const tokenVaultB = new anchor.BN(
+          await getTokenBalance(
+            provider,
+            tokenAccountB,
+          ),
+        );
+        return [tokenVaultA, tokenVaultB];
+      }
+
+      // |-S-***-------T,max----|  (*: liquidity, S: start, T: end)
+      it("ExactIn, sqrt_price_limit = 0", async () => {
+        const whirlpool = await client.getPool(whirlpoolKey, IGNORE_CACHE);
+        const whirlpoolData = whirlpool.getData();
+    
+        const amount = new BN("223379095563402706");
+        const quote = await swapQuoteByInputToken(
+          whirlpool,
+          whirlpoolData.tokenMintB,
+          amount.muln(2), // x2 input
+          Percentage.fromFraction(1, 100),
+          ctx.program.programId,
+          fetcher,
+          IGNORE_CACHE,
+        );
+
+        const [preA, preB] = await getTokenBalances();
+    
+        await toTx(
+          ctx,
+          WhirlpoolIx.swapV2Ix(ctx.program, {
+            ...quote,
+            whirlpool: whirlpoolPda.publicKey,
+            tokenAuthority: ctx.wallet.publicKey,
+            tokenOwnerAccountA: tokenAccountA,
+            tokenVaultA: poolInitInfo.tokenVaultAKeypair.publicKey,
+            tokenOwnerAccountB: tokenAccountB,
+            tokenVaultB: poolInitInfo.tokenVaultBKeypair.publicKey,
+            oracle: oraclePda.publicKey,
+            tokenMintA: whirlpoolData.tokenMintA,
+            tokenMintB: whirlpoolData.tokenMintB,
+            tokenProgramA: TEST_TOKEN_2022_PROGRAM_ID,
+            tokenProgramB: TEST_TOKEN_2022_PROGRAM_ID,
+
+            // sqrt_price_limit = 0
+            sqrtPriceLimit: ZERO_BN,
+            otherAmountThreshold: new BN(0),
+          }),
+        ).buildAndExecute();
+
+        const postWhirlpoolData = await whirlpool.refreshData();
+        const [postA, postB] = await getTokenBalances();
+        const diffA = postA.sub(preA);
+        const diffB = postB.sub(preB);
+
+        assert.ok(diffA.isZero()); // no output (round up is not used to calculate output)
+        assert.ok(diffB.neg().gte(amount) && diffB.neg().lt(amount.muln(2))); // partial
+        assert.ok(postWhirlpoolData.sqrtPrice.eq(MAX_SQRT_PRICE_BN)); // hit max
+      });
+
+      // |-S-***-------T,max----|  (*: liquidity, S: start, T: end)
+      it("ExactIn, sqrt_price_limit = MAX_SQRT_PRICE", async () => {
+        const whirlpool = await client.getPool(whirlpoolKey, IGNORE_CACHE);
+        const whirlpoolData = whirlpool.getData();
+    
+        const amount = new BN("223379095563402706");
+        const quote = await swapQuoteByInputToken(
+          whirlpool,
+          whirlpoolData.tokenMintB,
+          amount.muln(2), // x2 input
+          Percentage.fromFraction(1, 100),
+          ctx.program.programId,
+          fetcher,
+          IGNORE_CACHE,
+        );
+
+        const [preA, preB] = await getTokenBalances();
+    
+        await toTx(
+          ctx,
+          WhirlpoolIx.swapV2Ix(ctx.program, {
+            ...quote,
+            whirlpool: whirlpoolPda.publicKey,
+            tokenAuthority: ctx.wallet.publicKey,
+            tokenOwnerAccountA: tokenAccountA,
+            tokenVaultA: poolInitInfo.tokenVaultAKeypair.publicKey,
+            tokenOwnerAccountB: tokenAccountB,
+            tokenVaultB: poolInitInfo.tokenVaultBKeypair.publicKey,
+            oracle: oraclePda.publicKey,
+            tokenMintA: whirlpoolData.tokenMintA,
+            tokenMintB: whirlpoolData.tokenMintB,
+            tokenProgramA: TEST_TOKEN_2022_PROGRAM_ID,
+            tokenProgramB: TEST_TOKEN_2022_PROGRAM_ID,
+
+            // sqrt_price_limit = MAX_SQRT_PRICE
+            sqrtPriceLimit: MAX_SQRT_PRICE_BN,
+            otherAmountThreshold: new BN(0),
+          }),
+        ).buildAndExecute();
+
+        const postWhirlpoolData = await whirlpool.refreshData();
+        const [postA, postB] = await getTokenBalances();
+        const diffA = postA.sub(preA);
+        const diffB = postB.sub(preB);
+
+        assert.ok(diffA.isZero()); // no output (round up is not used to calculate output)
+        assert.ok(diffB.neg().gte(amount) && diffB.neg().lt(amount.muln(2))); // partial
+        assert.ok(postWhirlpoolData.sqrtPrice.eq(MAX_SQRT_PRICE_BN)); // hit max
+      });
+
+      // |-S-***-------T,max----|  (*: liquidity, S: start, T: end)
+      it("Fails ExactOut, sqrt_price_limit = 0", async () => {
+        const whirlpool = await client.getPool(whirlpoolKey, IGNORE_CACHE);
+        const whirlpoolData = whirlpool.getData();
+    
+        const amount = new BN("1");
+        const quote = await swapQuoteByOutputToken(
+          whirlpool,
+          whirlpoolData.tokenMintA,
+          amount,
+          Percentage.fromFraction(1, 100),
+          ctx.program.programId,
+          fetcher,
+          IGNORE_CACHE,
+        );
+
+        const [preA, preB] = await getTokenBalances();
+    
+        await assert.rejects(
+          toTx(
+            ctx,
+            WhirlpoolIx.swapV2Ix(ctx.program, {
+              ...quote,
+              whirlpool: whirlpoolPda.publicKey,
+              tokenAuthority: ctx.wallet.publicKey,
+              tokenOwnerAccountA: tokenAccountA,
+              tokenVaultA: poolInitInfo.tokenVaultAKeypair.publicKey,
+              tokenOwnerAccountB: tokenAccountB,
+              tokenVaultB: poolInitInfo.tokenVaultBKeypair.publicKey,
+              oracle: oraclePda.publicKey,
+              tokenMintA: whirlpoolData.tokenMintA,
+              tokenMintB: whirlpoolData.tokenMintB,
+              tokenProgramA: TEST_TOKEN_2022_PROGRAM_ID,
+              tokenProgramB: TEST_TOKEN_2022_PROGRAM_ID,
+  
+              // sqrt_price_limit = 0
+              sqrtPriceLimit: ZERO_BN,
+              amount, // 1
+              otherAmountThreshold: quote.estimatedAmountIn,
+            }),
+          ).buildAndExecute(),
+          /0x17a9/, // PartialFillError
+        );
+      });
+
+      // |-S-***-------T,max----|  (*: liquidity, S: start, T: end)
+      it("ExactOut, sqrt_price_limit = MAX_SQRT_PRICE", async () => {
+        const whirlpool = await client.getPool(whirlpoolKey, IGNORE_CACHE);
+        const whirlpoolData = whirlpool.getData();
+    
+        const amount = new BN("1");
+        const quote = await swapQuoteByOutputToken(
+          whirlpool,
+          whirlpoolData.tokenMintA,
+          amount,
+          Percentage.fromFraction(1, 100),
+          ctx.program.programId,
+          fetcher,
+          IGNORE_CACHE,
+        );
+
+        const [preA, preB] = await getTokenBalances();
+    
+        await toTx(
+          ctx,
+          WhirlpoolIx.swapV2Ix(ctx.program, {
+            ...quote,
+            whirlpool: whirlpoolPda.publicKey,
+            tokenAuthority: ctx.wallet.publicKey,
+            tokenOwnerAccountA: tokenAccountA,
+            tokenVaultA: poolInitInfo.tokenVaultAKeypair.publicKey,
+            tokenOwnerAccountB: tokenAccountB,
+            tokenVaultB: poolInitInfo.tokenVaultBKeypair.publicKey,
+            oracle: oraclePda.publicKey,
+            tokenMintA: whirlpoolData.tokenMintA,
+            tokenMintB: whirlpoolData.tokenMintB,
+            tokenProgramA: TEST_TOKEN_2022_PROGRAM_ID,
+            tokenProgramB: TEST_TOKEN_2022_PROGRAM_ID,
+
+            // sqrt_price_limit = MAX_SQRT_PRICE
+            sqrtPriceLimit: MAX_SQRT_PRICE_BN,
+            amount, // 1
+            otherAmountThreshold: quote.estimatedAmountIn,
+          }),
+        ).buildAndExecute();
+
+        const postWhirlpoolData = await whirlpool.refreshData();
+        const [postA, postB] = await getTokenBalances();
+        const diffA = postA.sub(preA);
+        const diffB = postB.sub(preB);
+
+        assert.ok(diffA.isZero()); // no output (round up is not used to calculate output)
+        assert.ok(diffB.neg().eq(quote.estimatedAmountIn)); // partial
+        assert.ok(postWhirlpoolData.sqrtPrice.eq(MAX_SQRT_PRICE_BN)); // hit max
+      });
+    });
+
+    describe("partial fill, a to b", () => {
+      const tickSpacing = 128;
+      const aToB = true;
+      const client = buildWhirlpoolClient(ctx);
+
+      let poolInitInfo: InitPoolV2Params;
+      let whirlpoolPda: PDA;
+      let tokenAccountA: PublicKey;
+      let tokenAccountB: PublicKey;
+      let whirlpoolKey: PublicKey;
+      let oraclePda: PDA;
+
+      beforeEach(async () => {
+        const init =
+          await initTestPoolWithTokensV2(
+            ctx,
+            {isToken2022: true},
+            {isToken2022: true},
+            tickSpacing,
+            PriceMath.tickIndexToSqrtPriceX64(-439296 - 1),
+            new BN("10000000000000000000000")
+          );
+
+        poolInitInfo = init.poolInitInfo;
+        whirlpoolPda = poolInitInfo.whirlpoolPda;
+        tokenAccountA = init.tokenAccountA;
+        tokenAccountB = init.tokenAccountB;
+        whirlpoolKey = poolInitInfo.whirlpoolPda.publicKey;
+        oraclePda = PDAUtil.getOracle(ctx.program.programId, whirlpoolKey);
+
+        await initTickArrayRange(
+          ctx,
+          whirlpoolPda.publicKey,
+          -450560, // left most TickArray
+          1,
+          tickSpacing,
+          aToB,
+        );
+    
+        // a: 223379098170764880 (to get 1, need >= 223379098170764880)
+        // b: 1 (round up)
+        const fundParams: FundedPositionV2Params[] = [
+          {
+            liquidityAmount: new anchor.BN(10_000_000_000),
+            tickLowerIndex: -439552,
+            tickUpperIndex: -439424,
+          },
+        ];
+    
+        await fundPositionsV2(
+          ctx,
+          poolInitInfo,
+          tokenAccountA,
+          tokenAccountB,
+          fundParams,
+        );      
+      });
+
+      async function getTokenBalances(): Promise<[anchor.BN, anchor.BN]> {
+        const tokenVaultA = new anchor.BN(
+          await getTokenBalance(
+            provider,
+            tokenAccountA,
+          ),
+        );
+        const tokenVaultB = new anchor.BN(
+          await getTokenBalance(
+            provider,
+            tokenAccountB,
+          ),
+        );
+        return [tokenVaultA, tokenVaultB];
+      }
+
+      // |-min,T---------***-S-|  (*: liquidity, S: start, T: end)
+      it("ExactIn, sqrt_price_limit = 0", async () => {
+        const whirlpool = await client.getPool(whirlpoolKey, IGNORE_CACHE);
+        const whirlpoolData = whirlpool.getData();
+    
+        const amount = new BN("223379098170764880");
+        const quote = await swapQuoteByInputToken(
+          whirlpool,
+          whirlpoolData.tokenMintA,
+          amount.muln(2), // x2 input
+          Percentage.fromFraction(1, 100),
+          ctx.program.programId,
+          fetcher,
+          IGNORE_CACHE,
+        );
+
+        const [preA, preB] = await getTokenBalances();
+    
+        await toTx(
+          ctx,
+          WhirlpoolIx.swapV2Ix(ctx.program, {
+            ...quote,
+            whirlpool: whirlpoolPda.publicKey,
+            tokenAuthority: ctx.wallet.publicKey,
+            tokenOwnerAccountA: tokenAccountA,
+            tokenVaultA: poolInitInfo.tokenVaultAKeypair.publicKey,
+            tokenOwnerAccountB: tokenAccountB,
+            tokenVaultB: poolInitInfo.tokenVaultBKeypair.publicKey,
+            oracle: oraclePda.publicKey,
+            tokenMintA: whirlpoolData.tokenMintA,
+            tokenMintB: whirlpoolData.tokenMintB,
+            tokenProgramA: TEST_TOKEN_2022_PROGRAM_ID,
+            tokenProgramB: TEST_TOKEN_2022_PROGRAM_ID,
+
+            // sqrt_price_limit = 0
+            sqrtPriceLimit: ZERO_BN,
+            otherAmountThreshold: new BN(0),
+          }),
+        ).buildAndExecute();
+
+        const postWhirlpoolData = await whirlpool.refreshData();
+        const [postA, postB] = await getTokenBalances();
+        const diffA = postA.sub(preA);
+        const diffB = postB.sub(preB);
+
+        assert.ok(diffA.neg().gte(amount) && diffA.neg().lt(amount.muln(2))); // partial
+        assert.ok(diffB.isZero()); // no output (round up is not used to calculate output)
+        assert.ok(postWhirlpoolData.sqrtPrice.eq(MIN_SQRT_PRICE_BN)); // hit min
+      });
+
+      // |-min,T---------***-S-|  (*: liquidity, S: start, T: end)
+      it("ExactIn, sqrt_price_limit = MIN_SQRT_PRICE", async () => {
+        const whirlpool = await client.getPool(whirlpoolKey, IGNORE_CACHE);
+        const whirlpoolData = whirlpool.getData();
+    
+        const amount = new BN("223379098170764880");
+        const quote = await swapQuoteByInputToken(
+          whirlpool,
+          whirlpoolData.tokenMintA,
+          amount.muln(2), // x2 input
+          Percentage.fromFraction(1, 100),
+          ctx.program.programId,
+          fetcher,
+          IGNORE_CACHE,
+        );
+
+        const [preA, preB] = await getTokenBalances();
+    
+        await toTx(
+          ctx,
+          WhirlpoolIx.swapV2Ix(ctx.program, {
+            ...quote,
+            whirlpool: whirlpoolPda.publicKey,
+            tokenAuthority: ctx.wallet.publicKey,
+            tokenOwnerAccountA: tokenAccountA,
+            tokenVaultA: poolInitInfo.tokenVaultAKeypair.publicKey,
+            tokenOwnerAccountB: tokenAccountB,
+            tokenVaultB: poolInitInfo.tokenVaultBKeypair.publicKey,
+            oracle: oraclePda.publicKey,
+            tokenMintA: whirlpoolData.tokenMintA,
+            tokenMintB: whirlpoolData.tokenMintB,
+            tokenProgramA: TEST_TOKEN_2022_PROGRAM_ID,
+            tokenProgramB: TEST_TOKEN_2022_PROGRAM_ID,
+
+            // sqrt_price_limit = MIN_SQRT_PRICE
+            sqrtPriceLimit: MIN_SQRT_PRICE_BN,
+            otherAmountThreshold: new BN(0),
+          }),
+        ).buildAndExecute();
+
+        const postWhirlpoolData = await whirlpool.refreshData();
+        const [postA, postB] = await getTokenBalances();
+        const diffA = postA.sub(preA);
+        const diffB = postB.sub(preB);
+
+        assert.ok(diffA.neg().gte(amount) && diffA.neg().lt(amount.muln(2))); // partial
+        assert.ok(diffB.isZero()); // no output (round up is not used to calculate output)
+        assert.ok(postWhirlpoolData.sqrtPrice.eq(MIN_SQRT_PRICE_BN)); // hit min
+      });
+
+      // |-min,T---------***-S-|  (*: liquidity, S: start, T: end)
+      it("Fails ExactOut, sqrt_price_limit = 0", async () => {
+        const whirlpool = await client.getPool(whirlpoolKey, IGNORE_CACHE);
+        const whirlpoolData = whirlpool.getData();
+    
+        const amount = new BN("1");
+        const quote = await swapQuoteByOutputToken(
+          whirlpool,
+          whirlpoolData.tokenMintB,
+          amount,
+          Percentage.fromFraction(1, 100),
+          ctx.program.programId,
+          fetcher,
+          IGNORE_CACHE,
+        );
+
+        const [preA, preB] = await getTokenBalances();
+    
+        await assert.rejects(
+          toTx(
+            ctx,
+            WhirlpoolIx.swapV2Ix(ctx.program, {
+              ...quote,
+              whirlpool: whirlpoolPda.publicKey,
+              tokenAuthority: ctx.wallet.publicKey,
+              tokenOwnerAccountA: tokenAccountA,
+              tokenVaultA: poolInitInfo.tokenVaultAKeypair.publicKey,
+              tokenOwnerAccountB: tokenAccountB,
+              tokenVaultB: poolInitInfo.tokenVaultBKeypair.publicKey,
+              oracle: oraclePda.publicKey,
+              tokenMintA: whirlpoolData.tokenMintA,
+              tokenMintB: whirlpoolData.tokenMintB,
+              tokenProgramA: TEST_TOKEN_2022_PROGRAM_ID,
+              tokenProgramB: TEST_TOKEN_2022_PROGRAM_ID,
+  
+              // sqrt_price_limit = 0
+              sqrtPriceLimit: ZERO_BN,
+              amount, // 1
+              otherAmountThreshold: quote.estimatedAmountIn,
+            }),
+          ).buildAndExecute(),
+          /0x17a9/, // PartialFillError
+        );
+      });
+
+      // |-min,T---------***-S-|  (*: liquidity, S: start, T: end)
+      it("ExactOut, sqrt_price_limit = MAX_SQRT_PRICE", async () => {
+        const whirlpool = await client.getPool(whirlpoolKey, IGNORE_CACHE);
+        const whirlpoolData = whirlpool.getData();
+    
+        const amount = new BN("1");
+        const quote = await swapQuoteByOutputToken(
+          whirlpool,
+          whirlpoolData.tokenMintB,
+          amount,
+          Percentage.fromFraction(1, 100),
+          ctx.program.programId,
+          fetcher,
+          IGNORE_CACHE,
+        );
+
+        const [preA, preB] = await getTokenBalances();
+    
+        await toTx(
+          ctx,
+          WhirlpoolIx.swapV2Ix(ctx.program, {
+            ...quote,
+            whirlpool: whirlpoolPda.publicKey,
+            tokenAuthority: ctx.wallet.publicKey,
+            tokenOwnerAccountA: tokenAccountA,
+            tokenVaultA: poolInitInfo.tokenVaultAKeypair.publicKey,
+            tokenOwnerAccountB: tokenAccountB,
+            tokenVaultB: poolInitInfo.tokenVaultBKeypair.publicKey,
+            oracle: oraclePda.publicKey,
+            tokenMintA: whirlpoolData.tokenMintA,
+            tokenMintB: whirlpoolData.tokenMintB,
+            tokenProgramA: TEST_TOKEN_2022_PROGRAM_ID,
+            tokenProgramB: TEST_TOKEN_2022_PROGRAM_ID,
+
+            // sqrt_price_limit = MIN_SQRT_PRICE
+            sqrtPriceLimit: MIN_SQRT_PRICE_BN,
+            amount, // 1
+            otherAmountThreshold: quote.estimatedAmountIn,
+          }),
+        ).buildAndExecute();
+
+        const postWhirlpoolData = await whirlpool.refreshData();
+        const [postA, postB] = await getTokenBalances();
+        const diffA = postA.sub(preA);
+        const diffB = postB.sub(preB);
+
+        assert.ok(diffA.neg().eq(quote.estimatedAmountIn)); // partial
+        assert.ok(diffB.isZero()); // no output (round up is not used to calculate output)
+        assert.ok(postWhirlpoolData.sqrtPrice.eq(MIN_SQRT_PRICE_BN)); // hit min
+      });
+
     });
   });
 

--- a/legacy-sdk/whirlpool/tests/integration/v2/swap_v2.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v2/swap_v2.test.ts
@@ -1,6 +1,7 @@
 import * as anchor from "@coral-xyz/anchor";
 import { web3 } from "@coral-xyz/anchor";
-import { MathUtil, PDA, Percentage } from "@orca-so/common-sdk";
+import { MathUtil, Percentage } from "@orca-so/common-sdk";
+import { PDA } from "@orca-so/common-sdk";
 import * as assert from "assert";
 import { BN } from "bn.js";
 import Decimal from "decimal.js";
@@ -48,7 +49,7 @@ import {
 } from "../../utils/v2/init-utils-v2";
 import { createMintV2 } from "../../utils/v2/token-2022";
 import { TokenExtensionUtil } from "../../../src/utils/public/token-extension-util";
-import { PublicKey } from "@solana/web3.js";
+import type { PublicKey } from "@solana/web3.js";
 
 describe("swap_v2", () => {
   const provider = anchor.AnchorProvider.local(
@@ -2547,8 +2548,6 @@ describe("swap_v2", () => {
           IGNORE_CACHE,
         );
 
-        const [preA, preB] = await getTokenBalances();
-    
         await assert.rejects(
           toTx(
             ctx,
@@ -2818,8 +2817,6 @@ describe("swap_v2", () => {
           IGNORE_CACHE,
         );
 
-        const [preA, preB] = await getTokenBalances();
-    
         await assert.rejects(
           toTx(
             ctx,

--- a/legacy-sdk/whirlpool/tests/integration/v2/two_hop_swap_v2.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v2/two_hop_swap_v2.test.ts
@@ -5,8 +5,13 @@ import * as assert from "assert";
 import { BN } from "bn.js";
 import type { InitPoolParams, WhirlpoolData } from "../../../src";
 import {
+  buildWhirlpoolClient,
   METADATA_PROGRAM_ADDRESS,
+  MIN_SQRT_PRICE_BN,
   PDAUtil,
+  PriceMath,
+  swapQuoteByInputToken,
+  swapQuoteByOutputToken,
   swapQuoteWithParams,
   SwapUtils,
   toTx,
@@ -2267,6 +2272,378 @@ describe("two_hop_swap_v2", () => {
           );
         });
       });
+    });
+  });
+
+  describe("partial fill", () => {
+    const client = buildWhirlpoolClient(ctx);
+    const aqConfig = {
+      ...getDefaultAquariumV2(),
+      initMintParams: [
+        {tokenTrait: {isToken2022: true}},
+        {tokenTrait: {isToken2022: true}},
+        {tokenTrait: {isToken2022: true}},
+      ],
+      initTokenAccParams: [
+        { mintIndex: 0 },
+        { mintIndex: 1 },
+        { mintIndex: 2 },
+      ],
+      initPoolParams: [
+        { mintIndices: [0, 1] as [number, number], tickSpacing: 128, },
+        { mintIndices: [1, 2] as [number, number], tickSpacing: 128, },
+      ],
+    };
+
+    // Reject partial fill result
+    // |--***T**-S-| --> |-min,T----**-S-| (where *: liquidity, S: start, T: end)
+    it("fails ExactOut, partial fill on second swap, sqrt_price_limit_two == 0", async () => {
+      const aquarium = (await buildTestAquariumsV2(ctx, [{
+        configParams: aqConfig.configParams,
+        initFeeTierParams: aqConfig.initFeeTierParams,
+        initMintParams: aqConfig.initMintParams,
+        initTokenAccParams: [
+          {mintIndex: 0, mintAmount: new BN(1_000_000_000_000_000)},
+          {mintIndex: 1, mintAmount: new BN(1_000_000_000_000_000)},
+          {mintIndex: 2, mintAmount: new BN(1_000_000_000_000_000)},
+        ],
+        initPoolParams: [
+          { ...aqConfig.initPoolParams[0], tickSpacing: 128, initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(-1) },
+          { ...aqConfig.initPoolParams[1], tickSpacing: 128, initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(-439296 - 1) },
+        ],
+        initTickArrayRangeParams: [
+          {
+            poolIndex: 0,
+            startTickIndex: 0,
+            arrayCount: 3,
+            aToB: true,
+          },
+          {
+            poolIndex: 1,
+            startTickIndex: -450560,
+            arrayCount: 1,
+            aToB: true,
+          },
+        ],
+        initPositionParams: [
+          {poolIndex: 0, fundParams: [{tickLowerIndex: -512, tickUpperIndex: -128, liquidityAmount: new BN(5_000_000_000_000)}]},
+          {poolIndex: 1, fundParams: [{tickLowerIndex: -439296 - 256, tickUpperIndex: -439296 - 128, liquidityAmount: new BN(1_000)}]},
+        ],
+      }]))[0];
+      const { tokenAccounts, mintKeys, pools } = aquarium;
+
+      const whirlpoolOneKey = pools[0].whirlpoolPda.publicKey;
+      const whirlpoolTwoKey = pools[1].whirlpoolPda.publicKey;
+      let whirlpoolOne = await client.getPool(whirlpoolOneKey, IGNORE_CACHE);
+      let whirlpoolTwo = await client.getPool(whirlpoolTwoKey, IGNORE_CACHE);
+
+      const [inputToken, intermediaryToken, outputToken] = mintKeys;
+  
+      const quoteSecond = await swapQuoteByOutputToken(
+        whirlpoolTwo,
+        outputToken,
+        new BN(1),
+        Percentage.fromFraction(0, 100),
+        ctx.program.programId,
+        fetcher,
+        IGNORE_CACHE,
+      );
+  
+      const quoteFirst = await swapQuoteByOutputToken(
+        whirlpoolOne,
+        intermediaryToken,
+        quoteSecond.estimatedAmountIn,
+        Percentage.fromFraction(0, 100),
+        ctx.program.programId,
+        fetcher,
+        IGNORE_CACHE,
+      );
+    
+      const twoHopQuote = twoHopSwapQuoteFromSwapQuotes(quoteFirst, quoteSecond);
+  
+      await assert.rejects(
+        toTx(
+          ctx,
+          WhirlpoolIx.twoHopSwapV2Ix(ctx.program, {
+            ...twoHopQuote,
+            sqrtPriceLimitTwo: new BN(0), // Partial fill is NOT allowed
+            ...getParamsFromPools([pools[0], pools[1]], [true, true], tokenAccounts),
+            tokenAuthority: ctx.wallet.publicKey,
+          }),
+        ).buildAndExecute(),
+        /0x17a9/,  // PartialFillError
+      );
+
+      await toTx(
+        ctx,
+        WhirlpoolIx.twoHopSwapV2Ix(ctx.program, {
+          ...twoHopQuote,
+          sqrtPriceLimitTwo: MIN_SQRT_PRICE_BN, // Partial fill is allowed
+          ...getParamsFromPools([pools[0], pools[1]], [true, true], tokenAccounts),
+          tokenAuthority: ctx.wallet.publicKey,
+        }),
+      ).buildAndExecute();
+    });
+
+    // Reject partial fill on the first swap by sqrt_price_limit_one = 0
+    // |-min,T----**-S-| --> |--***T**-S-| (where *: liquidity, S: start, T: end)
+    it("fails ExactOut, partial fill on first swap, sqrt_price_limit_one == 0", async () => {
+      const aquarium = (await buildTestAquariumsV2(ctx, [{
+        configParams: aqConfig.configParams,
+        initFeeTierParams: [{tickSpacing: 128, feeRate: 0}], // to realize input = 1 on second swap
+        initMintParams: aqConfig.initMintParams,
+        initTokenAccParams: [
+          {mintIndex: 0, mintAmount: new BN(1_000_000_000_000_000)},
+          {mintIndex: 1, mintAmount: new BN(1_000_000_000_000_000)},
+          {mintIndex: 2, mintAmount: new BN(1_000_000_000_000_000)},
+        ],
+        initPoolParams: [
+          { ...aqConfig.initPoolParams[0], tickSpacing: 128, initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(-439296 - 1) },
+          { ...aqConfig.initPoolParams[1], tickSpacing: 128, initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(1024 + 1) },
+        ],
+        initTickArrayRangeParams: [
+          {
+            poolIndex: 0,
+            startTickIndex: -450560,
+            arrayCount: 1,
+            aToB: true,
+          },
+          {
+            poolIndex: 1,
+            startTickIndex: 0,
+            arrayCount: 3,
+            aToB: true,
+          },
+        ],
+        initPositionParams: [
+          {poolIndex: 0, fundParams: [{tickLowerIndex: -439296 - 256, tickUpperIndex: -439296 - 128, liquidityAmount: new BN(1_000)}]},
+          {poolIndex: 1, fundParams: [{tickLowerIndex: 512, tickUpperIndex: 1024, liquidityAmount: new BN(5_000_000_000_000)}]},
+        ],
+      }]))[0];
+      const { tokenAccounts, mintKeys, pools } = aquarium;
+
+      const whirlpoolOneKey = pools[0].whirlpoolPda.publicKey;
+      const whirlpoolTwoKey = pools[1].whirlpoolPda.publicKey;
+      let whirlpoolOne = await client.getPool(whirlpoolOneKey, IGNORE_CACHE);
+      let whirlpoolTwo = await client.getPool(whirlpoolTwoKey, IGNORE_CACHE);
+
+      const [inputToken, intermediaryToken, outputToken] = mintKeys;
+  
+      // 1 --> 1
+      const quoteSecond = await swapQuoteByOutputToken(
+        whirlpoolTwo,
+        outputToken,
+        new BN(1),
+        Percentage.fromFraction(0, 100),
+        ctx.program.programId,
+        fetcher,
+        IGNORE_CACHE,
+      );
+  
+      // 22337909818 --> 0 (not round up)
+      const quoteFirst = await swapQuoteByOutputToken(
+        whirlpoolOne,
+        intermediaryToken,
+        quoteSecond.estimatedAmountIn,
+        Percentage.fromFraction(0, 100),
+        ctx.program.programId,
+        fetcher,
+        IGNORE_CACHE,
+      );
+    
+      const twoHopQuote = twoHopSwapQuoteFromSwapQuotes(quoteFirst, quoteSecond);
+  
+      await assert.rejects(
+        toTx(
+          ctx,
+          WhirlpoolIx.twoHopSwapV2Ix(ctx.program, {
+            ...twoHopQuote,
+            sqrtPriceLimitOne: new BN(0), // Partial fill is NOT allowed
+            ...getParamsFromPools([pools[0], pools[1]], [true, true], tokenAccounts),
+            tokenAuthority: ctx.wallet.publicKey,
+          }),
+        ).buildAndExecute(),
+        /0x17a9/,  // PartialFillError
+      );
+    });
+
+    // Reject partial fill on the first swap by the constraint that first output must be equal to the second input
+    // Pools are safe, but owner consume intermediate tokens unproportionally
+    // |-min,T----**-S-| --> |--***T**-S-| (where *: liquidity, S: start, T: end)
+    it("fails ExactOut, partial fill on first swap, sqrt_price_limit_one != 0", async () => {
+      const aquarium = (await buildTestAquariumsV2(ctx, [{
+        configParams: aqConfig.configParams,
+        initFeeTierParams: [{tickSpacing: 128, feeRate: 0}], // to realize input = 1 on second swap
+        initMintParams: aqConfig.initMintParams,
+        initTokenAccParams: [
+          {mintIndex: 0, mintAmount: new BN(1_000_000_000_000_000)},
+          {mintIndex: 1, mintAmount: new BN(1_000_000_000_000_000)},
+          {mintIndex: 2, mintAmount: new BN(1_000_000_000_000_000)},
+        ],
+        initPoolParams: [
+          { ...aqConfig.initPoolParams[0], tickSpacing: 128, initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(-439296 - 1) },
+          { ...aqConfig.initPoolParams[1], tickSpacing: 128, initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(1024 + 1) },
+        ],
+        initTickArrayRangeParams: [
+          {
+            poolIndex: 0,
+            startTickIndex: -450560,
+            arrayCount: 1,
+            aToB: true,
+          },
+          {
+            poolIndex: 1,
+            startTickIndex: 0,
+            arrayCount: 3,
+            aToB: true,
+          },
+        ],
+        initPositionParams: [
+          {poolIndex: 0, fundParams: [{tickLowerIndex: -439296 - 256, tickUpperIndex: -439296 - 128, liquidityAmount: new BN(1_000)}]},
+          {poolIndex: 1, fundParams: [{tickLowerIndex: 512, tickUpperIndex: 1024, liquidityAmount: new BN(5_000_000_000_000)}]},
+        ],
+      }]))[0];
+      const { tokenAccounts, mintKeys, pools } = aquarium;
+
+      const whirlpoolOneKey = pools[0].whirlpoolPda.publicKey;
+      const whirlpoolTwoKey = pools[1].whirlpoolPda.publicKey;
+      let whirlpoolOne = await client.getPool(whirlpoolOneKey, IGNORE_CACHE);
+      let whirlpoolTwo = await client.getPool(whirlpoolTwoKey, IGNORE_CACHE);
+
+      const [inputToken, intermediaryToken, outputToken] = mintKeys;
+  
+      // 1 --> 1
+      const quoteSecond = await swapQuoteByOutputToken(
+        whirlpoolTwo,
+        outputToken,
+        new BN(1),
+        Percentage.fromFraction(0, 100),
+        ctx.program.programId,
+        fetcher,
+        IGNORE_CACHE,
+      );
+  
+      // 22337909818 --> 0 (not round up)
+      const quoteFirst = await swapQuoteByOutputToken(
+        whirlpoolOne,
+        intermediaryToken,
+        quoteSecond.estimatedAmountIn,
+        Percentage.fromFraction(0, 100),
+        ctx.program.programId,
+        fetcher,
+        IGNORE_CACHE,
+      );
+    
+      const twoHopQuote = twoHopSwapQuoteFromSwapQuotes(quoteFirst, quoteSecond);
+  
+      await assert.rejects(
+        toTx(
+          ctx,
+          WhirlpoolIx.twoHopSwapV2Ix(ctx.program, {
+            ...twoHopQuote,
+            sqrtPriceLimitTwo: new BN(0), // Partial fill is NOT allowed
+            ...getParamsFromPools([pools[0], pools[1]], [true, true], tokenAccounts),
+            tokenAuthority: ctx.wallet.publicKey,
+          }),
+        ).buildAndExecute(),
+        /0x17a3/,  // IntermediateTokenAmountMismatch
+      );
+    });
+
+    // Reject partial fill on the second swap by the constraint that second output must be equal to the first input
+    // Pools and owner are safe, but owner will receive unconsumed intermediate tokens
+    // |-S-***T**-| -> |-S-***T,limit**--| (where *: liquidity, S: start, T: end)
+    it("fails ExactIn, partial fill on second swap", async () => {
+      const aquarium = (await buildTestAquariumsV2(ctx, [{
+        configParams: aqConfig.configParams,
+        initFeeTierParams: aqConfig.initFeeTierParams,
+        initMintParams: aqConfig.initMintParams,
+        initTokenAccParams: [
+          {mintIndex: 0, mintAmount: new BN(1_000_000_000_000_000)},
+          {mintIndex: 1, mintAmount: new BN(1_000_000_000_000_000)},
+          {mintIndex: 2, mintAmount: new BN(1_000_000_000_000_000)},
+        ],
+        initPoolParams: [
+          { ...aqConfig.initPoolParams[0], tickSpacing: 128, initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(1024 + 1) },
+          { ...aqConfig.initPoolParams[1], tickSpacing: 128, initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(1024 + 1) },
+        ],
+        initTickArrayRangeParams: [
+          {
+            poolIndex: 0,
+            startTickIndex: 0,
+            arrayCount: 3,
+            aToB: true,
+          },
+          {
+            poolIndex: 1,
+            startTickIndex: 0,
+            arrayCount: 3,
+            aToB: true,
+          },
+        ],
+        initPositionParams: [
+          {poolIndex: 0, fundParams: [{tickLowerIndex: 512, tickUpperIndex: 1024, liquidityAmount: new BN(1_000_000_000)}]},
+          {poolIndex: 1, fundParams: [{tickLowerIndex: 512, tickUpperIndex: 1024, liquidityAmount: new BN(1_000_000_000)}]},
+        ],
+      }]))[0];
+      const { tokenAccounts, mintKeys, pools } = aquarium;
+
+      const whirlpoolOneKey = pools[0].whirlpoolPda.publicKey;
+      const whirlpoolTwoKey = pools[1].whirlpoolPda.publicKey;
+      let whirlpoolOne = await client.getPool(whirlpoolOneKey, IGNORE_CACHE);
+      let whirlpoolTwo = await client.getPool(whirlpoolTwoKey, IGNORE_CACHE);
+
+      const [inputToken, intermediaryToken, outputToken] = mintKeys;
+        
+      // 1000000 --> 1103339
+      const quoteFirst = await swapQuoteByInputToken(
+        whirlpoolOne,
+        inputToken,
+        new BN(1_000_000),
+        Percentage.fromFraction(0, 100),
+        ctx.program.programId,
+        fetcher,
+        IGNORE_CACHE,
+      );
+
+      // 1103339 1217224
+      const quoteSecond = await swapQuoteByInputToken(
+        whirlpoolTwo,
+        intermediaryToken,
+        quoteFirst.estimatedAmountOut,
+        Percentage.fromFraction(0, 100),
+        ctx.program.programId,
+        fetcher,
+        IGNORE_CACHE,
+      );
+    
+      const twoHopQuote = twoHopSwapQuoteFromSwapQuotes(quoteFirst, quoteSecond);
+
+      assert.ok(quoteSecond.estimatedEndTickIndex < 1002);
+      await assert.rejects(
+        toTx(
+          ctx,
+          WhirlpoolIx.twoHopSwapV2Ix(ctx.program, {
+            ...twoHopQuote,
+            sqrtPriceLimitTwo: PriceMath.tickIndexToSqrtPriceX64(1002), // Partial fill
+            ...getParamsFromPools([pools[0], pools[1]], [true, true], tokenAccounts),
+            tokenAuthority: ctx.wallet.publicKey,
+          }),
+        ).buildAndExecute(),
+        /0x17a3/,  // IntermediateTokenAmountMismatch
+      );
+
+      assert.ok(quoteSecond.estimatedEndTickIndex > 999);
+      await toTx(
+        ctx,
+        WhirlpoolIx.twoHopSwapV2Ix(ctx.program, {
+          ...twoHopQuote,
+          sqrtPriceLimitTwo: PriceMath.tickIndexToSqrtPriceX64(999),
+          ...getParamsFromPools([pools[0], pools[1]], [true, true], tokenAccounts),
+          tokenAuthority: ctx.wallet.publicKey,
+        }),
+      ).buildAndExecute();
+
     });
   });
 

--- a/legacy-sdk/whirlpool/tests/integration/v2/two_hop_swap_v2.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v2/two_hop_swap_v2.test.ts
@@ -2501,6 +2501,7 @@ describe("two_hop_swap_v2", () => {
           ctx,
           WhirlpoolIx.twoHopSwapV2Ix(ctx.program, {
             ...twoHopQuote,
+            sqrtPriceLimitOne: MIN_SQRT_PRICE_BN, // Partial fill is allowed
             sqrtPriceLimitTwo: new BN(0), // Partial fill is NOT allowed
             ...getParamsFromPools([pools[0], pools[1]], [true, true], tokenAccounts),
             tokenAuthority: ctx.wallet.publicKey,
@@ -2513,6 +2514,7 @@ describe("two_hop_swap_v2", () => {
         ctx,
         WhirlpoolIx.twoHopSwapV2Ix(ctx.program, {
           ...twoHopQuote,
+          sqrtPriceLimitOne: MIN_SQRT_PRICE_BN, // Partial fill is allowed
           sqrtPriceLimitTwo: MIN_SQRT_PRICE_BN, // Partial fill is allowed
           ...getParamsFromPools([pools[0], pools[1]], [true, true], tokenAccounts),
           tokenAuthority: ctx.wallet.publicKey,
@@ -2594,6 +2596,7 @@ describe("two_hop_swap_v2", () => {
           WhirlpoolIx.twoHopSwapV2Ix(ctx.program, {
             ...twoHopQuote,
             sqrtPriceLimitOne: new BN(0), // Partial fill is NOT allowed
+            sqrtPriceLimitTwo: MIN_SQRT_PRICE_BN, // Partial fill is allowed
             ...getParamsFromPools([pools[0], pools[1]], [true, true], tokenAccounts),
             tokenAuthority: ctx.wallet.publicKey,
           }),
@@ -2603,7 +2606,7 @@ describe("two_hop_swap_v2", () => {
     });
 
     // Reject partial fill on the first swap by the constraint that first output must be equal to the second input
-    // Pools are safe, but owner consume intermediate tokens unproportionally
+    // This case must be rejected due to vault to vault transfer
     // |-min,T----**-S-| --> |--***T**-S-| (where *: liquidity, S: start, T: end)
     it("fails ExactOut, partial fill on first swap, sqrt_price_limit_one != 0", async () => {
       const aquarium = (await buildTestAquariumsV2(ctx, [{
@@ -2676,7 +2679,8 @@ describe("two_hop_swap_v2", () => {
           ctx,
           WhirlpoolIx.twoHopSwapV2Ix(ctx.program, {
             ...twoHopQuote,
-            sqrtPriceLimitTwo: new BN(0), // Partial fill is NOT allowed
+            sqrtPriceLimitOne: MIN_SQRT_PRICE_BN, // Partial fill is allowed
+            sqrtPriceLimitTwo: MIN_SQRT_PRICE_BN, // Partial fill is allowed
             ...getParamsFromPools([pools[0], pools[1]], [true, true], tokenAccounts),
             tokenAuthority: ctx.wallet.publicKey,
           }),
@@ -2895,6 +2899,7 @@ describe("two_hop_swap_v2", () => {
           ctx,
           WhirlpoolIx.twoHopSwapV2Ix(ctx.program, {
             ...twoHopQuote,
+            sqrtPriceLimitOne: MIN_SQRT_PRICE_BN, // Partial fill is allowed
             sqrtPriceLimitTwo: PriceMath.tickIndexToSqrtPriceX64(1002), // Partial fill
             ...getParamsFromPools([pools[0], pools[1]], [true, true], tokenAccounts),
             tokenAuthority: ctx.wallet.publicKey,

--- a/legacy-sdk/whirlpool/tests/integration/v2/two_hop_swap_v2.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v2/two_hop_swap_v2.test.ts
@@ -2337,7 +2337,7 @@ describe("two_hop_swap_v2", () => {
       let whirlpoolOne = await client.getPool(whirlpoolOneKey, IGNORE_CACHE);
       let whirlpoolTwo = await client.getPool(whirlpoolTwoKey, IGNORE_CACHE);
 
-      const [inputToken, intermediaryToken, outputToken] = mintKeys;
+      const [_inputToken, intermediaryToken, outputToken] = mintKeys;
   
       const quoteSecond = await swapQuoteByOutputToken(
         whirlpoolTwo,
@@ -2427,7 +2427,7 @@ describe("two_hop_swap_v2", () => {
       let whirlpoolOne = await client.getPool(whirlpoolOneKey, IGNORE_CACHE);
       let whirlpoolTwo = await client.getPool(whirlpoolTwoKey, IGNORE_CACHE);
 
-      const [inputToken, intermediaryToken, outputToken] = mintKeys;
+      const [_inputToken, intermediaryToken, outputToken] = mintKeys;
   
       // 1 --> 1
       const quoteSecond = await swapQuoteByOutputToken(
@@ -2510,7 +2510,7 @@ describe("two_hop_swap_v2", () => {
       let whirlpoolOne = await client.getPool(whirlpoolOneKey, IGNORE_CACHE);
       let whirlpoolTwo = await client.getPool(whirlpoolTwoKey, IGNORE_CACHE);
 
-      const [inputToken, intermediaryToken, outputToken] = mintKeys;
+      const [_inputToken, intermediaryToken, outputToken] = mintKeys;
   
       // 1 --> 1
       const quoteSecond = await swapQuoteByOutputToken(
@@ -2593,7 +2593,7 @@ describe("two_hop_swap_v2", () => {
       let whirlpoolOne = await client.getPool(whirlpoolOneKey, IGNORE_CACHE);
       let whirlpoolTwo = await client.getPool(whirlpoolTwoKey, IGNORE_CACHE);
 
-      const [inputToken, intermediaryToken, outputToken] = mintKeys;
+      const [inputToken, intermediaryToken, _outputToken] = mintKeys;
         
       // 1000000 --> 1103339
       const quoteFirst = await swapQuoteByInputToken(

--- a/legacy-sdk/whirlpool/tests/integration/v2/two_hop_swap_v2.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v2/two_hop_swap_v2.test.ts
@@ -1,5 +1,5 @@
 import * as anchor from "@coral-xyz/anchor";
-import { Percentage } from "@orca-so/common-sdk";
+import { Percentage, U64_MAX } from "@orca-so/common-sdk";
 import { PublicKey } from "@solana/web3.js";
 import * as assert from "assert";
 import { BN } from "bn.js";
@@ -45,7 +45,7 @@ import {
   asyncAssertOwnerProgram,
   createMintV2,
 } from "../../utils/v2/token-2022";
-import { TokenExtensionUtil } from "../../../src/utils/public/token-extension-util";
+import { NO_TOKEN_EXTENSION_CONTEXT, TokenExtensionUtil } from "../../../src/utils/public/token-extension-util";
 
 describe("two_hop_swap_v2", () => {
   const provider = anchor.AnchorProvider.local(
@@ -2295,6 +2295,141 @@ describe("two_hop_swap_v2", () => {
       ],
     };
 
+    // Partial fill on second swap in ExactOut is allowed
+    // |--***T**-S-| --> |--***T,limit**-S-| (where *: liquidity, S: start, T: end)
+    it("ExactOut, partial fill on second swap", async () => {
+      const aquarium = (await buildTestAquariumsV2(ctx, [{
+        configParams: aqConfig.configParams,
+        initFeeTierParams: aqConfig.initFeeTierParams,
+        initMintParams: aqConfig.initMintParams,
+        initTokenAccParams: [
+          {mintIndex: 0, mintAmount: new BN(1_000_000_000_000_000)},
+          {mintIndex: 1, mintAmount: new BN(1_000_000_000_000_000)},
+          {mintIndex: 2, mintAmount: new BN(1_000_000_000_000_000)},
+        ],
+        initPoolParams: [
+          { ...aqConfig.initPoolParams[0], tickSpacing: 128, initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(1024 + 1) },
+          { ...aqConfig.initPoolParams[1], tickSpacing: 128, initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(1024 + 1) },
+        ],
+        initTickArrayRangeParams: [
+          {
+            poolIndex: 0,
+            startTickIndex: 0,
+            arrayCount: 3,
+            aToB: true,
+          },
+          {
+            poolIndex: 1,
+            startTickIndex: 0,
+            arrayCount: 3,
+            aToB: true,
+          },
+        ],
+        initPositionParams: [
+          {poolIndex: 0, fundParams: [{tickLowerIndex: 512, tickUpperIndex: 1024, liquidityAmount: new BN(1_000_000_000)}]},
+          {poolIndex: 1, fundParams: [{tickLowerIndex: 512, tickUpperIndex: 1024, liquidityAmount: new BN(1_000_000_000)}]},
+        ],
+      }]))[0];
+      const { tokenAccounts, mintKeys, pools } = aquarium;
+
+      const whirlpoolOneKey = pools[0].whirlpoolPda.publicKey;
+      const whirlpoolTwoKey = pools[1].whirlpoolPda.publicKey;
+      let whirlpoolOne = await client.getPool(whirlpoolOneKey, IGNORE_CACHE);
+      let whirlpoolTwo = await client.getPool(whirlpoolTwoKey, IGNORE_CACHE);
+
+      const [_inputToken, intermediaryToken, _outputToken] = mintKeys;
+
+      const quoteParams = {
+        amountSpecifiedIsInput: false,
+        aToB: true,
+        otherAmountThreshold: U64_MAX,
+        tickArrays: await SwapUtils.getTickArrays(
+          whirlpoolTwo.getData().tickCurrentIndex,
+          whirlpoolTwo.getData().tickSpacing,
+          true,
+          ctx.program.programId,
+          whirlpoolTwoKey,
+          ctx.fetcher,
+          IGNORE_CACHE
+        ),
+        tokenExtensionCtx: NO_TOKEN_EXTENSION_CONTEXT,
+        whirlpoolData: whirlpoolOne.getData(),
+        tokenAmount: new BN(1_000_000),
+      };
+
+      // 906251 --> 1000000 (end tick: 1004)
+      const quoteSecondWithoutLimit = swapQuoteWithParams({
+        ...quoteParams,
+        sqrtPriceLimit: MIN_SQRT_PRICE_BN,
+      }, Percentage.fromFraction(0, 100));
+      assert.ok(quoteSecondWithoutLimit.estimatedEndTickIndex < 1008);
+
+      // 762627 --> 841645 (end tick: 1008)
+      const quoteSecondWithLimit = swapQuoteWithParams({
+        ...quoteParams,
+        sqrtPriceLimit: PriceMath.tickIndexToSqrtPriceX64(1008),
+      }, Percentage.fromFraction(0, 100));
+      assert.ok(quoteSecondWithLimit.estimatedEndTickIndex == 1008);
+      assert.ok(quoteSecondWithLimit.estimatedAmountOut.lt(quoteSecondWithoutLimit.estimatedAmountOut));
+      assert.ok(quoteSecondWithLimit.estimatedAmountIn.lt(quoteSecondWithoutLimit.estimatedAmountIn));
+
+      // 821218 --> 906251
+      const quoteFirstWithoutLimit = await swapQuoteByOutputToken(
+        whirlpoolOne,
+        intermediaryToken,
+        quoteSecondWithoutLimit.estimatedAmountIn,
+        Percentage.fromFraction(0, 100),
+        ctx.program.programId,
+        fetcher,
+        IGNORE_CACHE,
+      );
+
+      // 690975 --> 762627
+      const quoteFirstWithLimit = await swapQuoteByOutputToken(
+        whirlpoolOne,
+        intermediaryToken,
+        quoteSecondWithLimit.estimatedAmountIn,
+        Percentage.fromFraction(0, 100),
+        ctx.program.programId,
+        fetcher,
+        IGNORE_CACHE,
+      );
+
+      // build without limit
+      const twoHopQuote = twoHopSwapQuoteFromSwapQuotes(quoteFirstWithoutLimit, quoteSecondWithoutLimit);
+
+      await assert.rejects(
+        toTx(
+          ctx,
+          WhirlpoolIx.twoHopSwapV2Ix(ctx.program, {
+            ...twoHopQuote,
+            amount: quoteSecondWithoutLimit.estimatedAmountOut,
+            sqrtPriceLimitOne: new BN(0), // partial fill on second swap is NOT allowd
+            sqrtPriceLimitTwo: PriceMath.tickIndexToSqrtPriceX64(1008), // partial fill is allowed
+            // -1 to check input amount
+            otherAmountThreshold: quoteFirstWithLimit.estimatedAmountIn.subn(1),
+            ...getParamsFromPools([pools[0], pools[1]], [true, true], tokenAccounts),
+            tokenAuthority: ctx.wallet.publicKey,
+          }),
+        ).buildAndExecute(),
+        /0x1795/,  // AmountInAboveMaximum.
+      );
+
+      assert.ok(quoteSecondWithoutLimit.estimatedEndTickIndex > 999);
+      await toTx(
+        ctx,
+        WhirlpoolIx.twoHopSwapV2Ix(ctx.program, {
+          ...twoHopQuote,
+          amount: quoteSecondWithoutLimit.estimatedAmountOut,
+          sqrtPriceLimitOne: new BN(0), // partial fill on second swap is NOT allowd
+          sqrtPriceLimitTwo: PriceMath.tickIndexToSqrtPriceX64(1008), // partial fill is allowed
+          otherAmountThreshold: quoteFirstWithLimit.estimatedAmountIn,
+          ...getParamsFromPools([pools[0], pools[1]],  [true, true], tokenAccounts),
+          tokenAuthority: ctx.wallet.publicKey,
+        }),
+      ).buildAndExecute();
+    });
+
     // Reject partial fill result
     // |--***T**-S-| --> |-min,T----**-S-| (where *: liquidity, S: start, T: end)
     it("fails ExactOut, partial fill on second swap, sqrt_price_limit_two == 0", async () => {
@@ -2550,9 +2685,144 @@ describe("two_hop_swap_v2", () => {
       );
     });
 
+    // Partial fill on the first swap in ExactIn is allowed.
+    // |--***T,limit**-S-| -> |--***T**-S--| (where *: liquidity, S: start, T: end)
+    it("ExactIn, partial fill on first swap", async () => {
+      const aquarium = (await buildTestAquariumsV2(ctx, [{
+        configParams: aqConfig.configParams,
+        initFeeTierParams: aqConfig.initFeeTierParams,
+        initMintParams: aqConfig.initMintParams,
+        initTokenAccParams: [
+          {mintIndex: 0, mintAmount: new BN(1_000_000_000_000_000)},
+          {mintIndex: 1, mintAmount: new BN(1_000_000_000_000_000)},
+          {mintIndex: 2, mintAmount: new BN(1_000_000_000_000_000)},
+        ],
+        initPoolParams: [
+          { ...aqConfig.initPoolParams[0], tickSpacing: 128, initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(1024 + 1) },
+          { ...aqConfig.initPoolParams[1], tickSpacing: 128, initSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(1024 + 1) },
+        ],
+        initTickArrayRangeParams: [
+          {
+            poolIndex: 0,
+            startTickIndex: 0,
+            arrayCount: 3,
+            aToB: true,
+          },
+          {
+            poolIndex: 1,
+            startTickIndex: 0,
+            arrayCount: 3,
+            aToB: true,
+          },
+        ],
+        initPositionParams: [
+          {poolIndex: 0, fundParams: [{tickLowerIndex: 512, tickUpperIndex: 1024, liquidityAmount: new BN(1_000_000_000)}]},
+          {poolIndex: 1, fundParams: [{tickLowerIndex: 512, tickUpperIndex: 1024, liquidityAmount: new BN(1_000_000_000)}]},
+        ],
+      }]))[0];
+      const { tokenAccounts, mintKeys, pools } = aquarium;
+
+      const whirlpoolOneKey = pools[0].whirlpoolPda.publicKey;
+      const whirlpoolTwoKey = pools[1].whirlpoolPda.publicKey;
+      let whirlpoolOne = await client.getPool(whirlpoolOneKey, IGNORE_CACHE);
+      let whirlpoolTwo = await client.getPool(whirlpoolTwoKey, IGNORE_CACHE);
+
+      const [_inputToken, intermediaryToken, _outputToken] = mintKeys;
+
+      const quoteParams = {
+        amountSpecifiedIsInput: true,
+        aToB: true,
+        otherAmountThreshold: new BN(0),
+        tickArrays: await SwapUtils.getTickArrays(
+          whirlpoolOne.getData().tickCurrentIndex,
+          whirlpoolOne.getData().tickSpacing,
+          true,
+          ctx.program.programId,
+          whirlpoolOneKey,
+          ctx.fetcher,
+          IGNORE_CACHE
+        ),
+        tokenExtensionCtx: NO_TOKEN_EXTENSION_CONTEXT,
+        whirlpoolData: whirlpoolOne.getData(),
+        tokenAmount: new BN(1_000_000),
+      };
+
+      // 1000000 --> 1103339
+      const quoteFirstWithoutLimit = swapQuoteWithParams({
+        ...quoteParams,
+        sqrtPriceLimit: MIN_SQRT_PRICE_BN,
+      }, Percentage.fromFraction(0, 100));
+      assert.ok(quoteFirstWithoutLimit.estimatedEndTickIndex < 1010);
+
+      // 667266 --> 736476
+      const quoteFirstWithLimit = swapQuoteWithParams({
+        ...quoteParams,
+        sqrtPriceLimit: PriceMath.tickIndexToSqrtPriceX64(1010),
+      }, Percentage.fromFraction(0, 100));
+      assert.ok(quoteFirstWithLimit.estimatedEndTickIndex == 1010);
+      assert.ok(quoteFirstWithLimit.estimatedAmountIn.lt(quoteFirstWithoutLimit.estimatedAmountIn));
+      assert.ok(quoteFirstWithLimit.estimatedAmountOut.lt(quoteFirstWithoutLimit.estimatedAmountOut));
+
+      // 1103339 --> 1217224
+      const quoteSecondWithoutLimit = await swapQuoteByInputToken(
+        whirlpoolTwo,
+        intermediaryToken,
+        quoteFirstWithoutLimit.estimatedAmountOut,
+        Percentage.fromFraction(0, 100),
+        ctx.program.programId,
+        fetcher,
+        IGNORE_CACHE,
+      );
+
+      // 736476 --> 812807
+      const quoteSecondWithLimit = await swapQuoteByInputToken(
+        whirlpoolTwo,
+        intermediaryToken,
+        quoteFirstWithLimit.estimatedAmountOut,
+        Percentage.fromFraction(0, 100),
+        ctx.program.programId,
+        fetcher,
+        IGNORE_CACHE,
+      );
+
+      // build without limit
+      const twoHopQuote = twoHopSwapQuoteFromSwapQuotes(quoteFirstWithoutLimit, quoteSecondWithoutLimit);
+
+      await assert.rejects(
+        toTx(
+          ctx,
+          WhirlpoolIx.twoHopSwapV2Ix(ctx.program, {
+            ...twoHopQuote,
+            amount: quoteFirstWithoutLimit.estimatedAmountIn,
+            sqrtPriceLimitOne: PriceMath.tickIndexToSqrtPriceX64(1010), // partial fill is allowed
+            sqrtPriceLimitTwo: new BN(0), // partial fill on second swap is NOT allowd
+            // +1 to check output amount
+            otherAmountThreshold: quoteSecondWithLimit.estimatedAmountOut.addn(1),
+            ...getParamsFromPools([pools[0], pools[1]], [true, true], tokenAccounts),
+            tokenAuthority: ctx.wallet.publicKey,
+          }),
+        ).buildAndExecute(),
+        /0x1794/,  // AmountOutBelowMinimum
+      );
+
+      assert.ok(quoteSecondWithoutLimit.estimatedEndTickIndex > 999);
+      await toTx(
+        ctx,
+        WhirlpoolIx.twoHopSwapV2Ix(ctx.program, {
+          ...twoHopQuote,
+          amount: quoteFirstWithoutLimit.estimatedAmountIn,
+          sqrtPriceLimitOne: PriceMath.tickIndexToSqrtPriceX64(1010), // partial fill is allowed
+          sqrtPriceLimitTwo: new BN(0), // partial fill on second swap is NOT allowd
+          otherAmountThreshold: quoteSecondWithLimit.estimatedAmountOut,
+          ...getParamsFromPools([pools[0], pools[1]], [true, true], tokenAccounts),
+          tokenAuthority: ctx.wallet.publicKey,
+      }),
+      ).buildAndExecute();
+    });
+
     // Reject partial fill on the second swap by the constraint that second output must be equal to the first input
     // Pools and owner are safe, but owner will receive unconsumed intermediate tokens
-    // |-S-***T**-| -> |-S-***T,limit**--| (where *: liquidity, S: start, T: end)
+    // |--***T**-S-| -> |--***T,limit**-S--| (where *: liquidity, S: start, T: end)
     it("fails ExactIn, partial fill on second swap", async () => {
       const aquarium = (await buildTestAquariumsV2(ctx, [{
         configParams: aqConfig.configParams,

--- a/legacy-sdk/whirlpool/tests/utils/v2/aquarium-v2.ts
+++ b/legacy-sdk/whirlpool/tests/utils/v2/aquarium-v2.ts
@@ -121,7 +121,7 @@ export async function buildTestAquariumsV2(
   ctx: WhirlpoolContext,
   initParams: InitAquariumV2Params[],
 ): Promise<TestAquarium[]> {
-  const aquariums = [];
+  const aquariums: TestAquarium[] = [];
   // Airdrop SOL into provider wallet;
   await ctx.connection.requestAirdrop(
     ctx.provider.wallet.publicKey,
@@ -381,7 +381,7 @@ export function getTokenAccsForPoolsV2(
     tokenTrait: TokenTrait;
   }[],
 ) {
-  const mints = [];
+  const mints: PublicKey[] = [];
   for (const pool of pools) {
     mints.push(pool.tokenMintA);
     mints.push(pool.tokenMintB);

--- a/programs/whirlpool/src/errors.rs
+++ b/programs/whirlpool/src/errors.rs
@@ -143,6 +143,9 @@ pub enum ErrorCode {
     TooManySupplementalTickArrays, // 0x17a7 (6055)
     #[msg("TickArray account for different whirlpool provided")]
     DifferentWhirlpoolTickArrayAccount, // 0x17a8 (6056)
+
+    #[msg("Trade resulted in partial fill")]
+    PartialFillError, // 0x17a9 (6057)
 }
 
 impl From<TryFromIntError> for ErrorCode {

--- a/programs/whirlpool/src/instructions/two_hop_swap.rs
+++ b/programs/whirlpool/src/instructions/two_hop_swap.rs
@@ -202,6 +202,21 @@ pub fn handler(
         (swap_calc_one, swap_calc_two)
     };
 
+    // All output token should be consumed by the second swap
+    let swap_calc_one_output = if a_to_b_one {
+        swap_update_one.amount_b
+    } else {
+        swap_update_one.amount_a
+    };
+    let swap_calc_two_input = if a_to_b_two {
+        swap_update_two.amount_a
+    } else {
+        swap_update_two.amount_b
+    };
+    if swap_calc_one_output != swap_calc_two_input {
+        return Err(ErrorCode::IntermediateTokenAmountMismatch.into());
+    }
+
     if amount_specified_is_input {
         // If amount_specified_is_input == true, then we have a variable amount of output
         // The slippage we care about is the output of the second swap.

--- a/programs/whirlpool/src/math/swap_math.rs
+++ b/programs/whirlpool/src/math/swap_math.rs
@@ -3,6 +3,8 @@ use std::convert::TryInto;
 use crate::errors::ErrorCode;
 use crate::math::*;
 
+pub const NO_EXPLICIT_SQRT_PRICE_LIMIT: u128 = 0u128;
+
 #[derive(PartialEq, Debug)]
 pub struct SwapStepComputation {
     pub amount_in: u64,


### PR DESCRIPTION
## The risk of partial fill in ExactOut
Trades may complete with partial fill when sqrt_price_limit is reached in both ExactIn and ExactOut.

In ExactIn, the amount of output is verified by other_amount_threshold, so even if a partial fill occurs, the transaction will fail unless the trader obtains the desired output for the input.

In ExactOut, on the other hand, other_amount_threshold defines an upper limit on the amount of input, so that a transaction will not fail when a part of input amount is used. However, this may result in an unfavorable rate if the specified amount of output is not obtained due to partial fill.

For traders who wish to explicitly reject the occurrence of Partial fill in ExactOut, the program will accept an input of sqrt_price_limit = 0. If sqrt_price_limit = 0, then if a Partial fill occurs in ExactOut, the transaction will be rejected.

Note that sqrt_price_limit = 0 does not overlap with the previously accepted value, so a breaking change will not occur.

## TwoHopSwap (v1) partial fill rejection
TwoHopSwap receives sqrt_price_limit_one and sqrt_price_limit_two, which may result in partial fill.

Among these cases, the following cases will result in an excess or shortage of intermediate tokens.
- Partial fill of the second swap in ExactIn 
- Partial fill of the first swap in ExactOut

In both cases, the pool is protected even in the case of over/shortage, since the transfer between the pool and the owner is always used. However, unintended intermediate tokens may be used or left over.
To avoid this, if the output and input amounts of intermediate tokens do not match, the transaction will fail.

V2 already performs this verification for vault to vault transfers.