### PR TITLE
More sophisticated version setting for publish gh action

### DIFF
--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -50,6 +50,6 @@ runs:
       if: ${{ steps.env.outputs.ENV == 'cargo' }}
       run: |
         sed -i 's/^version = ".*"$/version = "${{ steps.version.outputs.VERSION }}"/' ${{ inputs.manifest-file }}
-        # TODO: Following should only happen in dependencies and not devDependencies
+        # TODO: Following should only happen in dependencies and not dev-dependencies
         # sed -i 's/path = ".*"/version = "${{ steps.version.outputs.VERSION }}"/' ${{ inputs.manifest-file }}
       shell: bash

--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -1,0 +1,55 @@
+name: 'Setup Version in monorepo'
+description: 'Set version of all packages in monorepo.'
+
+branding:
+  icon: type
+  color: red
+
+inputs:
+  version:
+    description: 'The version to update all packages to.'
+    required: true
+  manifest-file:
+    description: 'The package to update the versions for.'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get New Version Number
+      id: version
+      run: |
+        VERSION=$(basename ${{ inputs.version }})
+        if [[ $VERSION != v* ]]; then
+          echo "Invalid version number" 1>&2
+          exit 1
+        fi
+        echo "VERSION=${VERSION:1}" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Get Environment
+      id: env
+      run: |
+        if [[ $(basename ${{ inputs.manifest-file }}) == "package.json" ]]; then
+          ENV="npm"
+        elif [[ $(basename ${{ inputs.manifest-file }}) == "Cargo.toml" ]]; then
+          ENV="cargo"
+        else
+          echo "Unknown package type" 1>&2
+          exit 1
+        fi
+        echo "ENV=$ENV" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Update npm Packages
+      if: ${{ steps.env.outputs.ENV == 'npm' }}
+      run: |
+        sed -i 's/"version": ".*"/"version": "${{ steps.version.outputs.VERSION }}"/' ${{ inputs.manifest-file }}
+        # TODO: Following should only happen in dependencies and not devDependencies
+        # sed -i 's/"\*"/"${{ steps.version.outputs.VERSION }}"/' ${{ inputs.manifest-file }}
+      shell: bash
+    - name: Update Cargo Packages
+      if: ${{ steps.env.outputs.ENV == 'cargo' }}
+      run: |
+        sed -i 's/^version = ".*"$/version = "${{ steps.version.outputs.VERSION }}"/' ${{ inputs.manifest-file }}
+        # TODO: Following should only happen in dependencies and not devDependencies
+        # sed -i 's/path = ".*"/version = "${{ steps.version.outputs.VERSION }}"/' ${{ inputs.manifest-file }}
+      shell: bash

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -8,7 +8,7 @@ jobs:
 
   automerge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: ${{ github.actor == 'dependabot[bot]' }}
     permissions:
       pull-requests: write
       contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,13 +17,15 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Set Version
+      uses: ./.github/actions/version
+      with:
+        version: ${{ github.ref }}
+        manifest-file: ts-sdk/${{ matrix.package }}/package.json
     - name: Deploy npm
       uses: ./.github/actions/anchor
       with:
         run: |
-          VERSION=$(basename ${{ github.ref }})
-          sed -i "s/\"version\": \".*\",/\"version\": \"${VERSION:1}\",/" ts-sdk/${{ matrix.package }}/package.json
-          # TODO: replace workspace dependencies with fixed version
           yarn install
           yarn build ts-sdk/${{ matrix.package }} --output-style static
           cd ts-sdk/${{ matrix.package }} && npm publish --access public
@@ -40,13 +42,15 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Set Version
+      uses: ./.github/actions/version
+      with:
+        version: ${{ github.ref }}
+        manifest-file: rust-sdk/${{ matrix.package }}/Cargo.toml
     - name: Deploy cargo
       uses: ./.github/actions/anchor
       with:
         run: |
-          VERSION=$(basename ${{ github.ref }})
-          sed -i "s/^version = \".*\"$/version = \"${VERSION:1}\"/" rust-sdk/${{ matrix.package }}/Cargo.toml
-          # TODO: replace workspace dependencies with fixed version
           yarn build rust-sdk/${{ matrix.package }} --output-style static
           cd rust-sdk/${{ matrix.package }} && cargo publish --allow-dirty
       env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,8 @@ jobs:
     strategy:
       matrix:
         package: [client]
+      max-parallel: 1
+      fail-fast: true
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
@@ -36,6 +38,8 @@ jobs:
     strategy:
       matrix:
         package: [client]
+      max-parallel: 1
+      fail-fast: true
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository


### PR DESCRIPTION
Tested locally using `act`. 

This setup *should* work for the `client` packages since they have no dependencies on other packages in this monorepo. 

For the other packages we would also need to update the local deps' version num (wrote a little bit but still commented out in the actions file). We can fix this later when we deploy those packages.