### PR TITLE
Fix: ExactOut + SOL input WSOL handling and missing refresh

### DIFF
--- a/legacy-sdk/whirlpool/package.json
+++ b/legacy-sdk/whirlpool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/whirlpools-sdk",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "description": "Typescript SDK to interact with Orca's Whirlpool program.",
   "license": "Apache-2.0",
   "main": "dist/index.js",

--- a/legacy-sdk/whirlpool/src/quotes/public/swap-quote.ts
+++ b/legacy-sdk/whirlpool/src/quotes/public/swap-quote.ts
@@ -224,7 +224,10 @@ async function swapQuoteByToken(
   fetcher: WhirlpoolAccountFetcherInterface,
   opts?: WhirlpoolAccountFetchOptions,
 ): Promise<SwapQuoteParam> {
-  const whirlpoolData = whirlpool.getData();
+  // If we use whirlpool.getData() here, quote will not be the latest even if opts is IGNORE_CACHE
+  const whirlpoolData = await fetcher.getPool(whirlpool.getAddress(), opts);
+  invariant(!!whirlpoolData, "Whirlpool data not found");
+
   const swapMintKey = AddressUtil.toPubKey(inputTokenMint);
   const swapTokenType = PoolUtil.getTokenType(whirlpoolData, swapMintKey);
   invariant(

--- a/legacy-sdk/whirlpool/tests/sdk/whirlpools/swap/swap-edge-case.test.ts
+++ b/legacy-sdk/whirlpool/tests/sdk/whirlpools/swap/swap-edge-case.test.ts
@@ -1,0 +1,159 @@
+import * as anchor from "@coral-xyz/anchor";
+import { Percentage } from "@orca-so/common-sdk";
+import * as assert from "assert";
+import BN from "bn.js";
+import {
+  PriceMath,
+  WhirlpoolContext,
+  buildWhirlpoolClient,
+  swapQuoteByInputToken,
+} from "../../../../src";
+import { IGNORE_CACHE } from "../../../../src/network/public/fetcher";
+import { defaultConfirmOptions } from "../../../utils/const";
+import { NATIVE_MINT } from "@solana/spl-token";
+import { WhirlpoolTestFixture } from "../../../utils/fixture";
+import { swapQuoteByOutputToken } from "../../../../dist";
+import { SystemInstruction } from "@solana/web3.js";
+import { SwapUtils } from "../../../../dist/utils/public/swap-utils";
+
+describe("swap edge case test", () => {
+  const provider = anchor.AnchorProvider.local(
+    undefined,
+    defaultConfirmOptions,
+  );
+
+  const program = anchor.workspace.Whirlpool;
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
+  const fetcher = ctx.fetcher;
+  const client = buildWhirlpoolClient(ctx);
+
+  describe("SOL Wrapping", () => {
+    async function buildTestFixture() {
+      const tickSpacing = 64;
+      const tickInitialIndex = -1988;
+      const tickUpperIndex = -64;
+      const tickLowerIndex = -3904;
+      const liquidityAmount = new BN(100000000000);
+
+      return new WhirlpoolTestFixture(ctx).init(
+        {
+          tokenAIsNative: true, // build pool which is similar to SOL/mSOL
+          initialSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(tickInitialIndex),
+          tickSpacing,
+          positions: [
+            { tickLowerIndex, tickUpperIndex, liquidityAmount }, // In range position
+          ],
+        },
+      );
+    }
+
+    it("ExactIn, SOL is input token", async () => {
+      const fixture = await buildTestFixture();
+      const poolInitInfo = fixture.getInfos().poolInitInfo;
+
+      const pool = await client.getPool(poolInitInfo.whirlpoolPda.publicKey, IGNORE_CACHE);
+      assert.ok(pool.getData().tokenMintA.equals(NATIVE_MINT));
+
+      const quote = await swapQuoteByInputToken(
+        pool,
+        pool.getData().tokenMintA, // SOL(tokenMintA) will be input
+        new BN(1_000_000_000), // 1 SOL (required input is obvilously 1 SOL + rent)
+        Percentage.fromFraction(0, 1000),
+        ctx.program.programId,
+        ctx.fetcher,
+        IGNORE_CACHE,
+      );
+
+      // ExactIn
+      assert.ok(quote.amountSpecifiedIsInput === true);
+      assert.ok(quote.aToB);
+
+      // The value of mSOL > The value of SOL
+      assert.ok(quote.amount.eq(new BN(1_000_000_000))); // 1 SOL
+      assert.ok(quote.otherAmountThreshold.lt(new BN(900_000_000))); // < 0.9 mSOL
+
+      const tx = await pool.swap(quote);
+
+      // check wrapping instruction
+      const createAccountIx = tx.compressIx(true).instructions[0];
+      const decoded = SystemInstruction.decodeCreateAccount(createAccountIx);
+      const tokenAccountRent = await fetcher.getAccountRentExempt(true);
+      const lamportsExpected = quote.amount.addn(tokenAccountRent);
+      assert.ok(lamportsExpected.eq(new BN(decoded.lamports)));
+
+      await tx.buildAndExecute();
+    });
+
+    it("ExactOut, SOL is input token", async () => {
+      const fixture = await buildTestFixture();
+      const poolInitInfo = fixture.getInfos().poolInitInfo;
+
+      const pool = await client.getPool(poolInitInfo.whirlpoolPda.publicKey, IGNORE_CACHE);
+      assert.ok(pool.getData().tokenMintA.equals(NATIVE_MINT));
+
+      const quote = await swapQuoteByOutputToken(
+        pool,
+        pool.getData().tokenMintB, // SOL(tokenMintA) will be input
+        new BN(1_000_000_000), // 1 mSOL (required input is obvilously larger than 1 SOL)
+        Percentage.fromFraction(0, 1000),
+        ctx.program.programId,
+        ctx.fetcher,
+        IGNORE_CACHE,
+      );
+
+      // ExactOut
+      assert.ok(quote.amountSpecifiedIsInput === false);
+      assert.ok(quote.aToB);
+
+      // If WSOL amount is 1 WSOL, swap should be failed
+      assert.ok(quote.amount.eq(new BN(1_000_000_000))); // 1 mSOL
+      assert.ok(quote.otherAmountThreshold.gt(new BN(1_100_000_000))); // > 1.1 SOL
+
+      const tx = await pool.swap(quote);
+
+      // check wrapping instruction
+      const createAccountIx = tx.compressIx(true).instructions[0];
+      const decoded = SystemInstruction.decodeCreateAccount(createAccountIx);
+      const tokenAccountRent = await fetcher.getAccountRentExempt(true);
+      const lamportsExpected = quote.otherAmountThreshold.addn(tokenAccountRent);
+      assert.ok(lamportsExpected.eq(new BN(decoded.lamports)));
+
+      await tx.buildAndExecute();
+    });
+
+    it("[Fail] ExactOut, SOL is input token, otherAmountThreshold is default value (U64_MAX)", async () => {
+      const fixture = await buildTestFixture();
+      const poolInitInfo = fixture.getInfos().poolInitInfo;
+
+      const pool = await client.getPool(poolInitInfo.whirlpoolPda.publicKey, IGNORE_CACHE);
+      assert.ok(pool.getData().tokenMintA.equals(NATIVE_MINT));
+
+      const quote = await swapQuoteByOutputToken(
+        pool,
+        pool.getData().tokenMintB, // SOL(tokenMintA) will be input
+        new BN(1_000_000_000), // 1 mSOL (required input is obvilously larger than 1 SOL)
+        Percentage.fromFraction(0, 1000),
+        ctx.program.programId,
+        ctx.fetcher,
+        IGNORE_CACHE,
+      );
+
+      // ExactOut
+      assert.ok(quote.amountSpecifiedIsInput === false);
+      assert.ok(quote.aToB);
+
+      // If WSOL amount is 1 WSOL, swap should be failed
+      assert.ok(quote.amount.eq(new BN(1_000_000_000))); // 1 mSOL
+      assert.ok(quote.otherAmountThreshold.gt(new BN(1_100_000_000))); // > 1.1 SOL
+
+      await assert.rejects(
+        pool.swap({
+          ...quote,
+          // use default otherAmountThreshold (U64_MAX)
+          otherAmountThreshold: SwapUtils.getDefaultOtherAmountThreshold(quote.amountSpecifiedIsInput),
+        }),
+        /Wrapping U64_MAX amount of SOL is not possible/
+      );
+    });
+  });
+});


### PR DESCRIPTION
This PR will fix the following 3 issues.

## ExactOut + SOL input WSOL handling
Current SDK implementation always wrap `amount` of SOL if input token is SOL.
But in ExactOut case, `amount` is output amount and may be not SOL.
In ExactOut case, we need to use `otherAmountThreshold` as input amount.

## Missing refresh on swapQuoteByInputToken
swapQuotesByInputToken receives `opts`.
But even when we use `IGNORE_CACHE`, it will try to use `whirlpool.getData()`.
It is cached value, so user cannot get the latest quote. (Only TickArray state will be refreshed)

## estimateLiquidityFromTokenAmounts uses currTick (not sqrtPrice)
estimateLiquidityFromTokenAmounts uses currTick so its result is not accurate.
To avoid breaking change, I introduced `estimateMaxLiquidityFromTokenAmounts`.
It uses `sqrtPriceX64`.

Also `estimateLiquidityFromTokenAmounts` have been deprecated.