### PR TITLE
InterestBearing support

### DIFF
--- a/legacy-sdk/whirlpool/src/utils/public/pool-utils.ts
+++ b/legacy-sdk/whirlpool/src/utils/public/pool-utils.ts
@@ -256,6 +256,7 @@ export class PoolUtil {
       switch (extension) {
         // supported
         case ExtensionType.TransferFeeConfig:
+        case ExtensionType.InterestBearingConfig:
         case ExtensionType.TokenMetadata:
         case ExtensionType.MetadataPointer:
         case ExtensionType.ConfidentialTransferMint:

--- a/legacy-sdk/whirlpool/tests/integration/v2/initialize_pool_v2.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v2/initialize_pool_v2.test.ts
@@ -1347,6 +1347,17 @@ describe("initialize_pool_v2", () => {
       });
     });
 
+    it("Token-2022: with InterestBearingConfig", async () => {
+      await runTest({
+        supported: true,
+        createTokenBadge: false,
+        tokenTrait: {
+          isToken2022: true,
+          hasInterestBearingExtension: true,
+        },
+      });
+    });
+
     it("Token-2022: with MetadataPointer & TokenMetadata", async () => {
       await runTest({
         supported: true,
@@ -1533,15 +1544,6 @@ describe("initialize_pool_v2", () => {
         createTokenBadge: true,
         isToken2022NativeMint: true,
       });
-    });
-
-    it("Token-2022: [FAIL] with/without TokenBadge with InterestBearingConfig", async () => {
-      const tokenTrait: TokenTrait = {
-        isToken2022: true,
-        hasInterestBearingExtension: true,
-      };
-      await runTest({ supported: false, createTokenBadge: true, tokenTrait });
-      await runTest({ supported: false, createTokenBadge: false, tokenTrait });
     });
 
     //[11 Mar, 2024] NOT IMPLEMENTED / I believe this extension is not stable yet

--- a/legacy-sdk/whirlpool/tests/integration/v2/initialize_reward_v2.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v2/initialize_reward_v2.test.ts
@@ -656,6 +656,17 @@ describe("initialize_reward_v2", () => {
       });
     });
 
