### PR TITLE
Fix an issue with npm deploy token in gh actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,8 +28,7 @@ jobs:
       uses: ./.github/actions/anchor
       with:
         run: |
-          export NODE_AUTH_TOKEN=${{ secrets.NPM_TOKEN }}
-          yarn install
+          npm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }} && yarn
           yarn build ts-sdk/${{ matrix.package }} --output-style static
           cd ts-sdk/${{ matrix.package }} && npm publish --access public
 


### PR DESCRIPTION
Almost there 😁 

**Issue**: `NODE_AUTH_TOKEN` only works with the [setup-node](https://github.com/actions/setup-node) action which we cannot use since we are running in a build container and not on the host itself
**Solution**: add auth token to .npmrc manually