### PR TITLE
Build rustdoc without 'wasm' feature

### DIFF
--- a/docs/rust/Cargo.toml
+++ b/docs/rust/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
-orca_whirlpools_core = { path = "../../rust-sdk/core", features = ["wasm", "floats"] }
+orca_whirlpools_core = { path = "../../rust-sdk/core", features = ["floats"] }
 orca_whirlpools_client = { path = "../../rust-sdk/client", features = ["anchor", "core-types"] }
 orca_whirlpools = { path = "../../rust-sdk/whirlpool" }
 


### PR DESCRIPTION
Currently the rustdoc builds with the `wasm` feature enabled. This adds certain fields that are only used in `wasm` to the docs. These features are not available otherwise so shouldn't show up in the docs.

Example is the wasm_expose const functions that the macro adds