### PR TITLE
Properly set version numbers in publish script

### DIFF
--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -42,14 +42,22 @@ runs:
     - name: Update npm Packages
       if: ${{ steps.env.outputs.ENV == 'npm' }}
       run: |
-        sed -i 's/"version": ".*"/"version": "${{ steps.version.outputs.VERSION }}"/' ${{ inputs.manifest-file }}
-        # TODO: Following should only happen in dependencies and not devDependencies
-        # sed -i 's/"\*"/"${{ steps.version.outputs.VERSION }}"/' ${{ inputs.manifest-file }}
+        jq --arg version "${{ steps.version.outputs.VERSION }}" '
+          .version = $version
+        ' ${{ inputs.manifest-file }} > tmp.json && mv tmp.json ${{ inputs.manifest-file }}
+        jq --arg version "${{ steps.version.outputs.VERSION }}" '
+          .dependencies |= with_entries(if .value == "*" then .value = $version else . end)
+        ' ${{ inputs.manifest-file }} > tmp.json && mv tmp.json ${{ inputs.manifest-file }}
       shell: bash
     - name: Update Cargo Packages
       if: ${{ steps.env.outputs.ENV == 'cargo' }}
       run: |
-        sed -i 's/^version = ".*"$/version = "${{ steps.version.outputs.VERSION }}"/' ${{ inputs.manifest-file }}
-        # TODO: Following should only happen in dependencies and not dev-dependencies
-        # sed -i 's/path = ".*"/version = "${{ steps.version.outputs.VERSION }}"/' ${{ inputs.manifest-file }}
+        awk -v version="${{ steps.version.outputs.VERSION }}" '
+          /^version = / { sub(/".*"/, "\"" version "\"") } { print }
+        ' ${{ inputs.manifest-file }} > tmp.toml && mv tmp.toml ${{ inputs.manifest-file }}
+        awk -v version="${{ steps.version.outputs.VERSION }}" '
+          /^\[dependencies\]/ { in_dependencies=1 }
+          /^\[/ && !/^\[dependencies\]/ { in_dependencies=0 }
+          in_dependencies && /path = ".*"/ { sub(/path = ".*"/, "version = \"" version "\"") } { print }
+        ' ${{ inputs.manifest-file }} > tmp.toml && mv tmp.toml ${{ inputs.manifest-file }}
       shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
   cargo:
     strategy:
       matrix:
-        package: [client]
+        package: [client, core]
       max-parallel: 1
       fail-fast: true
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
   npm:
     strategy:
       matrix:
-        package: [client]
+        package: [client, core, whirlpool]
       max-parallel: 1
       fail-fast: true
     runs-on: ubuntu-latest


### PR DESCRIPTION
Only the version field of the package itself was being set in the previous version of the script. This was fine for the `client` packages since they do not depend on any local dependencies. Now that we would like to publish `core` and `whirlpool` for TS we need a small change.

New version of this script changes both the version of the package itself, and the version of local dependencies that the package has.