### PR TITLE
Add github actions publish script for npm and crates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     groups:
       program-dependencies:
         applies-to: version-updates
-        update-types: production
+        dependency-type: production
   - package-ecosystem: "cargo"
     directories:
       - "rust-sdk/*"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
       uses: ./.github/actions/anchor
       with:
         run: |
-          sed -i 's/version = v[0-9]+.[0-9]+.[0-9]+/version = $(basename ${{ github.ref }})/' rust-sdk/${{ matrix.package }}/Cargo.toml
+          sed -i 's/^version = ".*"$/version = "$(basename ${{ github.ref }})"/' rust-sdk/${{ matrix.package }}/Cargo.toml
           # TODO: replace workspace dependencies with fixed version
           yarn build rust-sdk/${{ matrix.package }} --output-style static
           cd rust-sdk/${{ matrix.package }} && cargo publish --allow-dirty

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
   npm:
     strategy:
       matrix:
-        package: []
+        package: [client]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
@@ -21,8 +21,8 @@ jobs:
       uses: ./.github/actions/anchor
       with:
         run: |
-          # TODO: Copy over keys from root package.json
           cd ts-sdk/${{ matrix.package }} && yarn version $(basename ${{ github.ref }})
+          # TODO: replace workspace dependencies with fixed version
           yarn install
           yarn build ts-sdk/${{ matrix.package }} --output-style static
           cd ts-sdk/${{ matrix.package }} && npm publish --access public
@@ -32,7 +32,7 @@ jobs:
   cargo:
     strategy:
       matrix:
-        package: []
+        package: [client]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
@@ -43,23 +43,30 @@ jobs:
       uses: ./.github/actions/anchor
       with:
         run: |
-          # deploy cargo
+          sed -i 's/version = v[0-9]+.[0-9]+.[0-9]+/version = $(basename ${{ github.ref }})/' rust-sdk/${{ matrix.package }}/Cargo.toml
+          # TODO: replace workspace dependencies with fixed version
+          yarn build rust-sdk/${{ matrix.package }} --output-style static
+          cd rust-sdk/${{ matrix.package }} && cargo publish
+      env:
+        CRATES_IO_API_TOKEN: ${{ secrets.CRATES_TOKEN }}
 
   verifiable:
-    strategy:
-      matrix:
-        program: []
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Deploy cargo
-      uses: ./.github/actions/anchor
+    - name: Verifiable build
+      run: anchor build --verifiable
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
       with:
