### PR TITLE
Rename `fetchWhirlpools` to `fetchWhirlpoolsByTokenPair`

### DIFF
--- a/docs/whirlpool/docs/03-Whirlpools SDK/02-Whirlpool Management/02-Fetch Pools.md
+++ b/docs/whirlpool/docs/03-Whirlpools SDK/02-Whirlpool Management/02-Fetch Pools.md
@@ -58,7 +58,7 @@ const poolInfo = await fetchConcentratedLiquidityPool(
 2. **Fetch Pool Details**: Use the appropriate function to fetch the details of the specified pools.
 
 ```tsx
-const pools = await fetchWhirlPools(
+const pools = await fetchWhirlPoolsByTokenPair(
   rpc,
   tokenMintOne,
   tokenMintTwo

--- a/docs/whirlpool/docs/03-Whirlpools SDK/02-Whirlpool Management/02-Fetch Pools.md
+++ b/docs/whirlpool/docs/03-Whirlpools SDK/02-Whirlpool Management/02-Fetch Pools.md
@@ -58,7 +58,7 @@ const poolInfo = await fetchConcentratedLiquidityPool(
 2. **Fetch Pool Details**: Use the appropriate function to fetch the details of the specified pools.
 
 ```tsx
-const pools = await fetchWhirlPoolsByTokenPair(
+const pools = await fetchWhirlpoolsByTokenPair(
   rpc,
   tokenMintOne,
   tokenMintTwo

--- a/ts-sdk/whirlpool/src/pool.ts
+++ b/ts-sdk/whirlpool/src/pool.ts
@@ -175,7 +175,7 @@ export async function fetchConcentratedLiquidityPool(
  * @returns {Promise<PoolInfo[]>} - A promise that resolves to an array of pool information for each pool between the two tokens.
  *
  * @example
- * import { fetchWhirlpools } from '@orca-so/whirlpools';
+ * import { fetchWhirlPoolsByTokenPair } from '@orca-so/whirlpools';
  * import { generateKeyPairSigner, createSolanaRpc, devnet } from '@solana/web3.js';
  *
  * const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
@@ -185,13 +185,13 @@ export async function fetchConcentratedLiquidityPool(
  * const tokenMintOne = "TOKEN_MINT_ONE";
  * const tokenMintTwo = "TOKEN_MINT_TWO";
  *
- * const pools = await fetchWhirlpools(
+ * const pools = await fetchWhirlPoolsByTokenPair(
  *   devnetRpc,
  *   tokenMintOne,
  *   tokenMintTwo
  * );
  */
-export async function fetchWhirlpools(
+export async function fetchWhirlPoolsByTokenPair(
   rpc: Rpc<GetAccountInfoApi & GetMultipleAccountsApi & GetProgramAccountsApi>,
   tokenMintOne: Address,
   tokenMintTwo: Address,

--- a/ts-sdk/whirlpool/src/pool.ts
+++ b/ts-sdk/whirlpool/src/pool.ts
@@ -175,7 +175,7 @@ export async function fetchConcentratedLiquidityPool(
  * @returns {Promise<PoolInfo[]>} - A promise that resolves to an array of pool information for each pool between the two tokens.
  *
  * @example
- * import { fetchWhirlPoolsByTokenPair } from '@orca-so/whirlpools';
+ * import { fetchWhirlpoolsByTokenPair } from '@orca-so/whirlpools';
  * import { generateKeyPairSigner, createSolanaRpc, devnet } from '@solana/web3.js';
  *
  * const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
@@ -185,13 +185,13 @@ export async function fetchConcentratedLiquidityPool(
  * const tokenMintOne = "TOKEN_MINT_ONE";
  * const tokenMintTwo = "TOKEN_MINT_TWO";
  *
- * const pools = await fetchWhirlPoolsByTokenPair(
+ * const pools = await fetchWhirlpoolsByTokenPair(
  *   devnetRpc,
  *   tokenMintOne,
  *   tokenMintTwo
  * );
  */
-export async function fetchWhirlPoolsByTokenPair(
+export async function fetchWhirlpoolsByTokenPair(
   rpc: Rpc<GetAccountInfoApi & GetMultipleAccountsApi & GetProgramAccountsApi>,
   tokenMintOne: Address,
   tokenMintTwo: Address,


### PR DESCRIPTION
During the ts-sdk PR I remember there were a couple of comments about this but turns out I never actually ended up changing it. Theoretically this is now a breaking change since the ts-sdk has been deployed but I think this is semi-fine given that it has only been deployed for a week.

The issue with the `fetchWhirlpools` name is that it conflicts with `fetchWhirlpool` and `fetchAllWhirlpools` from whirlpools-client.