### PR TITLE
Fix a small bug with publish script not adding idl to gh release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,10 +86,9 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: idl
-        path: idl
     - name: Create Release
       uses: ncipollo/release-action@v1
       with:
         generateReleaseNotes: true
         allowUpdates: true
-        artifacts: idl
+        artifacts: idl.zip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,6 +89,7 @@ jobs:
     - name: Create Release
       uses: ncipollo/release-action@v1
       with:
+        name: "SDK - $(basename ${{ github.ref_name }})"
         generateReleaseNotes: true
         allowUpdates: true
         artifacts: idl.zip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,10 +86,13 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: idl
+    - name: Create Release Name
+      id: name
+      run: echo "NAME=SDK - $(basename ${{ github.ref_name }})" >> $GITHUB_OUTPUT
     - name: Create Release
       uses: ncipollo/release-action@v1
       with:
-        name: "SDK - $(basename ${{ github.ref_name }})"
+        name: ${{ steps.name.outputs.NAME }}
         generateReleaseNotes: true
         allowUpdates: true
         artifacts: idl.zip


### PR DESCRIPTION
## 1

Workflow itself works fine and release is created. Only the idl artifact is not attached to the release correctly: 
```
Warning: Artifact is a directory:idl/. Directories can not be uploaded to a release.
```

## 2

Change the release title to `SDK - vX.X.X` so that we can still make distinction between SDK and program releases