### PR TITLE
Typedocs for TS SDK

### DIFF
--- a/rust-sdk/client/Cargo.lock
+++ b/rust-sdk/client/Cargo.lock
@@ -893,19 +893,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gloo-utils"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037fcb07216cb3a30f7292bd0176b050b7b9a052ba830ef7d5d65f6dc64ba58e"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,11 +1264,6 @@ dependencies = [
  "ethnum",
  "libm",
  "orca_whirlpools_macros",
- "serde",
- "serde-big-array",
- "serde-wasm-bindgen 0.6.5",
- "tsify",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1563,37 +1545,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-big-array"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "serde_bytes"
 version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1607,17 +1558,6 @@ name = "serde_derive"
 version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.74",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e578a843d40b4189a4d66bba51d7684f57da5bd7c304c64e14bd63efbef49509"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1982,32 +1922,6 @@ dependencies = [
  "indexmap 2.4.0",
  "toml_datetime",
  "winnow",
-]
-
-[[package]]
-name = "tsify"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b26cf145f2f3b9ff84e182c448eaf05468e247f148cf3d2a7d67d78ff023a0"
-dependencies = [
- "gloo-utils",
- "serde",
- "serde-wasm-bindgen 0.5.0",
- "serde_json",
- "tsify-macros",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "tsify-macros"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a94b0f0954b3e59bfc2c246b4c8574390d94a4ad4ad246aaf2fb07d7dfd3b47"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.74",
 ]
 
 [[package]]

--- a/rust-sdk/whirlpool/Cargo.lock
+++ b/rust-sdk/whirlpool/Cargo.lock
@@ -615,19 +615,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gloo-utils"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037fcb07216cb3a30f7292bd0176b050b7b9a052ba830ef7d5d65f6dc64ba58e"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -936,11 +923,6 @@ dependencies = [
  "ethnum",
  "libm",
  "orca_whirlpools_macros",
- "serde",
- "serde-big-array",
- "serde-wasm-bindgen 0.6.5",
- "tsify",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1216,37 +1198,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-big-array"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "serde_bytes"
 version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1260,17 +1211,6 @@ name = "serde_derive"
 version = "1.0.207"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aea2634c86b0e8ef2cfdc0c340baede54ec27b1e46febd7f80dffb2aa44a00e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.74",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e578a843d40b4189a4d66bba51d7684f57da5bd7c304c64e14bd63efbef49509"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1568,32 +1508,6 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "winnow",
-]
-
-[[package]]
-name = "tsify"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b26cf145f2f3b9ff84e182c448eaf05468e247f148cf3d2a7d67d78ff023a0"
-dependencies = [
- "gloo-utils",
- "serde",
- "serde-wasm-bindgen 0.5.0",
- "serde_json",
- "tsify-macros",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "tsify-macros"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a94b0f0954b3e59bfc2c246b4c8574390d94a4ad4ad246aaf2fb07d7dfd3b47"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.74",
 ]
 
 [[package]]

--- a/ts-sdk/whirlpool/src/config.ts
+++ b/ts-sdk/whirlpool/src/config.ts
@@ -45,21 +45,19 @@ export function setDefaultSlippageToleranceBps(
 }
 
 /**
- * Keypair:
- * Create auxillary token account using keypair.
- * Optionally add funds to account.
- * Close account at the end of tx.
+ * Defines the strategy for handling SOL wrapping in a transaction.
  *
- * Seed:
- * Same as Keypair but then with a seed account.
+ * - **Keypair**: 
+ *   Creates an auxiliary token account using a keypair. Optionally adds funds to the account. Closes it at the end of the transaction.
  *
- * ATA:
- * Create ata (if needed) for NATIVE_MINT
- * Optionally add funds to ata.
- * Close ata at the end of tx if it did not exist before the tx.
+ * - **Seed**: 
+ *   Functions similarly to Keypair, but uses a seed account instead.
  *
- * None:
- * Use/create ata and do not do any wrapping / unwrapping of SOL
+ * - **ATA**: 
+ *   Creates an associated token account (ATA) for `NATIVE_MINT` if necessary. Optionally adds funds to the ATA. Closes it at the end of the transaction if it was newly created.
+ *
+ * - **None**: 
+ *   Uses or creates an ATA without performing any SOL wrapping or unwrapping.
  */
 export type SolWrappingStrategy = "keypair" | "seed" | "ata" | "none";
 

--- a/ts-sdk/whirlpool/src/config.ts
+++ b/ts-sdk/whirlpool/src/config.ts
@@ -11,6 +11,12 @@ export let WHIRLPOOLS_CONFIG_EXTENSION_ADDRESS: Address = address(
   "777H5H3Tp9U11uRVRzFwM8BinfiakbaLT8vQpeuhvEiH",
 );
 
+/**
+ * Updates the WhirlpoolsConfig and WhirlpoolsConfigExtension addresses.
+ *
+ * @param {Address} whirlpoolsConfigAddress - A WhirlpoolsConfig address.
+ * @returns {Promise<void>} - Resolves when the addresses have been updated.
+ */
 export async function setWhirlpoolsConfig(
   whirlpoolsConfigAddress: Address,
 ): Promise<void> {
@@ -26,6 +32,12 @@ export const SPLASH_POOL_TICK_SPACING = 32896;
 export let DEFAULT_FUNDER: TransactionPartialSigner =
   createNoopSigner(DEFAULT_ADDRESS);
 
+
+/**
+ * Sets the default funder for transactions.
+ *
+ * @param {TransactionPartialSigner | Address} funder - The funder to be set as default, either as an address or a transaction signer.
+ */
 export function setDefaultFunder(
   funder: TransactionPartialSigner | Address,
 ): void {
@@ -36,8 +48,16 @@ export function setDefaultFunder(
   }
 }
 
+/**
+ * The default slippage tolerance, expressed in hundredths of a basis point. Value of 100 is equivalent to 0.01%.
+ */
 export let DEFAULT_SLIPPAGE_TOLERANCE_BPS = 100;
 
+/**
+ * Sets the default slippage tolerance for transactions.
+ *
+ * @param {number} slippageToleranceBps - The slippage tolerance, expressed in hundredths of a basis point. Value of 100 is equivalent to 0.01%.
+ */
 export function setDefaultSlippageToleranceBps(
   slippageToleranceBps: number,
 ): void {
@@ -57,7 +77,7 @@ export function setDefaultSlippageToleranceBps(
  *   Creates an associated token account (ATA) for `NATIVE_MINT` if necessary. Optionally adds funds to the ATA. Closes it at the end of the transaction if it was newly created.
  *
  * - **None**: 
- *   Uses or creates an ATA without performing any SOL wrapping or unwrapping.
+ *   Uses or creates the ATA without performing any SOL wrapping or unwrapping.
  */
 export type SolWrappingStrategy = "keypair" | "seed" | "ata" | "none";
 
@@ -67,6 +87,11 @@ export function setSolWrappingStrategy(strategy: SolWrappingStrategy): void {
   SOL_WRAPPING_STRATEGY = strategy;
 }
 
+/**
+ * Resets the configuration to its default state.
+ *
+ * @returns {Promise<void>} - Resolves when the configuration has been reset.
+ */
 export async function resetConfiguration(): Promise<void> {
   await setWhirlpoolsConfig(
     address("2LecshUwdy9xi7meFgHtFJQNSKk4KdTrcpvaB56dP2NQ"),

--- a/ts-sdk/whirlpool/src/createPool.ts
+++ b/ts-sdk/whirlpool/src/createPool.ts
@@ -50,7 +50,7 @@ export type CreatePoolInstructions = {
 /**
  * Creates the necessary instructions to initialize a Splash Pool on Orca Whirlpools.
  *
- * @param {Rpc<GetMultipleAccountsApi & GetMinimumBalanceForRentExemptionApi>} rpc - A Solana RPC client for communicating with the blockchain.
+ * @param {SolanaRpc} rpc - A Solana RPC client for communicating with the blockchain.
  * @param {Address} tokenMintOne - The first token mint address to include in the pool.
  * @param {Address} tokenMintTwo - The second token mint address to include in the pool.
  * @param {number} [initialPrice=1] - The initial price of token 1 in terms of token 2.
@@ -98,7 +98,7 @@ export function createSplashPoolInstructions(
 /**
  * Creates the necessary instructions to initialize a Concentrated Liquidity Pool (CLMM) on Orca Whirlpools.
  *
- * @param {Rpc<GetMultipleAccountsApi & GetMinimumBalanceForRentExemptionApi>} rpc - A Solana RPC client for communicating with the blockchain.
+ * @param {SolanaRpc} rpc - A Solana RPC client for communicating with the blockchain.
  * @param {Address} tokenMintOne - The first token mint address to include in the pool.
  * @param {Address} tokenMintTwo - The second token mint address to include in the pool.
  * @param {number} tickSpacing - The spacing between price ticks for the pool.

--- a/ts-sdk/whirlpool/src/createPool.ts
+++ b/ts-sdk/whirlpool/src/createPool.ts
@@ -33,12 +33,38 @@ import {
 import { fetchAllMint, getTokenSize } from "@solana-program/token";
 import assert from "assert";
 
+/**
+ * Represents the instructions and metadata for creating a pool.
+ *
+ * @property {IInstruction[]} instructions - The list of instructions needed to create the pool.
+ * @property {LamportsUnsafeBeyond2Pow53Minus1} estInitializationCost - The estimated rent exemption cost for initializing the pool.
+ * @property {Address} poolAddress - The address of the newly created pool.
+ */
 type CreatePoolInstructions = {
   instructions: IInstruction[];
   estInitializationCost: LamportsUnsafeBeyond2Pow53Minus1;
   poolAddress: Address;
 };
 
+/**
+ * Creates the necessary instructions to initialize a Splash Pool on Orca Whirlpools.
+ *
+ * @param {Rpc<GetMultipleAccountsApi & GetMinimumBalanceForRentExemptionApi>} rpc - A Solana RPC client for communicating with the blockchain.
+ * @param {Address} tokenMintOne - The first token mint address to include in the pool.
+ * @param {Address} tokenMintTwo - The second token mint address to include in the pool.
+ * @param {number} [initialPrice=1] - The initial price of token 1 in terms of token 2.
+ * @param {TransactionPartialSigner} [funder=DEFAULT_FUNDER] - The account that will fund the initialization process.
+ * 
+ * @returns {Promise<CreatePoolInstructions>} A promise that resolves to an object containing the pool creation instructions, the estimated initialization cost, and the pool address.
+ *
+ * @example
+ * const { poolAddress, instructions, estInitializationCost } = await createSplashPoolInstructions(
+ *   connection, tokenMintOne, tokenMintTwo, initialPrice, wallet
+ * );
+ * console.log("Pool Address:", poolAddress);
+ * console.log("Initialization Instructions:", instructions);
+ * console.log("Rent (lamports):", estInitializationCost);
+ */
 export function createSplashPoolInstructions(
   rpc: Rpc<GetMultipleAccountsApi & GetMinimumBalanceForRentExemptionApi>,
   tokenMintOne: Address,
@@ -56,6 +82,26 @@ export function createSplashPoolInstructions(
   );
 }
 
+/**
+ * Creates the necessary instructions to initialize a Concentrated Liquidity Pool (CLMM) on Orca Whirlpools.
+ *
+ * @param {Rpc<GetMultipleAccountsApi & GetMinimumBalanceForRentExemptionApi>} rpc - A Solana RPC client for communicating with the blockchain.
+ * @param {Address} tokenMintOne - The first token mint address to include in the pool.
+ * @param {Address} tokenMintTwo - The second token mint address to include in the pool.
+ * @param {number} tickSpacing - The spacing between price ticks for the pool.
+ * @param {number} [initialPrice=1] - The initial price of token 1 in terms of token 2.
+ * @param {TransactionPartialSigner} [funder=DEFAULT_FUNDER] - The account that will fund the initialization process.
+ * 
+ * @returns {Promise<CreatePoolInstructions>} A promise that resolves to an object containing the pool creation instructions, the estimated initialization cost, and the pool address.
+ *
+ * @example
+ * const { poolAddress, instructions, estInitializationCost } = await createConcentratedLiquidityPoolInstructions(
+ *   connection, tokenMintOne, tokenMintTwo, tickSpacing, initialPrice, wallet
+ * );
+ * console.log("Pool Address:", poolAddress);
+ * console.log("Initialization Instructions:", instructions);
+ * console.log("Rent (lamports):", estInitializationCost);
+ */
 export async function createConcentratedLiquidityPoolInstructions(
   rpc: Rpc<GetMultipleAccountsApi & GetMinimumBalanceForRentExemptionApi>,
   tokenMintOne: Address,

--- a/ts-sdk/whirlpool/src/createPool.ts
+++ b/ts-sdk/whirlpool/src/createPool.ts
@@ -35,14 +35,15 @@ import assert from "assert";
 
 /**
  * Represents the instructions and metadata for creating a pool.
- *
- * @property {IInstruction[]} instructions - The list of instructions needed to create the pool.
- * @property {LamportsUnsafeBeyond2Pow53Minus1} estInitializationCost - The estimated rent exemption cost for initializing the pool.
- * @property {Address} poolAddress - The address of the newly created pool.
  */
 export type CreatePoolInstructions = {
+  /** The list of instructions needed to create the pool. */
   instructions: IInstruction[];
+
+  /** The estimated rent exemption cost for initializing the pool, in lamports. */
   estInitializationCost: LamportsUnsafeBeyond2Pow53Minus1;
+
+  /** The address of the newly created pool. */
   poolAddress: Address;
 };
 
@@ -76,10 +77,6 @@ export type CreatePoolInstructions = {
  *   initialPrice,
  *   wallet
  * );
- * 
- * console.log("Pool Address:", poolAddress);
- * console.log("Initialization Instructions:", instructions);
- * console.log("Rent (lamports):", initializationCost);
  */
 export function createSplashPoolInstructions(
   rpc: Rpc<GetMultipleAccountsApi & GetMinimumBalanceForRentExemptionApi>,
@@ -131,10 +128,6 @@ export function createSplashPoolInstructions(
  *   initialPrice,
  *   wallet
  * );
- * 
- * console.log("Pool Address:", poolAddress);
- * console.log("Initialization Instructions:", instructions);
- * console.log("Rent (lamports):", initializationCost);
  */
 export async function createConcentratedLiquidityPoolInstructions(
   rpc: Rpc<GetMultipleAccountsApi & GetMinimumBalanceForRentExemptionApi>,

--- a/ts-sdk/whirlpool/src/createPool.ts
+++ b/ts-sdk/whirlpool/src/createPool.ts
@@ -40,7 +40,7 @@ import assert from "assert";
  * @property {LamportsUnsafeBeyond2Pow53Minus1} estInitializationCost - The estimated rent exemption cost for initializing the pool.
  * @property {Address} poolAddress - The address of the newly created pool.
  */
-type CreatePoolInstructions = {
+export type CreatePoolInstructions = {
   instructions: IInstruction[];
   estInitializationCost: LamportsUnsafeBeyond2Pow53Minus1;
   poolAddress: Address;
@@ -58,12 +58,28 @@ type CreatePoolInstructions = {
  * @returns {Promise<CreatePoolInstructions>} A promise that resolves to an object containing the pool creation instructions, the estimated initialization cost, and the pool address.
  *
  * @example
- * const { poolAddress, instructions, estInitializationCost } = await createSplashPoolInstructions(
- *   connection, tokenMintOne, tokenMintTwo, initialPrice, wallet
+ * import { createSplashPoolInstructions } from '@orca-so/whirlpools';
+ * import { generateKeyPairSigner, createSolanaRpc, devnet } from '@solana/web3.js';
+ * 
+ * const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
+ * const wallet = await generateKeyPairSigner();
+ * await devnetRpc.requestAirdrop(wallet.address, lamports(1000000000n)).send();
+ * 
+ * const tokenMintOne = "TOKEN_MINT_ADDRESS_1"; 
+ * const tokenMintTwo = "TOKEN_MINT_ADDRESS_2"; 
+ * const initialPrice = 0.01;
+ * 
+ * const { poolAddress, instructions, initializationCost } = await createSplashPoolInstructions(
+ *   devnetRpc,
+ *   tokenMintOne,
+ *   tokenMintTwo,
+ *   initialPrice,
+ *   wallet
  * );
+ * 
  * console.log("Pool Address:", poolAddress);
  * console.log("Initialization Instructions:", instructions);
- * console.log("Rent (lamports):", estInitializationCost);
+ * console.log("Rent (lamports):", initializationCost);
  */
 export function createSplashPoolInstructions(
   rpc: Rpc<GetMultipleAccountsApi & GetMinimumBalanceForRentExemptionApi>,
@@ -95,12 +111,30 @@ export function createSplashPoolInstructions(
  * @returns {Promise<CreatePoolInstructions>} A promise that resolves to an object containing the pool creation instructions, the estimated initialization cost, and the pool address.
  *
  * @example
- * const { poolAddress, instructions, estInitializationCost } = await createConcentratedLiquidityPoolInstructions(
- *   connection, tokenMintOne, tokenMintTwo, tickSpacing, initialPrice, wallet
+ * import { createConcentratedLiquidityPool } from '@orca-so/whirlpools';
+ * import { generateKeyPairSigner, createSolanaRpc, devnet } from '@solana/web3.js';
+ * 
+ * const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
+ * const wallet = await generateKeyPairSigner();
+ * await devnetRpc.requestAirdrop(wallet.address, lamports(1000000000n)).send();
+ * 
+ * const tokenMintOne = "TOKEN_MINT_ADDRESS_1";
+ * const tokenMintTwo = "TOKEN_MINT_ADDRESS_2"; 
+ * const tickSpacing = 64;
+ * const initialPrice = 0.01;
+ * 
+ * const { poolAddress, instructions, initializationCost } = await createConcentratedLiquidityPool(
+ *   devnetRpc,
+ *   tokenMintOne,
+ *   tokenMintTwo,
+ *   tickSpacing,
+ *   initialPrice,
+ *   wallet
  * );
+ * 
  * console.log("Pool Address:", poolAddress);
  * console.log("Initialization Instructions:", instructions);
- * console.log("Rent (lamports):", estInitializationCost);
+ * console.log("Rent (lamports):", initializationCost);
  */
 export async function createConcentratedLiquidityPoolInstructions(
   rpc: Rpc<GetMultipleAccountsApi & GetMinimumBalanceForRentExemptionApi>,

--- a/ts-sdk/whirlpool/src/decreaseLiquidity.ts
+++ b/ts-sdk/whirlpool/src/decreaseLiquidity.ts
@@ -136,7 +136,7 @@ function getDecreaseLiquidityQuote(
 /**
  * Generates instructions to decrease liquidity from an existing position in an Orca Whirlpool.
  *
- * @param {Rpc<GetAccountInfoApi & GetMultipleAccountsApi & GetMinimumBalanceForRentExemptionApi>} rpc - A Solana RPC client for fetching necessary accounts and pool data.
+ * @param {SolanaRpc} rpc - A Solana RPC client for fetching necessary accounts and pool data.
  * @param {Address} positionMintAddress - The mint address of the NFT that represents ownership of the position from which liquidity will be removed.
  * @param {DecreaseLiquidityQuoteParam} param - Defines the liquidity removal method (liquidity, tokenA, or tokenB).
  * @param {number} [slippageToleranceBps=DEFAULT_SLIPPAGE_TOLERANCE_BPS] - The acceptable slippage tolerance in basis points.
@@ -281,7 +281,7 @@ export type ClosePositionInstructions = DecreaseLiquidityInstructions & {
  * Generates instructions to close a liquidity position in an Orca Whirlpool. This includes collecting all fees,
  * rewards, removing any remaining liquidity, and closing the position.
  *
- * @param {Rpc<GetAccountInfoApi & GetMultipleAccountsApi & GetMinimumBalanceForRentExemptionApi>} rpc - A Solana RPC client for fetching accounts and pool data.
+ * @param {SolanaRpc} rpc - A Solana RPC client for fetching accounts and pool data.
  * @param {Address} positionMintAddress - The mint address of the NFT that represents ownership of the position to be closed.
  * @param {DecreaseLiquidityQuoteParam} param - The parameters for removing liquidity (liquidity, tokenA, or tokenB).
  * @param {number} [slippageToleranceBps=DEFAULT_SLIPPAGE_TOLERANCE_BPS] - The acceptable slippage tolerance in basis points.

--- a/ts-sdk/whirlpool/src/decreaseLiquidity.ts
+++ b/ts-sdk/whirlpool/src/decreaseLiquidity.ts
@@ -63,14 +63,14 @@ import assert from "assert";
 // TODO: transfer hook
 
 /**
- * Parameters for decreasing liquidity in a position.
- *
- * You can specify one of the following:
- * - `liquidity`: Specify the amount of liquidity to remove.
- * - `tokenA`: Specify the amount of token A to remove.
- * - `tokenB`: Specify the amount of token B to remove.
+ * @typedef {Object} DecreaseLiquidityQuoteParam
+ * You must choose only one of the properties (`liquidity`, `tokenA`, or `tokenB`). The SDK will compute the other two based on the input provided.
+ * 
+ * @property {bigint} liquidity - The amount of liquidity to decrease. The SDK will calculate the corresponding amounts of Token A and Token B.
+ * @property {bigint} tokenA - The amount of Token A to withdraw. The SDK will calculate the corresponding liquidity decrease and Token B amount.
+ * @property {bigint} tokenB - The amount of Token B to withdraw. The SDK will calculate the corresponding liquidity decrease and Token A amount.
  */
-type DecreaseLiquidityQuoteParam =
+export type DecreaseLiquidityQuoteParam =
   | {
       liquidity: bigint;
     }
@@ -87,7 +87,7 @@ type DecreaseLiquidityQuoteParam =
  * @property {DecreaseLiquidityQuote} quote - The quote details for decreasing liquidity.
  * @property {IInstruction[]} instructions - The list of instructions required to decrease liquidity.
  */
-type DecreaseLiquidityInstructions = {
+export type DecreaseLiquidityInstructions = {
   quote: DecreaseLiquidityQuote;
   instructions: IInstruction[];
 };
@@ -262,7 +262,7 @@ export async function decreaseLiquidityInstructions(
  * @property {CollectFeesQuote} feesQuote - The fees collected from the position.
  * @property {CollectRewardsQuote} rewardsQuote - The rewards collected from the position.
  */
-type ClosePositionInstructions = DecreaseLiquidityInstructions & {
+export type ClosePositionInstructions = DecreaseLiquidityInstructions & {
   feesQuote: CollectFeesQuote;
   rewardsQuote: CollectRewardsQuote;
 };

--- a/ts-sdk/whirlpool/src/decreaseLiquidity.ts
+++ b/ts-sdk/whirlpool/src/decreaseLiquidity.ts
@@ -63,32 +63,32 @@ import assert from "assert";
 // TODO: transfer hook
 
 /**
- * @typedef {Object} DecreaseLiquidityQuoteParam
- * You must choose only one of the properties (`liquidity`, `tokenA`, or `tokenB`). The SDK will compute the other two based on the input provided.
- * 
- * @property {bigint} liquidity - The amount of liquidity to decrease. The SDK will calculate the corresponding amounts of Token A and Token B.
- * @property {bigint} tokenA - The amount of Token A to withdraw. The SDK will calculate the corresponding liquidity decrease and Token B amount.
- * @property {bigint} tokenB - The amount of Token B to withdraw. The SDK will calculate the corresponding liquidity decrease and Token A amount.
+ * Represents the parameters for decreasing liquidity. 
+ * You must choose only one of the properties (`liquidity`, `tokenA`, or `tokenB`). 
+ * The SDK will compute the other two based on the input provided.
  */
 export type DecreaseLiquidityQuoteParam =
   | {
+      /** The amount of liquidity to decrease.*/
       liquidity: bigint;
     }
   | {
+      /** The amount of Token A to withdraw.*/
       tokenA: bigint;
     }
   | {
+      /** The amount of Token B to withdraw.*/
       tokenB: bigint;
     };
 
 /**
  * Represents the instructions and quote for decreasing liquidity in a position.
- *
- * @property {DecreaseLiquidityQuote} quote - The quote details for decreasing liquidity.
- * @property {IInstruction[]} instructions - The list of instructions required to decrease liquidity.
  */
 export type DecreaseLiquidityInstructions = {
+  /** The quote details for decreasing liquidity, including the liquidity delta, estimated tokens, and minimum token amounts based on slippage tolerance. */
   quote: DecreaseLiquidityQuote;
+
+  /** The list of instructions required to decrease liquidity. */
   instructions: IInstruction[];
 };
 
@@ -145,15 +145,24 @@ function getDecreaseLiquidityQuote(
  * @returns {Promise<DecreaseLiquidityInstructions>} A promise resolving to an object containing the decrease liquidity quote and instructions.
  *
  * @example
+ * import { decreaseLiquidityInstructions } from '@orca-so/whirlpools';
+ * import { generateKeyPairSigner, createSolanaRpc, devnet } from '@solana/web3.js';
+ * 
+ * const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
+ * const wallet = await generateKeyPairSigner();
+ * await devnetRpc.requestAirdrop(wallet.address, lamports(1000000000n)).send();
+ * 
+ * const positionMint = "POSITION_MINT";  
+ * 
+ * const param = { liquidity: 500_000n }; 
+ * 
  * const { quote, instructions } = await decreaseLiquidityInstructions(
- *   connection,
- *   positionMintAddress,
- *   { liquidity: 500_000n },
- *   0.01,
+ *   devnetRpc,
+ *   positionMint,
+ *   param, 
+ *   100,
  *   wallet
  * );
- * console.log("Liquidity Decrease Quote:", quote);
- * console.log("Liquidity Decrease Instructions:", instructions);
  */
 export async function decreaseLiquidityInstructions(
   rpc: Rpc<
@@ -257,13 +266,13 @@ export async function decreaseLiquidityInstructions(
 
 /**
  * Represents the instructions and quotes for closing a liquidity position in an Orca Whirlpool.
- *
- * Extends `DecreaseLiquidityInstructions` and adds:
- * @property {CollectFeesQuote} feesQuote - The fees collected from the position.
- * @property {CollectRewardsQuote} rewardsQuote - The rewards collected from the position.
+ * Extends `DecreaseLiquidityInstructions` and adds additional fee and reward details.
  */
 export type ClosePositionInstructions = DecreaseLiquidityInstructions & {
+  /** The fees collected from the position, including the amounts for token A (`fee_owed_a`) and token B (`fee_owed_b`). */
   feesQuote: CollectFeesQuote;
+
+  /** The rewards collected from the position, including up to three reward tokens (`reward_owed_1`, `reward_owed_2`, and `reward_owed_3`). */
   rewardsQuote: CollectRewardsQuote;
 };
 
@@ -281,17 +290,24 @@ export type ClosePositionInstructions = DecreaseLiquidityInstructions & {
  * @returns {Promise<ClosePositionInstructions>} A promise resolving to an object containing instructions, fees quote, rewards quote, and the liquidity quote for the closed position.
  *
  * @example
+ * import { closePositionInstructions } from '@orca-so/whirlpools';
+ * import { generateKeyPairSigner, createSolanaRpc, devnet } from '@solana/web3.js';
+ * 
+ * const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
+ * const wallet = await generateKeyPairSigner();
+ * await devnetRpc.requestAirdrop(wallet.address, lamports(1000000000n)).send();
+ * 
+ * const positionMint = "POSITION_MINT";
+ * 
+ * const param = { liquidity: 500_000n };
+ * 
  * const { instructions, quote, feesQuote, rewardsQuote } = await closePositionInstructions(
- *   connection,
- *   positionMintAddress,
- *   { liquidity: 500_000n },
- *   0.01,
- *   wallet
+ *   devnetRpc,
+ *   positionMint,
+ *   param,
+ *   100, 
+ *   wallet 
  * );
- * console.log("Fees Collected:", feesQuote);
- * console.log("Rewards Collected:", rewardsQuote);
- * console.log("Liquidity Removed:", quote);
- * console.log("Close Position Instructions:", instructions);
  */
 export async function closePositionInstructions(
   rpc: Rpc<

--- a/ts-sdk/whirlpool/src/harvest.ts
+++ b/ts-sdk/whirlpool/src/harvest.ts
@@ -42,14 +42,16 @@ import assert from "assert";
 // TODO: Transfer hook
 
 /**
- * @typedef {Object} HarvestPositionInstructions
- * @property {CollectFeesQuote} feesQuote - A breakdown of the fees owed to the position owner in token A and token B.
- * @property {CollectRewardsQuote} rewardsQuote - A breakdown of the rewards owed in up to three reward tokens.
- * @property {IInstruction[]} instructions - A list of instructions needed to harvest the position.
+ * Represents the instructions and quotes for harvesting a position.
  */
 export type HarvestPositionInstructions = {
+  /** A breakdown of the fees owed to the position owner, detailing the amounts for token A (`fee_owed_a`) and token B (`fee_owed_b`). */
   feesQuote: CollectFeesQuote;
+
+  /** A breakdown of the rewards owed, detailing up to three reward tokens (`reward_owed_1`, `reward_owed_2`, and `reward_owed_3`). */
   rewardsQuote: CollectRewardsQuote;
+
+  /** A list of instructions required to harvest the position. */
   instructions: IInstruction[];
 };
 
@@ -80,29 +82,33 @@ async function getTransferFeeConfigs(
 }
 
 /**
- * Generates instructions to harvest accumulated fees and rewards from an Orca Whirlpool position.
- * 
  * This function creates a set of instructions that collect any accumulated fees and rewards from a position.
  * The liquidity remains in place, and the position stays open.
  * 
  * @param {Rpc<GetAccountInfoApi & GetMultipleAccountsApi & GetMinimumBalanceForRentExemptionApi & GetEpochInfoApi>} rpc 
  *    A Solana RPC client used to interact with the blockchain.
  * @param {Address} positionMintAddress 
- *    The mint address of the position you want to harvest fees and rewards from.
+ *    The position mint address you want to harvest fees and rewards from.
  * @param {TransactionPartialSigner} [authority=DEFAULT_FUNDER] 
  *    The account that authorizes the transaction. Defaults to a predefined funder.
  * 
  * @returns {Promise<HarvestPositionInstructions>} 
  *    A promise that resolves to an object containing the instructions, fees, and rewards quotes.
  * @example
+ * import { harvestPositionInstructions } from '@orca-so/whirlpools';
+ * import { generateKeyPairSigner, createSolanaRpc, devnet } from '@solana/web3.js';
+ * 
+ * const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
+ * const wallet = await generateKeyPairSigner();
+ * await devnetRpc.requestAirdrop(wallet.address, lamports(1000000000n)).send();
+ * 
+ * const positionMint = "POSITION_MINT";
+ * 
  * const { feesQuote, rewardsQuote, instructions } = await harvestPositionInstructions(
- *   connection,
- *   positionMintAddress,
+ *   devnetRpc,
+ *   positionMint,
  *   wallet
  * );
- * console.log("Fees Collected:", feesQuote);
- * console.log("Rewards Collected:", rewardsQuote);
- * console.log("Harvest Position Instructions:", instructions);
  */
 export async function harvestPositionInstructions(
   rpc: Rpc<

--- a/ts-sdk/whirlpool/src/harvest.ts
+++ b/ts-sdk/whirlpool/src/harvest.ts
@@ -41,7 +41,13 @@ import assert from "assert";
 
 // TODO: Transfer hook
 
-type HarvestPositionInstructions = {
+/**
+ * @typedef {Object} HarvestPositionInstructions
+ * @property {CollectFeesQuote} feesQuote - A breakdown of the fees owed to the position owner in token A and token B.
+ * @property {CollectRewardsQuote} rewardsQuote - A breakdown of the rewards owed in up to three reward tokens.
+ * @property {IInstruction[]} instructions - A list of instructions needed to harvest the position.
+ */
+export type HarvestPositionInstructions = {
   feesQuote: CollectFeesQuote;
   rewardsQuote: CollectRewardsQuote;
   instructions: IInstruction[];
@@ -73,6 +79,31 @@ async function getTransferFeeConfigs(
   };
 }
 
+/**
+ * Generates instructions to harvest accumulated fees and rewards from an Orca Whirlpool position.
+ * 
+ * This function creates a set of instructions that collect any accumulated fees and rewards from a position.
+ * The liquidity remains in place, and the position stays open.
+ * 
+ * @param {Rpc<GetAccountInfoApi & GetMultipleAccountsApi & GetMinimumBalanceForRentExemptionApi & GetEpochInfoApi>} rpc 
+ *    A Solana RPC client used to interact with the blockchain.
+ * @param {Address} positionMintAddress 
+ *    The mint address of the position you want to harvest fees and rewards from.
+ * @param {TransactionPartialSigner} [authority=DEFAULT_FUNDER] 
+ *    The account that authorizes the transaction. Defaults to a predefined funder.
+ * 
+ * @returns {Promise<HarvestPositionInstructions>} 
+ *    A promise that resolves to an object containing the instructions, fees, and rewards quotes.
+ * @example
+ * const { feesQuote, rewardsQuote, instructions } = await harvestPositionInstructions(
+ *   connection,
+ *   positionMintAddress,
+ *   wallet
+ * );
+ * console.log("Fees Collected:", feesQuote);
+ * console.log("Rewards Collected:", rewardsQuote);
+ * console.log("Harvest Position Instructions:", instructions);
+ */
 export async function harvestPositionInstructions(
   rpc: Rpc<
     GetAccountInfoApi &

--- a/ts-sdk/whirlpool/src/harvest.ts
+++ b/ts-sdk/whirlpool/src/harvest.ts
@@ -85,7 +85,7 @@ async function getTransferFeeConfigs(
  * This function creates a set of instructions that collect any accumulated fees and rewards from a position.
  * The liquidity remains in place, and the position stays open.
  * 
- * @param {Rpc<GetAccountInfoApi & GetMultipleAccountsApi & GetMinimumBalanceForRentExemptionApi & GetEpochInfoApi>} rpc 
+ * @param {SolanaRpc} rpc 
  *    A Solana RPC client used to interact with the blockchain.
  * @param {Address} positionMintAddress 
  *    The position mint address you want to harvest fees and rewards from.

--- a/ts-sdk/whirlpool/src/increaseLiquidity.ts
+++ b/ts-sdk/whirlpool/src/increaseLiquidity.ts
@@ -143,7 +143,7 @@ function getIncreaseLiquidityQuote(
 /**
  * Generates instructions to increase liquidity for an existing position.
  *
- * @param {Rpc<GetAccountInfoApi & GetMultipleAccountsApi & GetMinimumBalanceForRentExemptionApi>} rpc - The Solana RPC client.
+ * @param {SolanaRpc} rpc - The Solana RPC client.
  * @param {Address} positionMintAddress - The mint address of the NFT that represents the position.
  * @param {IncreaseLiquidityQuoteParam} param - The parameters for adding liquidity. Can specify liquidity, Token A, or Token B amounts.
  * @param {number} [slippageToleranceBps=DEFAULT_SLIPPAGE_TOLERANCE_BPS] - The maximum acceptable slippage, in basis points (BPS).
@@ -441,7 +441,7 @@ async function internalOpenPositionInstructions(
 /**
  * Opens a full-range position for a pool, typically used for Splash Pools or other full-range liquidity provisioning.
  *
- * @param {Rpc<GetAccountInfoApi & GetMultipleAccountsApi & GetMinimumBalanceForRentExemptionApi>} rpc - The Solana RPC client.
+ * @param {SolanaRpc} rpc - The Solana RPC client.
  * @param {Address} poolAddress - The address of the liquidity pool.
  * @param {IncreaseLiquidityQuoteParam} param - The parameters for adding liquidity, where one of `liquidity`, `tokenA`, or `tokenB` must be specified. The SDK will compute the others.
  * @param {number} [slippageToleranceBps=DEFAULT_SLIPPAGE_TOLERANCE_BPS] - The maximum acceptable slippage, in basis points (BPS).
@@ -502,7 +502,9 @@ export async function openFullRangePositionInstructions(
  * Opens a new position in a concentrated liquidity pool within a specific price range.
  * This function allows you to provide liquidity for the specified range of prices and adjust liquidity parameters accordingly.
  *
- * @param {Rpc<GetAccountInfoApi & GetMultipleAccountsApi & GetMinimumBalanceForRentExemptionApi>} rpc - A Solana RPC client used to interact with the blockchain.
+ * **Note:** This function cannot be used with Splash Pools.
+ * 
+ * @param {SolanaRpc} rpc - A Solana RPC client used to interact with the blockchain.
  * @param {Address} poolAddress - The address of the liquidity pool where the position will be opened.
  * @param {IncreaseLiquidityQuoteParam} param - The parameters for increasing liquidity, where you must choose one (`liquidity`, `tokenA`, or `tokenB`). The SDK will compute the other two.
  * @param {number} lowerPrice - The lower bound of the price range for the position.

--- a/ts-sdk/whirlpool/src/increaseLiquidity.ts
+++ b/ts-sdk/whirlpool/src/increaseLiquidity.ts
@@ -67,33 +67,35 @@ import assert from "assert";
 // TODO: transfer hook
 
 /**
- * @typedef {Object} IncreaseLiquidityQuoteParam
- * You must choose only one of the properties (`liquidity`, `tokenA`, or `tokenB`). The SDK will compute the other two based on the input provided.
- * 
- * @property {bigint} liquidity - The amount of liquidity to increase. The SDK will calculate the required amounts of Token A and Token B.
- * @property {bigint} tokenA - The amount of Token A to add. The SDK will calculate the corresponding liquidity and Token B amount.
- * @property {bigint} tokenB - The amount of Token B to add. The SDK will calculate the corresponding liquidity and Token A amount.
+ * Represents the parameters for increasing liquidity.
+ * You must choose only one of the properties (`liquidity`, `tokenA`, or `tokenB`).
+ * The SDK will compute the other two based on the input provided.
  */
 export type IncreaseLiquidityQuoteParam =
   | {
+      /** The amount of liquidity to increase. */
       liquidity: bigint;
     }
   | {
+      /** The amount of Token A to add. */
       tokenA: bigint;
     }
   | {
+      /** The amount of Token B to add. */
       tokenB: bigint;
     };
 
 /**
- * @typedef {Object} IncreaseLiquidityInstructions
- * @property {IncreaseLiquidityQuote} quote - The quote object with details about the increase in liquidity.
- * @property {LamportsUnsafeBeyond2Pow53Minus1} initializationCost - The initialization cost for liquidity in lamports.
- * @property {IInstruction[]} instructions - List of Solana transaction instructions to execute.
+ * Represents the instructions and quote for increasing liquidity in a position.
  */
 export type IncreaseLiquidityInstructions = {
+  /** The quote object with details about the increase in liquidity, including the liquidity delta, estimated tokens, and maximum token amounts based on slippage tolerance. */
   quote: IncreaseLiquidityQuote;
+
+  /** The initialization cost for liquidity in lamports. */
   initializationCost: LamportsUnsafeBeyond2Pow53Minus1;
+
+  /** List of Solana transaction instructions to execute. */
   instructions: IInstruction[];
 };
 
@@ -149,16 +151,24 @@ function getIncreaseLiquidityQuote(
  * @returns {Promise<IncreaseLiquidityInstructions>} - Instructions and quote for increasing liquidity.
  *
  * @example
+ * import { increaseLiquidityInstructions } from '@orca-so/whirlpools';
+ * import { generateKeyPairSigner, createSolanaRpc, devnet } from '@solana/web3.js';
+ * 
+ * const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
+ * const wallet = await generateKeyPairSigner();
+ * await devnetRpc.requestAirdrop(wallet.address, lamports(1000000000n)).send();
+ * 
+ * const positionMint = "POSITION_MINT";  
+ * 
+ * const param = { tokenA: 1_000_000n }; 
+ * 
  * const { quote, instructions, initializationCost } = await increaseLiquidityInstructions(
- *   connection,
- *   positionMintAddress,
- *   { liquidity: 500_000n },
- *   0.01,
+ *   devnetRpc, 
+ *   positionMint, 
+ *   param, 
+ *   100, 
  *   wallet
  * );
- * console.log("Liquidity Quote:", quote);
- * console.log("Initialization Cost:", initializationCost);
- * console.log("Instructions:", instructions);
  */
 export async function increaseLiquidityInstructions(
   rpc: Rpc<
@@ -439,16 +449,24 @@ async function internalOpenPositionInstructions(
  * @returns {Promise<IncreaseLiquidityInstructions>} - Instructions and quote for opening a full-range position.
  *
  * @example
+ * import { openFullRangePositionInstructions } from '@orca-so/whirlpools';
+ * import { generateKeyPairSigner, createSolanaRpc, devnet } from '@solana/web3.js';
+ * 
+ * const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
+ * const wallet = await generateKeyPairSigner();
+ * await devnetRpc.requestAirdrop(wallet.address, lamports(1000000000n)).send();
+ * 
+ * const poolAddress = "POOL_ADDRESS";
+ * 
+ * const param = { tokenA: 1_000_000n }; 
+ * 
  * const { quote, instructions, initializationCost } = await openFullRangePositionInstructions(
- *   connection,
+ *   devnetRpc,
  *   poolAddress,
- *   { tokenA: 1_000_000n },
- *   0.01,
+ *   param, 
+ *   100,
  *   wallet
  * );
- * console.log("Position Quote:", quote);
- * console.log("Initialization Cost:", initializationCost);
- * console.log("Instructions:", instructions);
  */
 export async function openFullRangePositionInstructions(
   rpc: Rpc<
@@ -495,18 +513,28 @@ export async function openFullRangePositionInstructions(
  * @returns {Promise<IncreaseLiquidityInstructions>} A promise that resolves to an object containing liquidity information and the list of instructions needed to open the position.
  *
  * @example
- * const { instructions, quote, initializationCost } = await openPositionInstructions(
- *   connection,
+ * import { openPositionInstructions } from '@orca-so/whirlpools';
+ * import { generateKeyPairSigner, createSolanaRpc, devnet } from '@solana/web3.js';
+ * 
+ * const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
+ * const wallet = await generateKeyPairSigner();
+ * await devnetRpc.requestAirdrop(wallet.address, lamports(1000000000n)).send();
+ * 
+ * const poolAddress = "POOL_ADDRESS";
+ * 
+ * const param = { tokenA: 1_000_000n };
+ * const lowerPrice = 0.00005;
+ * const upperPrice = 0.00015;
+ * 
+ * const { quote, instructions, initializationCost } = await openPositionInstructions(
+ *   devnetRpc,
  *   poolAddress,
- *   { tokenA: 1_000_000n },
- *   0.00005,
- *   0.00015,
- *   0.01,
+ *   param,
+ *   lowerPrice,
+ *   upperPrice,
+ *   100,
  *   wallet
  * );
- * console.log("Liquidity Quote:", quote);
- * console.log("Initialization Instructions:", instructions);
- * console.log("Rent (lamports):", initializationCost);
  */
 export async function openPositionInstructions(
   rpc: Rpc<

--- a/ts-sdk/whirlpool/src/pool.ts
+++ b/ts-sdk/whirlpool/src/pool.ts
@@ -19,6 +19,18 @@ import type {
 } from "@solana/web3.js";
 import { SPLASH_POOL_TICK_SPACING, WHIRLPOOLS_CONFIG_ADDRESS } from "./config";
 
+/**
+ * Type representing a pool that is not yet initialized.
+ *
+ * @typedef {Object} InitializablePool
+ * @property {false} initialized - Indicates the pool is not initialized.
+ * @property {Address} whirlpoolsConfig - The configuration address of the Whirlpool.
+ * @property {number} tickSpacing - The spacing between ticks in the pool.
+ * @property {number} feeRate - The fee rate applied to swaps in the pool.
+ * @property {number} protocolFeeRate - The fee rate collected by the protocol.
+ * @property {Address} tokenMintA - The mint address for the first token in the pool.
+ * @property {Address} tokenMintB - The mint address for the second token in the pool.
+ */
 type InitializablePool = {
   initialized: false;
 } & Pick<
@@ -31,12 +43,54 @@ type InitializablePool = {
   | "tokenMintB"
 >;
 
+/**
+ * Type representing a pool that has been initialized.
+ *
+ * @typedef {Object} InitializedPool
+ * @property {true} initialized - Indicates the pool is initialized.
+ * @extends Whirlpool
+ */
 type InitializedPool = {
   initialized: true;
 } & Whirlpool;
 
+/**
+ * Combined type representing both initialized and uninitialized pools.
+ *
+ * @typedef {Object} PoolInfo
+ * @property {Address} address - The address of the pool.
+ * @property {boolean} initialized - Indicates whether the pool is initialized or not.
+ * @property {Whirlpool | InitializablePool} - Either the fully initialized pool details or initializable pool configuration.
+ */
 type PoolInfo = (InitializablePool | InitializedPool) & { address: Address };
 
+/**
+ * Fetches the details of a specific Splash Pool.
+ *
+ * @param {Rpc<GetAccountInfoApi>} rpc - The Solana RPC client.
+ * @param {Address} tokenMintOne - The first token mint address in the pool.
+ * @param {Address} tokenMintTwo - The second token mint address in the pool.
+ * @returns {Promise<PoolInfo>} - A promise that resolves to the pool information, which includes whether the pool is initialized or not.
+ *
+ * @example
+ * import { fetchSplashPool } from '@orca-so/whirlpools';
+ * import { generateKeyPairSigner, createSolanaRpc, devnet } from '@solana/web3.js';
+ * 
+ * const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
+ * const wallet = await generateKeyPairSigner();
+ * await devnetRpc.requestAirdrop(wallet.address, lamports(1000000000n)).send();
+ * 
+ * const tokenMintOne = "TOKEN_MINT_ONE"; 
+ * const tokenMintTwo = "TOKEN_MINT_TWO";
+ * 
+ * const poolInfo = await fetchSplashPool(
+ *   devnetRpc,
+ *   tokenMintOne,
+ *   tokenMintTwo
+ * );
+ * 
+ * console.log("Splash Pool State:", poolInfo);
+ */
 export async function fetchSplashPool(
   rpc: Rpc<GetAccountInfoApi>,
   tokenMintOne: Address,
@@ -50,6 +104,40 @@ export async function fetchSplashPool(
   );
 }
 
+/**
+ * Fetches the details of a specific Concentrated Liquidity Pool.
+ *
+ * @param {Rpc<GetAccountInfoApi>} rpc - The Solana RPC client.
+ * @param {Address} tokenMintOne - The first token mint address in the pool.
+ * @param {Address} tokenMintTwo - The second token mint address in the pool.
+ * @param {number} tickSpacing - The tick spacing of the pool.
+ * @returns {Promise<PoolInfo>} - A promise that resolves to the pool information, which includes whether the pool is initialized or not.
+ *
+ * @example
+ * import { fetchPool } from '@orca-so/whirlpools';
+ * import { generateKeyPairSigner, createSolanaRpc, devnet } from '@solana/web3.js';
+ * 
+ * const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
+ * const wallet = await generateKeyPairSigner();
+ * await devnetRpc.requestAirdrop(wallet.address, lamports(1000000000n)).send();
+ * 
+ * const tokenMintOne = "TOKEN_MINT_ONE";
+ * const tokenMintTwo = "TOKEN_MINT_TWO";
+ * const tickSpacing = 64;
+ * 
+ * const poolInfo = await fetchPool(
+ *   devnetRpc,
+ *   tokenMintOne,
+ *   tokenMintTwo,
+ *   tickSpacing
+ * );
+ * 
+ * if (poolInfo.initialized) {
+ *   console.log("Initialized Pool State:", poolInfo);
+ * } else {
+ *   console.log("Uninitialized Pool Info (Defaults):", poolInfo);
+ * }
+ */
 export async function fetchConcentratedLiquidityPool(
   rpc: Rpc<GetAccountInfoApi>,
   tokenMintOne: Address,
@@ -98,6 +186,39 @@ export async function fetchConcentratedLiquidityPool(
   }
 }
 
+/**
+ * Fetches all possible liquidity pools between two token mints in Orca Whirlpools.
+ *
+ * @param {Rpc<GetAccountInfoApi & GetMultipleAccountsApi & GetProgramAccountsApi>} rpc - The Solana RPC client.
+ * @param {Address} tokenMintOne - The first token mint address in the pool.
+ * @param {Address} tokenMintTwo - The second token mint address in the pool.
+ * @returns {Promise<PoolInfo[]>} - A promise that resolves to an array of pool information for each pool between the two tokens.
+ *
+ * @example
+ * import { fetchWhirlpools } from '@orca-so/whirlpools';
+ * import { generateKeyPairSigner, createSolanaRpc, devnet } from '@solana/web3.js';
+ * 
+ * const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
+ * const wallet = await generateKeyPairSigner();
+ * await devnetRpc.requestAirdrop(wallet.address, lamports(1000000000n)).send();
+ * 
+ * const tokenMintOne = "TOKEN_MINT_ONE";  
+ * const tokenMintTwo = "TOKEN_MINT_TWO"; 
+ * 
+ * const pools = await fetchWhirlpools(
+ *   devnetRpc,
+ *   tokenMintOne,
+ *   tokenMintTwo
+ * );
+ * 
+ * pools.forEach(pool => {
+ *   if (pool.initialized) {
+ *     console.log("Initialized Pool Info:", pool);
+ *   } else {
+ *     console.log("Uninitialized Pool Info (Defaults):", pool);
+ *   }
+ * });
+ */
 export async function fetchWhirlpools(
   rpc: Rpc<GetAccountInfoApi & GetMultipleAccountsApi & GetProgramAccountsApi>,
   tokenMintOne: Address,

--- a/ts-sdk/whirlpool/src/pool.ts
+++ b/ts-sdk/whirlpool/src/pool.ts
@@ -54,7 +54,7 @@ export type PoolInfo = (InitializablePool | InitializedPool) & {
 /**
  * Fetches the details of a specific Splash Pool.
  *
- * @param {Rpc<GetAccountInfoApi>} rpc - The Solana RPC client.
+ * @param {SolanaRpc} rpc - The Solana RPC client.
  * @param {Address} tokenMintOne - The first token mint address in the pool.
  * @param {Address} tokenMintTwo - The second token mint address in the pool.
  * @returns {Promise<PoolInfo>} - A promise that resolves to the pool information, which includes whether the pool is initialized or not.
@@ -92,7 +92,7 @@ export async function fetchSplashPool(
 /**
  * Fetches the details of a specific Concentrated Liquidity Pool.
  *
- * @param {Rpc<GetAccountInfoApi>} rpc - The Solana RPC client.
+ * @param {SolanaRpc} rpc - The Solana RPC client.
  * @param {Address} tokenMintOne - The first token mint address in the pool.
  * @param {Address} tokenMintTwo - The second token mint address in the pool.
  * @param {number} tickSpacing - The tick spacing of the pool.
@@ -169,7 +169,7 @@ export async function fetchConcentratedLiquidityPool(
  * Fetches all possible liquidity pools between two token mints in Orca Whirlpools.
  * If a pool does not exist, it creates a placeholder account for the uninitialized pool with default data
  * 
- * @param {Rpc<GetAccountInfoApi & GetMultipleAccountsApi & GetProgramAccountsApi>} rpc - The Solana RPC client.
+ * @param {SolanaRpc} rpc - The Solana RPC client.
  * @param {Address} tokenMintOne - The first token mint address in the pool.
  * @param {Address} tokenMintTwo - The second token mint address in the pool.
  * @returns {Promise<PoolInfo[]>} - A promise that resolves to an array of pool information for each pool between the two tokens.

--- a/ts-sdk/whirlpool/src/pool.ts
+++ b/ts-sdk/whirlpool/src/pool.ts
@@ -20,17 +20,9 @@ import { SPLASH_POOL_TICK_SPACING, WHIRLPOOLS_CONFIG_ADDRESS } from "./config";
 
 /**
  * Type representing a pool that is not yet initialized.
- *
- * @typedef {Object} InitializablePool
- * @property {false} initialized - Indicates the pool is not initialized.
- * @property {Address} whirlpoolsConfig - The configuration address of the Whirlpool.
- * @property {number} tickSpacing - The spacing between ticks in the pool.
- * @property {number} feeRate - The fee rate applied to swaps in the pool.
- * @property {number} protocolFeeRate - The fee rate collected by the protocol.
- * @property {Address} tokenMintA - The mint address for the first token in the pool.
- * @property {Address} tokenMintB - The mint address for the second token in the pool.
  */
-type InitializablePool = {
+export type InitializablePool = {
+  /** Indicates the pool is not initialized. */
   initialized: false;
 } & Pick<
   Whirlpool,
@@ -44,24 +36,20 @@ type InitializablePool = {
 
 /**
  * Type representing a pool that has been initialized.
- *
- * @typedef {Object} InitializedPool
- * @property {true} initialized - Indicates the pool is initialized.
- * @extends Whirlpool
+ * Extends the `Whirlpool` type, inheriting all its properties.
  */
-type InitializedPool = {
+export type InitializedPool = {
+  /** Indicates the pool is initialized. */
   initialized: true;
 } & Whirlpool;
 
 /**
  * Combined type representing both initialized and uninitialized pools.
- *
- * @typedef {Object} PoolInfo
- * @property {Address} address - The address of the pool.
- * @property {boolean} initialized - Indicates whether the pool is initialized or not.
- * @property {Whirlpool | InitializablePool} - Either the fully initialized pool details or initializable pool configuration.
  */
-type PoolInfo = (InitializablePool | InitializedPool) & { address: Address };
+export type PoolInfo = (InitializablePool | InitializedPool) & {
+  /** The address of the pool. */
+  address: Address;
+};
 
 /**
  * Fetches the details of a specific Splash Pool.
@@ -87,8 +75,6 @@ type PoolInfo = (InitializablePool | InitializedPool) & { address: Address };
  *   tokenMintOne,
  *   tokenMintTwo
  * );
- * 
- * console.log("Splash Pool State:", poolInfo);
  */
 export async function fetchSplashPool(
   rpc: Rpc<GetAccountInfoApi>,
@@ -130,12 +116,6 @@ export async function fetchSplashPool(
  *   tokenMintTwo,
  *   tickSpacing
  * );
- * 
- * if (poolInfo.initialized) {
- *   console.log("Initialized Pool State:", poolInfo);
- * } else {
- *   console.log("Uninitialized Pool Info (Defaults):", poolInfo);
- * }
  */
 export async function fetchConcentratedLiquidityPool(
   rpc: Rpc<GetAccountInfoApi>,
@@ -187,7 +167,8 @@ export async function fetchConcentratedLiquidityPool(
 
 /**
  * Fetches all possible liquidity pools between two token mints in Orca Whirlpools.
- *
+ * If a pool does not exist, it creates a placeholder account for the uninitialized pool with default data
+ * 
  * @param {Rpc<GetAccountInfoApi & GetMultipleAccountsApi & GetProgramAccountsApi>} rpc - The Solana RPC client.
  * @param {Address} tokenMintOne - The first token mint address in the pool.
  * @param {Address} tokenMintTwo - The second token mint address in the pool.
@@ -209,14 +190,6 @@ export async function fetchConcentratedLiquidityPool(
  *   tokenMintOne,
  *   tokenMintTwo
  * );
- * 
- * pools.forEach(pool => {
- *   if (pool.initialized) {
- *     console.log("Initialized Pool Info:", pool);
- *   } else {
- *     console.log("Uninitialized Pool Info (Defaults):", pool);
- *   }
- * });
  */
 export async function fetchWhirlpools(
   rpc: Rpc<GetAccountInfoApi & GetMultipleAccountsApi & GetProgramAccountsApi>,

--- a/ts-sdk/whirlpool/src/position.ts
+++ b/ts-sdk/whirlpool/src/position.ts
@@ -53,7 +53,7 @@ function decodePositionOrBundle(
  * For token accounts holding exactly 1 token (indicating a position or bundle), it fetches the corresponding position addresses,
  * decodes the accounts, and returns an array of position or bundle data.
  *
- * @param {Rpc<GetTokenAccountsByOwnerApi & GetMultipleAccountsApi>} rpc - The Solana RPC client used to fetch token accounts and multiple accounts.
+ * @param {SolanaRpc} rpc - The Solana RPC client used to fetch token accounts and multiple accounts.
  * @param {Address} owner - The wallet address whose positions you want to fetch.
  * @returns {Promise<PositionData[]>} - A promise that resolves to an array of decoded position data for the given owner.
  *

--- a/ts-sdk/whirlpool/src/position.ts
+++ b/ts-sdk/whirlpool/src/position.ts
@@ -17,8 +17,24 @@ import type {
 } from "@solana/web3.js";
 import { getBase58Encoder, getBase64Encoder } from "@solana/web3.js";
 
-type PositionOrBundle = Account<Position | PositionBundle>;
-type PositionData = PositionOrBundle & {
+/**
+ * Represents either a Position or Position Bundle account.
+ *
+ * @typedef {Object} PositionOrBundle
+ * @property {Account<Position | PositionBundle>} data - The decoded data of the position or bundle.
+ */
+export type PositionOrBundle = Account<Position | PositionBundle>;
+
+/**
+ * Represents a decoded Position or Position Bundle account.
+ * Includes the token program address associated with the position.
+ *
+ * @typedef {Object} PositionData
+ * @property {Account<Position | PositionBundle>} data - The decoded position or bundle data.
+ * @property {Address} address - The address of the position or bundle.
+ * @property {Address} tokenProgram - The token program associated with the position (either TOKEN_PROGRAM_ADDRESS or TOKEN_2022_PROGRAM_ADDRESS).
+ */
+export type PositionData = PositionOrBundle & {
   tokenProgram: Address;
 };
 
@@ -38,6 +54,23 @@ function decodePositionOrBundle(
   throw new Error("Could not decode position or bundle dat");
 }
 
+/**
+ * Fetches all positions owned by a given wallet in the Orca Whirlpools.
+ * It looks for token accounts owned by the wallet using both the TOKEN_PROGRAM_ADDRESS and TOKEN_2022_PROGRAM_ADDRESS.
+ * For token accounts holding exactly 1 token (indicating a position or bundle), it fetches the corresponding position addresses,
+ * decodes the accounts, and returns an array of position or bundle data.
+ *
+ * @param {Rpc<GetTokenAccountsByOwnerApi & GetMultipleAccountsApi>} rpc - The Solana RPC client used to fetch token accounts and multiple accounts.
+ * @param {Address} owner - The wallet address whose positions you want to fetch.
+ * @returns {Promise<PositionData[]>} - A promise that resolves to an array of decoded position data for the given owner.
+ *
+ * @example
+ * const positions = await fetchPositions(connection, walletAddress);
+ * positions.forEach((position) => {
+ *   console.log("Position Address:", position.address);
+ *   console.log("Position Data:", position.data);
+ * });
+ */
 export async function fetchPositions(
   rpc: Rpc<GetTokenAccountsByOwnerApi & GetMultipleAccountsApi>,
   owner: Address,

--- a/ts-sdk/whirlpool/src/position.ts
+++ b/ts-sdk/whirlpool/src/position.ts
@@ -19,22 +19,15 @@ import { getBase58Encoder, getBase64Encoder } from "@solana/web3.js";
 
 /**
  * Represents either a Position or Position Bundle account.
- *
- * @typedef {Object} PositionOrBundle
- * @property {Account<Position | PositionBundle>} data - The decoded data of the position or bundle.
  */
 export type PositionOrBundle = Account<Position | PositionBundle>;
 
 /**
  * Represents a decoded Position or Position Bundle account.
  * Includes the token program address associated with the position.
- *
- * @typedef {Object} PositionData
- * @property {Account<Position | PositionBundle>} data - The decoded position or bundle data.
- * @property {Address} address - The address of the position or bundle.
- * @property {Address} tokenProgram - The token program associated with the position (either TOKEN_PROGRAM_ADDRESS or TOKEN_2022_PROGRAM_ADDRESS).
  */
 export type PositionData = PositionOrBundle & {
+  /** The token program associated with the position (either TOKEN_PROGRAM_ADDRESS or TOKEN_2022_PROGRAM_ADDRESS). */
   tokenProgram: Address;
 };
 
@@ -65,11 +58,14 @@ function decodePositionOrBundle(
  * @returns {Promise<PositionData[]>} - A promise that resolves to an array of decoded position data for the given owner.
  *
  * @example
- * const positions = await fetchPositions(connection, walletAddress);
- * positions.forEach((position) => {
- *   console.log("Position Address:", position.address);
- *   console.log("Position Data:", position.data);
- * });
+ * import { fetchPositions } from '@orca-so/whirlpools';
+ * import { generateKeyPairSigner, createSolanaRpc, devnet } from '@solana/web3.js';
+ * 
+ * const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
+ * const wallet = await generateKeyPairSigner();
+ * await devnetRpc.requestAirdrop(wallet.address, lamports(1000000000n)).send();
+ * 
+ * const positions = await fetchPositions(devnetRpc, wallet.address);
  */
 export async function fetchPositions(
   rpc: Rpc<GetTokenAccountsByOwnerApi & GetMultipleAccountsApi>,

--- a/ts-sdk/whirlpool/src/swap.ts
+++ b/ts-sdk/whirlpool/src/swap.ts
@@ -183,7 +183,7 @@ function getSwapQuote<T extends SwapParams>(
  * It handles both exact input and exact output swaps, fetching the required accounts, tick arrays, and determining the swap quote.
  *
  * @template T - The type of swap (exact input or output).
- * @param {Rpc<GetAccountInfoApi & GetMultipleAccountsApi & GetMinimumBalanceForRentExemptionApi>} rpc - The Solana RPC client.
+ * @param {SolanaRpc} rpc - The Solana RPC client.
  * @param {T} params - The swap parameters, specifying either the input or output amount and the mint address of the token being swapped.
  * @param {Address} poolAddress - The address of the Whirlpool against which the swap will be made.
  * @param {number} [slippageToleranceBps=DEFAULT_SLIPPAGE_TOLERANCE_BPS] - The maximum acceptable slippage tolerance for the swap, in basis points (BPS).

--- a/ts-sdk/whirlpool/src/swap.ts
+++ b/ts-sdk/whirlpool/src/swap.ts
@@ -43,57 +43,47 @@ import { fetchAllMint } from "@solana-program/token-2022";
 
 /**
  * Parameters for an exact input swap.
- *
- * @typedef {Object} ExactInParams
- * @property {bigint} inputAmount - The exact amount of input tokens to be swapped.
  */
-type ExactInParams = {
+export type ExactInParams = {
+  /** The exact amount of input tokens to be swapped. */
   inputAmount: bigint;
 };
 
 /**
  * Parameters for an exact output swap.
- *
- * @typedef {Object} ExactOutParams
- * @property {bigint} outputAmount - The exact amount of output tokens to be received from the swap.
  */
-type ExactOutParams = {
+export type ExactOutParams = {
+  /** The exact amount of output tokens to be received from the swap. */
   outputAmount: bigint;
 };
 
 /**
  * Swap parameters, either for an exact input or exact output swap.
- *
- * @typedef {Object} SwapParams
- * @property {bigint} inputAmount - The exact input amount for the swap.
- * @property {bigint} outputAmount - The exact output amount for the swap.
- * @property {Address} mint - The mint address of the token being swapped.
  */
-type SwapParams = (ExactInParams | ExactOutParams) & {
+export type SwapParams = (ExactInParams | ExactOutParams) & {
+  /** The mint address of the token being swapped. */
   mint: Address;
 };
 
 /**
  * Swap quote that corresponds to the type of swap being executed (either input or output swap).
  *
- * @typedef {Object} SwapQuote
  * @template T - The type of swap (input or output).
- * @property {ExactInSwapQuote | ExactOutSwapQuote} - The quote for the swap based on input or output.
  */
-type SwapQuote<T extends SwapParams> = T extends ExactInParams
+export type SwapQuote<T extends SwapParams> = T extends ExactInParams
   ? ExactInSwapQuote
   : ExactOutSwapQuote;
 
 /**
  * Instructions and quote for executing a swap.
  *
- * @typedef {Object} SwapInstructions
  * @template T - The type of swap (input or output).
- * @property {IInstruction[]} instructions - The list of instructions needed to perform the swap.
- * @property {SwapQuote<T>} quote - The swap quote, which includes information about the amounts involved in the swap.
  */
-type SwapInstructions<T extends SwapParams> = {
+export type SwapInstructions<T extends SwapParams> = {
+  /** The list of instructions needed to perform the swap. */
   instructions: IInstruction[];
+
+  /** The swap quote, which includes information about the amounts involved in the swap. */
   quote: SwapQuote<T>;
 };
 
@@ -195,21 +185,30 @@ function getSwapQuote<T extends SwapParams>(
  * @template T - The type of swap (exact input or output).
  * @param {Rpc<GetAccountInfoApi & GetMultipleAccountsApi & GetMinimumBalanceForRentExemptionApi>} rpc - The Solana RPC client.
  * @param {T} params - The swap parameters, specifying either the input or output amount and the mint address of the token being swapped.
- * @param {Address} poolAddress - The address of the Whirlpool pool where the swap will take place.
+ * @param {Address} poolAddress - The address of the Whirlpool against which the swap will be made.
  * @param {number} [slippageToleranceBps=DEFAULT_SLIPPAGE_TOLERANCE_BPS] - The maximum acceptable slippage tolerance for the swap, in basis points (BPS).
  * @param {TransactionPartialSigner} [signer=DEFAULT_FUNDER] - The wallet or signer executing the swap.
  * @returns {Promise<SwapInstructions<T>>} - A promise that resolves to an object containing the swap instructions and the swap quote.
  *
  * @example
- * const { quote, instructions } = await swapInstructions(
- *   connection,
- *   { inputAmount: 1_000_000n, mint: mintAddress },
- *   poolAddress,
- *   0.01,
+ * import { swapInstructions } from '@orca-so/whirlpools';
+ * import { generateKeyPairSigner, createSolanaRpc, devnet } from '@solana/web3.js';
+ * 
+ * const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
+ * const wallet = await generateKeyPairSigner();
+ * await devnetRpc.requestAirdrop(wallet.address, lamports(1000000000n)).send();
+ * 
+ * const poolAddress = "POOL_ADDRESS";
+ * const mintAddress = "TOKEN_MINT";
+ * const inputAmount = 1_000_000n;
+ * 
+ * const { instructions, quote } = await swapInstructions(
+ *   devnetRpc, 
+ *   { inputAmount, mint: mintAddress }, 
+ *   poolAddress, 
+ *   100,
  *   wallet
  * );
- * console.log("Swap Quote:", quote);
- * console.log("Swap Instructions:", instructions);
  */
 export async function swapInstructions<T extends SwapParams>(
   rpc: Rpc<

--- a/ts-sdk/whirlpool/src/token.ts
+++ b/ts-sdk/whirlpool/src/token.ts
@@ -39,9 +39,17 @@ export const NATIVE_MINT = address(
   "So11111111111111111111111111111111111111112",
 );
 
+/**
+ * Represents the instructions and associated addresses for preparing token accounts during a transaction.
+ */
 type TokenAccountInstructions = {
+  /** A list of instructions required to create the necessary token accounts. */
   createInstructions: IInstruction[];
+
+  /** A list of instructions to clean up (e.g., close) token accounts after the transaction is complete. */
   cleanupInstructions: IInstruction[];
+
+  /** A mapping of mint addresses to their respective token account addresses. */
   tokenAccountAddresses: Record<Address, Address>;
 };
 
@@ -231,6 +239,18 @@ export async function prepareTokenAccountsInstructions(
   };
 }
 
+/**
+ * Retrieves the current transfer fee configuration for a given token mint based on the current epoch.
+ * 
+ * This function checks the mint's transfer fee configuration and returns the appropriate fee 
+ * structure (older or newer) depending on the current epoch. If no transfer fee configuration is found,
+ * it returns `undefined`.
+ *
+ * @param {Mint} mint - The mint account of the token, which may include transfer fee extensions.
+ * @param {bigint} currentEpoch - The current epoch to determine the applicable transfer fee.
+ * 
+ * @returns {TransferFee | undefined} - The transfer fee configuration for the given mint, or `undefined` if no transfer fee is configured.
+ */
 export function getCurrentTransferFee(
   mint: Mint,
   currentEpoch: bigint,


### PR DESCRIPTION
Typedocs for TS SDK

- Use `export` keyword to create clickable types in typedocs
- Add documentation to types and exported functions
- Add examples usage to documentation

![Screenshot 2024-10-17 005137](https://github.com/user-attachments/assets/7ae39f2a-0961-4487-abaa-dd4c7dbee962)

![Screenshot 2024-10-17 005155](https://github.com/user-attachments/assets/cafcfc46-0eb4-453e-bc43-822f48b93bf9)
