### PR TITLE
Fix a bug in publishing ts-sdk/core

### DIFF
--- a/ts-sdk/core/package.json
+++ b/ts-sdk/core/package.json
@@ -21,7 +21,8 @@
   "scripts": {
     "build": "wasm-pack build --out-dir ./dist/web --target web && wasm-pack build --out-dir ./dist/nodejs --target nodejs",
     "test": "tsc --noEmit && vitest run tests",
-    "clean": "cargo clean && rimraf dist"
+    "clean": "cargo clean && rimraf dist",
+    "prepublishOnly": "rimraf dist/web/.gitignore dist/nodejs/.gitignore"
   },
   "devDependencies": {
     "@orca-so/whirlpools-client": "*",


### PR DESCRIPTION
Because of the `.gitignore` files that wasm-pack creates, npm ignores all the files in that subfolder, meaning the actual wasm bundle doesn't get included in the npm package.

with this change:
```
npm notice total files: 10
```

without this change:
```
npm notice total files: 2
```