### PR TITLE
Bump legacy-sdk version 0.13.6

### DIFF
--- a/legacy-sdk/whirlpool/package.json
+++ b/legacy-sdk/whirlpool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/whirlpools-sdk",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "description": "Typescript SDK to interact with Orca's Whirlpool program.",
   "license": "Apache-2.0",
   "main": "dist/index.js",


### PR DESCRIPTION
https://github.com/orca-so/whirlpools/pull/244 is live now.

This PR is just to release the latest sdk. 🙏