-        run: |
-          # verifiable build and add to release
+        name: verifiable-build
+        path: |
+          target/deploy/*.so
+          target/idl/*.json
+        if-no-files-found: error
 
   release:
     needs: [npm, cargo, verifiable]
@@ -68,8 +75,14 @@ jobs:
     permissions:
       contents: write
     steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: verifiable-build
+        path: artifacts/
     - name: Create Release
       uses: ncipollo/release-action@v1
       with:
         generateReleaseNotes: true
         allowUpdates: true
+        artifacts: artifacts/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
           sed -i 's/version = v[0-9]+.[0-9]+.[0-9]+/version = $(basename ${{ github.ref }})/' rust-sdk/${{ matrix.package }}/Cargo.toml
           # TODO: replace workspace dependencies with fixed version
           yarn build rust-sdk/${{ matrix.package }} --output-style static
-          cd rust-sdk/${{ matrix.package }} && cargo publish
+          cd rust-sdk/${{ matrix.package }} && cargo publish --allow-dirty
       env:
         CRATES_IO_API_TOKEN: ${{ secrets.CRATES_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ This repository uses NX to manage the Rust and Typescript codebases. This allows
 This repository is split up into sevaral parts. The following is a (non-exhaustive) list of the components and their purpose.
 
 * **`/programs/*`** - Rust programs that are deployed on Solana.
-* **`/ts-sdk/*`** (WIP) - Typescript SDKs for interacting with the programs.
-* **`/rust-sdk/*`** (WIP) - Rust SDKs for interacting with the programs.
-* **`/docs/*`** (WIP) - Documentation for the programs and SDKs.
+* **`/ts-sdk/*`** - Typescript SDKs for interacting with the programs.
+* **`/rust-sdk/*`** - Rust SDKs for interacting with the programs.
+* **`/docs/*`** - Documentation for the programs and SDKs.
 * **`/legacy-sdk/*`** - Legacy Typescript SDKs and integration tests.
 
 ### Commands

--- a/docs/legacy/typedoc.json
+++ b/docs/legacy/typedoc.json
@@ -2,6 +2,5 @@
   "entryPoints": ["../../legacy-sdk/whirlpool/src/index.ts"],
   "entryPointStrategy": "resolve",
   "githubPages": false,
-  "readme": "none",
   "out": "dist/legacy"
 }

--- a/docs/ts/typedoc.json
+++ b/docs/ts/typedoc.json
@@ -2,6 +2,5 @@
   "entryPoints": ["../../ts-sdk/whirlpool/src/index.ts"],
   "entryPointStrategy": "resolve",
   "githubPages": false,
-  "readme": "none",
   "out": "dist/ts"
 }

--- a/legacy-sdk/whirlpool/package.json
+++ b/legacy-sdk/whirlpool/package.json
@@ -37,7 +37,13 @@
     "type": "git",
     "url": "git+https://github.com/orca-so/whirlpools.git"
   },
-  "keywords": ["solana", "crypto", "defi", "dex", "amm"],
+  "keywords": [
+    "solana",
+    "crypto",
+    "defi",
+    "dex",
+    "amm"
+  ],
   "author": "team@orca.so",
   "bugs": {
     "url": "https://github.com/orca-so/whirlpools/issues"

--- a/legacy-sdk/whirlpool/package.json
+++ b/legacy-sdk/whirlpool/package.json
@@ -37,17 +37,7 @@
     "type": "git",
     "url": "git+https://github.com/orca-so/whirlpools.git"
   },
-  "keywords": [
-    "orca_so",
-    "orca",
-    "solana",
-    "typescript",
-    "sdk",
-    "crypto",
-    "defi",
-    "dex",
-    "amm"
-  ],
+  "keywords": ["solana", "crypto", "defi", "dex", "amm"],
   "author": "team@orca.so",
   "bugs": {
     "url": "https://github.com/orca-so/whirlpools/issues"

--- a/legacy-sdk/whirlpool/package.json
+++ b/legacy-sdk/whirlpool/package.json
@@ -44,11 +44,13 @@
     "typescript",
     "sdk",
     "crypto",
-    "dex"
+    "defi",
+    "dex",
+    "amm"
   ],
   "author": "team@orca.so",
   "bugs": {
     "url": "https://github.com/orca-so/whirlpools/issues"
   },
-  "homepage": "https://www.orca.so"
+  "homepage": "https://orca.so"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@orca-so/whirlpools-monorepo",
   "private": true,
-  "license": "Apache-2.0",
   "packageManager": "yarn@4.4.0",
   "type": "module",
   "scripts": {
@@ -35,23 +34,5 @@
   ],
   "lint-staged": {
     "*": "yarn format"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/orca-so/whirlpools.git"
-  },
-  "keywords": [
-    "orca_so",
-    "orca",
-    "solana",
-    "typescript",
-    "sdk",
-    "crypto",
-    "dex"
-  ],
-  "author": "team@orca.so",
-  "bugs": {
-    "url": "https://github.com/orca-so/whirlpools/issues"
-  },
-  "homepage": "https://www.orca.so"
+  }
 }

--- a/programs/whirlpool/Cargo.toml
+++ b/programs/whirlpool/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "whirlpool"
 version = "0.3.1"
+publish = false
 edition = "2021"
 
 [lib]

--- a/rust-sdk/client/Cargo.toml
+++ b/rust-sdk/client/Cargo.toml
@@ -2,11 +2,12 @@
 name = "orca_whirlpools_client"
 version = "0.1.0"
 description = "Rust client to interact with Orca's on-chain Whirlpool program."
+include = ["src/*"]
 documentation = "https://orca-so.github.io/whirlpools/"
 homepage = "https://orca.so"
 repository = "https://github.com/orca-so/whirlpools"
 license = "Apache-2.0"
-keywords =["orca_so", "orca", "solana", "rust", "sdk", "crypto", "defi", "dex", "amm"]
+keywords = ["solana", "crypto", "defi", "dex", "amm"]
 authors = ["team@orca.so"]
 edition = "2021"
 

--- a/rust-sdk/client/Cargo.toml
+++ b/rust-sdk/client/Cargo.toml
@@ -1,6 +1,13 @@
 [package]
 name = "orca_whirlpools_client"
 version = "0.1.0"
+description = "Rust client to interact with Orca's on-chain Whirlpool program."
+documentation = "https://orca-so.github.io/whirlpools/"
+homepage = "https://orca.so"
+repository = "https://github.com/orca-so/whirlpools"
+license = "Apache-2.0"
+keywords =["orca_so", "orca", "solana", "rust", "sdk", "crypto", "defi", "dex", "amm"]
+authors = ["team@orca.so"]
 edition = "2021"
 
 [features]

--- a/rust-sdk/client/README.md
+++ b/rust-sdk/client/README.md
@@ -1,0 +1,1 @@
+# Orca Whirlpools Rust Client

--- a/rust-sdk/whirlpool/Cargo.toml
+++ b/rust-sdk/whirlpool/Cargo.toml
@@ -6,7 +6,7 @@ documentation = "https://orca-so.github.io/whirlpools/"
 homepage = "https://orca.so"
 repository = "https://github.com/orca-so/whirlpools"
 license = "Apache-2.0"
-keywords =["orca_so", "orca", "solana", "rust", "sdk", "crypto", "defi", "dex", "amm"]
+keywords = ["solana", "crypto", "defi", "dex", "amm"]
 edition = "2021"
 
 [dependencies]

--- a/rust-sdk/whirlpool/Cargo.toml
+++ b/rust-sdk/whirlpool/Cargo.toml
@@ -1,6 +1,12 @@
 [package]
 name = "orca_whirlpools"
 version = "0.1.0"
+description = "Orca's high-level rust sdk to interact with Orca's on-chain Whirlpool program."
+documentation = "https://orca-so.github.io/whirlpools/"
+homepage = "https://orca.so"
+repository = "https://github.com/orca-so/whirlpools"
+license = "Apache-2.0"
+keywords =["orca_so", "orca", "solana", "rust", "sdk", "crypto", "defi", "dex", "amm"]
 edition = "2021"
 
 [dependencies]

--- a/rust-sdk/whirlpool/README.md
+++ b/rust-sdk/whirlpool/README.md
@@ -1,0 +1,1 @@
+# Orca Whirlpools Rust SDK

--- a/ts-sdk/client/README.md
+++ b/ts-sdk/client/README.md
@@ -1,0 +1,1 @@
+# Orca Whirlpools Typescript Client

--- a/ts-sdk/client/package.json
+++ b/ts-sdk/client/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@orca-so/whirlpools-client",
   "version": "0.0.1",
+  "description": "Typescript client to interact with Orca's on-chain Whirlpool program.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "type": "module",
   "files": [
     "dist",
-    "LICENSE"
+    "README.md"
   ],
   "scripts": {
     "build": "node ./kinobi.js && tsc",
@@ -24,5 +25,25 @@
     "@solana/web3.js": "^2.0.0-preview.4",
     "kinobi": "^0.21.4",
     "typescript": "^5.5.4"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/orca-so/whirlpools.git"
+  },
+  "license": "Apache-2.0",
+  "keywords": [
+    "orca_so",
+    "orca",
+    "solana",
+    "typescript",
+    "sdk",
+    "crypto",
+    "dex",
+    "amm"
+  ],
+  "author": "team@orca.so",
+  "bugs": {
+    "url": "https://github.com/orca-so/whirlpools/issues"
+  },
+  "homepage": "https://orca.so"
 }

--- a/ts-sdk/client/package.json
+++ b/ts-sdk/client/package.json
@@ -31,7 +31,13 @@
     "url": "git+https://github.com/orca-so/whirlpools.git"
   },
   "license": "Apache-2.0",
-  "keywords": ["solana", "crypto", "defi", "dex", "amm"],
+  "keywords": [
+    "solana",
+    "crypto",
+    "defi",
+    "dex",
+    "amm"
+  ],
   "author": "team@orca.so",
   "bugs": {
     "url": "https://github.com/orca-so/whirlpools/issues"

--- a/ts-sdk/client/package.json
+++ b/ts-sdk/client/package.json
@@ -31,16 +31,7 @@
     "url": "git+https://github.com/orca-so/whirlpools.git"
   },
   "license": "Apache-2.0",
-  "keywords": [
-    "orca_so",
-    "orca",
-    "solana",
-    "typescript",
-    "sdk",
-    "crypto",
-    "dex",
-    "amm"
-  ],
+  "keywords": ["solana", "crypto", "defi", "dex", "amm"],
   "author": "team@orca.so",
   "bugs": {
     "url": "https://github.com/orca-so/whirlpools/issues"

--- a/ts-sdk/whirlpool/README.md
+++ b/ts-sdk/whirlpool/README.md
@@ -1,0 +1,1 @@
+# Orca Whirlpools Typescript SDK

--- a/ts-sdk/whirlpool/package.json
+++ b/ts-sdk/whirlpool/package.json
@@ -24,7 +24,13 @@
     "url": "git+https://github.com/orca-so/whirlpools.git"
   },
   "license": "Apache-2.0",
-  "keywords": ["solana", "crypto", "defi", "dex", "amm"],
+  "keywords": [
+    "solana",
+    "crypto",
+    "defi",
+    "dex",
+    "amm"
+  ],
   "author": "team@orca.so",
   "bugs": {
     "url": "https://github.com/orca-so/whirlpools/issues"

--- a/ts-sdk/whirlpool/package.json
+++ b/ts-sdk/whirlpool/package.json
@@ -24,17 +24,7 @@
     "url": "git+https://github.com/orca-so/whirlpools.git"
   },
   "license": "Apache-2.0",
-  "keywords": [
-    "orca_so",
-    "orca",
-    "solana",
-    "typescript",
-    "sdk",
-    "crypto",
-    "defi",
-    "dex",
-    "amm"
-  ],
+  "keywords": ["solana", "crypto", "defi", "dex", "amm"],
   "author": "team@orca.so",
   "bugs": {
     "url": "https://github.com/orca-so/whirlpools/issues"

--- a/ts-sdk/whirlpool/package.json
+++ b/ts-sdk/whirlpool/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@orca-so/whirlpools",
   "version": "0.0.1",
+  "description": "Orca's high-level typescript sdk to interact with Orca's on-chain Whirlpool program.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "files": [
     "dist",
-    "LICENSE"
+    "README.md"
   ],
   "scripts": {
     "build": "tsc",
@@ -17,5 +18,26 @@
   },
   "devDependencies": {
     "typescript": "^5.5.4"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/orca-so/whirlpools.git"
+  },
+  "license": "Apache-2.0",
+  "keywords": [
+    "orca_so",
+    "orca",
+    "solana",
+    "typescript",
+    "sdk",
+    "crypto",
+    "defi",
+    "dex",
+    "amm"
+  ],
+  "author": "team@orca.so",
+  "bugs": {
+    "url": "https://github.com/orca-so/whirlpools/issues"
+  },
+  "homepage": "https://orca.so"
 }


### PR DESCRIPTION
This would only publish `client` packages on tag. The other packages are still WIP and will not be published yet