### PR TITLE
Add Whirlpools SDK dropdown to navbar

### DIFF
--- a/docs/whirlpool/docusaurus.config.js
+++ b/docs/whirlpool/docusaurus.config.js
@@ -49,16 +49,20 @@ export default {
       items: [
         { to: "/", label: "Docs", position: "left" },
         {
-          href: "/orca_whirlpools_docs/",
-          label: "Rust SDK Reference",
+          label: "Whirlpools SDK Reference",
           position: "left",
-          target: "_blank",
-        },
-        {
-          href: "/ts/",
-          label: "TS SDK Reference",
-          position: "left",
-          target: "_blank",
+          items: [
+            {
+              href: "/ts/",
+              label: "TS SDK Reference",
+              target: "_blank",
+            },
+            {
+              href: "/orca_whirlpools_docs/",
+              label: "Rust SDK Reference",
+              target: "_blank",
+            },
+          ],
         },
         {
           href: "/legacy/",


### PR DESCRIPTION
### Title
Add Whirlpools SDK dropdown to navbar

### Description
- Added a "Whirlpools SDK Reference" dropdown to the navbar.
- The dropdown includes links to "TS SDK Reference" and "Rust SDK Reference".
- This change groups the SDK references under a single menu item for better organization and easier navigation.
![Screenshot 2024-10-30 164545](https://github.com/user-attachments/assets/4dfcf2cb-9c95-45be-aa42-5e720dec4d3b)
