### PR TITLE
Fix two bugs in publish github actions script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           yarn install
           yarn build ts-sdk/${{ matrix.package }} --output-style static
+          npm config set registry https://registry.npmjs.org/
           cd ts-sdk/${{ matrix.package }} && npm publish --access public
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -58,7 +59,7 @@ jobs:
           yarn build rust-sdk/${{ matrix.package }} --output-style static
           cd rust-sdk/${{ matrix.package }} && cargo publish --allow-dirty
       env:
-        CRATES_IO_API_TOKEN: ${{ secrets.CRATES_TOKEN }}
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
 
   idl:
     runs-on: ubuntu-latest


### PR DESCRIPTION
* Github runner comes preconfigured with ghpr as node registry instead of npmjs (worked locally but not on gh runner)
* Action is calling for `CARGO_REGISTRY_TOKEN` as the env variable instead of `CRATES_IO_API_TOKEN`