+    it("Token-2022: with InterestBearingConfig", async () => {
+      await runTest({
+        supported: true,
+        createTokenBadge: false,
+        tokenTrait: {
+          isToken2022: true,
+          hasInterestBearingExtension: true,
+        },
+      });
+    });
+
     it("Token-2022: with MetadataPointer & TokenMetadata", async () => {
       await runTest({
         supported: true,
@@ -834,15 +845,6 @@ describe("initialize_reward_v2", () => {
           isNativeMint: true,
         },
       });
-    });
-
-    it("Token-2022: [FAIL] with/without TokenBadge with InterestBearingConfig", async () => {
-      const tokenTrait: TokenTrait = {
-        isToken2022: true,
-        hasInterestBearingExtension: true,
-      };
-      await runTest({ supported: false, createTokenBadge: true, tokenTrait });
-      await runTest({ supported: false, createTokenBadge: false, tokenTrait });
     });
 
     // [11 Mar, 2024] NOT IMPLEMENTED / I believe this extension is not stable yet

--- a/legacy-sdk/whirlpool/tests/integration/v2/token-extensions/interest-bearing.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v2/token-extensions/interest-bearing.test.ts
@@ -1,5 +1,6 @@
 import * as anchor from "@coral-xyz/anchor";
 import { BN } from "@coral-xyz/anchor";
+import type NodeWallet from "@coral-xyz/anchor/dist/cjs/nodewallet";
 import { Percentage } from "@orca-so/common-sdk";
 import * as assert from "assert";
 import type {
@@ -20,7 +21,7 @@ import {
   fundPositionsV2,
   initTestPoolWithTokensV2,
 } from "../../../utils/v2/init-utils-v2";
-import { Keypair, type PublicKey } from "@solana/web3.js";
+import type { PublicKey } from "@solana/web3.js";
 import { initTickArrayRange } from "../../../utils/init-utils";
 import { TokenExtensionUtil } from "../../../../src/utils/public/token-extension-util";
 import { amountToUiAmount, updateRateInterestBearingMint } from "@solana/spl-token";
@@ -34,8 +35,7 @@ describe("TokenExtension/InterestBearing", () => {
   const ctx = WhirlpoolContext.fromWorkspace(provider, program);
   const fetcher = ctx.fetcher;
 
-  // HACK: use NodeWallet.payer field
-  const payer = ctx.wallet["payer"] as Keypair;
+  const payer = (ctx.wallet as NodeWallet).payer;
 
   async function rawAmountToUIAmount(mint: PublicKey, rawAmount: BN): Promise<string> {
     const result = await amountToUiAmount(ctx.connection, payer, mint, rawAmount.toNumber(), TEST_TOKEN_2022_PROGRAM_ID);

--- a/legacy-sdk/whirlpool/tests/integration/v2/token-extensions/interest-bearing.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v2/token-extensions/interest-bearing.test.ts
@@ -1,0 +1,196 @@
+import * as anchor from "@coral-xyz/anchor";
+import { BN } from "@coral-xyz/anchor";
+import type { PDA } from "@orca-so/common-sdk";
+import { MathUtil, Percentage } from "@orca-so/common-sdk";
+import * as assert from "assert";
+import Decimal from "decimal.js";
+import type {
+  DecreaseLiquidityQuote,
+  InitPoolV2Params,
+  PositionData,
+  SwapQuote,
+  TwoHopSwapV2Params,
+  WhirlpoolData,
+} from "../../../../src";
+import {
+  buildWhirlpoolClient,
+  collectRewardsQuote,
+  decreaseLiquidityQuoteByLiquidityWithParams,
+  NUM_REWARDS,
+  PDAUtil,
+  swapQuoteWithParams,
+  SwapUtils,
+  toTx,
+  twoHopSwapQuoteFromSwapQuotes,
+  WhirlpoolContext,
+  WhirlpoolIx,
+} from "../../../../src";
+import { IGNORE_CACHE } from "../../../../src/network/public/fetcher";
+import { getTokenBalance, sleep, TickSpacing, ZERO_BN } from "../../../utils";
+import { defaultConfirmOptions } from "../../../utils/const";
+import { WhirlpoolTestFixtureV2 } from "../../../utils/v2/fixture-v2";
+import type { FundedPositionV2Params } from "../../../utils/v2/init-utils-v2";
+import {
+  fundPositionsV2,
+  initTestPoolWithTokensV2,
+} from "../../../utils/v2/init-utils-v2";
+import {
+  createTokenAccountV2,
+  disableRequiredMemoTransfers,
+  enableRequiredMemoTransfers,
+  isRequiredMemoTransfersEnabled,
+} from "../../../utils/v2/token-2022";
+import type { PublicKey } from "@solana/web3.js";
+import { initTickArrayRange } from "../../../utils/init-utils";
+import type { InitAquariumV2Params } from "../../../utils/v2/aquarium-v2";
+import {
+  buildTestAquariumsV2,
+  getDefaultAquariumV2,
+  getTokenAccsForPoolsV2,
+} from "../../../utils/v2/aquarium-v2";
+import { TokenExtensionUtil } from "../../../../src/utils/public/token-extension-util";
+
+describe("TokenExtension/InterestBearing", () => {
+  const provider = anchor.AnchorProvider.local(
+    undefined,
+    defaultConfirmOptions,
+  );
+  const program = anchor.workspace.Whirlpool;
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
+  const fetcher = ctx.fetcher;
+  const client = buildWhirlpoolClient(ctx);
+
+  it("swap_v2", async () => {
+    const {
+      whirlpoolPda,
+      poolInitInfo,
+      tokenAccountA,
+      tokenAccountB,
+    } = await initTestPoolWithTokensV2(
+      ctx,
+      { isToken2022: true, hasInterestBearingExtension: true, interestBearingRate: 10_000 },
+      { isToken2022: true, hasInterestBearingExtension: true, interestBearingRate: 10_000 },
+      TickSpacing.Standard,
+    );
+
+    const aToB = false;
+    await initTickArrayRange(
+      ctx,
+      whirlpoolPda.publicKey,
+      22528, // to 33792
+      3,
+      TickSpacing.Standard,
+      aToB,
+    );
+
+    const fundParams: FundedPositionV2Params[] = [
+      {
+        liquidityAmount: new anchor.BN(10_000_000),
+        tickLowerIndex: 29440,
+        tickUpperIndex: 33536,
+      },
+    ];
+
+    await fundPositionsV2(
+      ctx,
+      poolInitInfo,
+      tokenAccountA,
+      tokenAccountB,
+      fundParams,
+    );
+
+    const oraclePubkey = PDAUtil.getOracle(
+      ctx.program.programId,
+      whirlpoolPda.publicKey,
+    ).publicKey;
+
+    const whirlpoolKey = poolInitInfo.whirlpoolPda.publicKey;
+    const whirlpoolData = (await fetcher.getPool(
+      whirlpoolKey,
+      IGNORE_CACHE,
+    )) as WhirlpoolData;
+
+    const quoteAToB = swapQuoteWithParams(
+      {
+        amountSpecifiedIsInput: true,
+        aToB: true,
+        tokenAmount: new BN(100000),
+        otherAmountThreshold: SwapUtils.getDefaultOtherAmountThreshold(true),
+        sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(true),
+        whirlpoolData,
+        tickArrays: await SwapUtils.getTickArrays(
+          whirlpoolData.tickCurrentIndex,
+          whirlpoolData.tickSpacing,
+          true,
+          ctx.program.programId,
+          whirlpoolKey,
+          fetcher,
+          IGNORE_CACHE,
+        ),
+        tokenExtensionCtx:
+          await TokenExtensionUtil.buildTokenExtensionContext(
+            fetcher,
+            whirlpoolData,
+            IGNORE_CACHE,
+          ),
+      },
+      Percentage.fromFraction(100, 100), // 100% slippage
+    );
+
+    const quoteBToA = swapQuoteWithParams(
+      {
+        amountSpecifiedIsInput: true,
+        aToB: false,
+        tokenAmount: new BN(100000),
+        otherAmountThreshold: SwapUtils.getDefaultOtherAmountThreshold(true),
+        sqrtPriceLimit: SwapUtils.getDefaultSqrtPriceLimit(false),
+        whirlpoolData,
+        tickArrays: await SwapUtils.getTickArrays(
+          whirlpoolData.tickCurrentIndex,
+          whirlpoolData.tickSpacing,
+          false,
+          ctx.program.programId,
+          whirlpoolKey,
+          fetcher,
+          IGNORE_CACHE,
+        ),
+        tokenExtensionCtx:
+          await TokenExtensionUtil.buildTokenExtensionContext(
+            fetcher,
+            whirlpoolData,
+            IGNORE_CACHE,
+          ),
+      },
+      Percentage.fromFraction(100, 100), // 100% slippage
+    );
+
+    const balanceA0 = new BN(await getTokenBalance(provider, tokenAccountA));
+    const balanceB0 = new BN(await getTokenBalance(provider, tokenAccountB));
+
+    const sigBToA = await toTx(
+      ctx,
+      WhirlpoolIx.swapV2Ix(ctx.program, {
+        ...quoteBToA,
+        whirlpool: whirlpoolPda.publicKey,
+        tokenAuthority: ctx.wallet.publicKey,
+        tokenMintA: poolInitInfo.tokenMintA,
+        tokenMintB: poolInitInfo.tokenMintB,
+        tokenProgramA: poolInitInfo.tokenProgramA,
+        tokenProgramB: poolInitInfo.tokenProgramB,
+        tokenOwnerAccountA: tokenAccountA,
+        tokenVaultA: poolInitInfo.tokenVaultAKeypair.publicKey,
+        tokenOwnerAccountB: tokenAccountB,
+        tokenVaultB: poolInitInfo.tokenVaultBKeypair.publicKey,
+        oracle: oraclePubkey,
+      }),
+    ).buildAndExecute();
+
+    const balanceA1 = new BN(await getTokenBalance(provider, tokenAccountA));
+    const balanceB1 = new BN(await getTokenBalance(provider, tokenAccountB));
+    assert.ok(balanceB1.lt(balanceB0));
+    assert.ok(balanceA1.gt(balanceA0));
+
+
+  });
+
+});

--- a/legacy-sdk/whirlpool/tests/utils/v2/init-utils-v2.ts
+++ b/legacy-sdk/whirlpool/tests/utils/v2/init-utils-v2.ts
@@ -57,6 +57,7 @@ export interface TokenTrait {
   hasConfidentialTransferExtension?: boolean;
 
   hasInterestBearingExtension?: boolean;
+  interestBearingRate?: number; // u16
   hasMintCloseAuthorityExtension?: boolean;
   hasDefaultAccountStateExtension?: boolean;
   defaultAccountInitialState?: AccountState;

--- a/legacy-sdk/whirlpool/tests/utils/v2/token-2022.ts
+++ b/legacy-sdk/whirlpool/tests/utils/v2/token-2022.ts
@@ -245,7 +245,7 @@ async function createMintInstructions(
         createInitializeInterestBearingMintInstruction(
           mint,
           authority,
-          1,
+          tokenTrait.interestBearingRate ?? 1, // default 1/10000
           TEST_TOKEN_2022_PROGRAM_ID,
         ),
       );

--- a/programs/whirlpool/src/util/v2/token.rs
+++ b/programs/whirlpool/src/util/v2/token.rs
@@ -233,6 +233,7 @@ pub fn is_supported_token_mint(
         match extension {
             // supported
             extension::ExtensionType::TransferFeeConfig => {}
+            extension::ExtensionType::InterestBearingConfig => {}
             extension::ExtensionType::TokenMetadata => {}
             extension::ExtensionType::MetadataPointer => {}
             // partially supported


### PR DESCRIPTION
https://linear.app/orca-so/issue/INF-149/[amm]-interestbearing-support

## Add InterestBearing extension as supported extensions
- The program handles u64 amount (raw amount) only. (not handle UI Amount)
- TokenBadge is not required.

## Current state: ~~Pending~~ Go
~~The handling of InterestBearing is being discussed so as not to create confusion throughout the Solana ecosystem.
Supporting it should wait for now.~~

There is no problem to enable it on the contract side, so we'll merge the PR.
We need to tackling to the difficulty in handling InterestBearing on the UI side. 😂