### PR TITLE
Improve calculating index in tick array

### DIFF
--- a/rust-sdk/core/src/constants/error.rs
+++ b/rust-sdk/core/src/constants/error.rs
@@ -43,3 +43,6 @@ pub const INVALID_TRANSFER_FEE: ErrorCode = 9011;
 
 #[cfg_attr(feature = "wasm", wasm_expose)]
 pub const INVALID_SLIPPAGE_TOLERANCE: ErrorCode = 9012;
+
+#[cfg_attr(feature = "wasm", wasm_expose)]
+pub const TICK_INDEX_NOT_IN_ARRAY: ErrorCode = 9013;

--- a/rust-sdk/core/src/math/tick.rs
+++ b/rust-sdk/core/src/math/tick.rs
@@ -4,7 +4,7 @@ use ethnum::U256;
 use orca_whirlpools_macros::wasm_expose;
 
 use crate::{
-    CoreError, TickRange, FULL_RANGE_ONLY_TICK_SPACING_THRESHOLD, MAX_TICK_INDEX, MIN_TICK_INDEX, TICK_ARRAY_SIZE, TICK_INDEX_NOT_IN_ARRAY, U128
+    ErrorCode, TickRange, FULL_RANGE_ONLY_TICK_SPACING_THRESHOLD, MAX_TICK_INDEX, MIN_TICK_INDEX, TICK_ARRAY_SIZE, TICK_INDEX_NOT_IN_ARRAY, U128
 };
 
 const LOG_B_2_X32: i128 = 59543866431248i128;
@@ -306,7 +306,7 @@ pub fn get_tick_index_in_array(
     tick_index: i32,
     tick_array_start_index: i32,
     tick_spacing: u16,
-) -> Result<u32, CoreError> {
+) -> Result<u32, ErrorCode> {
     let tick_spacing_i32 = tick_spacing as i32;
     if tick_index < tick_array_start_index {
         return Err(TICK_INDEX_NOT_IN_ARRAY);
@@ -606,8 +606,9 @@ mod tests {
         assert_eq!(get_tick_index_in_array(100, 0, 10), Ok(10));
         assert_eq!(get_tick_index_in_array(50, 0, 10), Ok(5));
         assert_eq!(get_tick_index_in_array(0, 0, 10), Ok(0));
-        assert_eq!(get_tick_index_in_array(-830, 0, 10), Err(TICK_INDEX_NOT_IN_ARRAY));
+        assert_eq!(get_tick_index_in_array(-1, 0, 10), Err(TICK_INDEX_NOT_IN_ARRAY));
         assert_eq!(get_tick_index_in_array(-830, -880, 10), Ok(5));
         assert_eq!(get_tick_index_in_array(-780, -880, 10), Ok(10));
+        assert_eq!(get_tick_index_in_array(-881, -880, 10), Err(TICK_INDEX_NOT_IN_ARRAY));
     }
 }

--- a/rust-sdk/core/src/math/tick.rs
+++ b/rust-sdk/core/src/math/tick.rs
@@ -300,13 +300,13 @@ pub fn is_full_range_only(tick_spacing: u16) -> bool {
 /// - `tick_spacing` - A u16 integer representing the tick spacing
 ///
 /// # Returns
-/// - A u32 integer representing the tick index in the tick array
+/// - A u16 integer representing the tick index in the tick array
 #[cfg_attr(feature = "wasm", wasm_expose)]
 pub fn get_tick_index_in_array(
     tick_index: i32,
     tick_array_start_index: i32,
     tick_spacing: u16,
-) -> Result<u32, ErrorCode> {
+) -> Result<u16, ErrorCode> {
     let tick_spacing_i32 = tick_spacing as i32;
     if tick_index < tick_array_start_index {
         return Err(TICK_INDEX_NOT_IN_ARRAY);
@@ -314,10 +314,9 @@ pub fn get_tick_index_in_array(
     if tick_index >= tick_array_start_index + (TICK_ARRAY_SIZE as i32) * tick_spacing_i32 {
         return Err(TICK_INDEX_NOT_IN_ARRAY);
     }
-    let result = (tick_index - tick_array_start_index)
-        .div_euclid(tick_spacing_i32)
-        .unsigned_abs();
-    Ok(result)
+    let offset = (tick_index - tick_array_start_index)
+        .unsigned_abs() as u16;
+    Ok(offset / tick_spacing)
 }
 
 // Private functions

--- a/rust-sdk/core/src/math/tick.rs
+++ b/rust-sdk/core/src/math/tick.rs
@@ -600,15 +600,24 @@ mod tests {
 
     #[test]
     fn test_get_tick_index_in_array() {
-        assert_eq!(get_tick_index_in_array(2861952, 0, 32896), Ok(87));
-        assert_eq!(get_tick_index_in_array(880, 0, 10), Err(TICK_INDEX_NOT_IN_ARRAY));
+        // Zero tick index
+        assert_eq!(get_tick_index_in_array(0, 0, 10), Ok(0));
+
+        // Positive tick index
         assert_eq!(get_tick_index_in_array(100, 0, 10), Ok(10));
         assert_eq!(get_tick_index_in_array(50, 0, 10), Ok(5));
-        assert_eq!(get_tick_index_in_array(0, 0, 10), Ok(0));
-        assert_eq!(get_tick_index_in_array(-1, 0, 10), Err(TICK_INDEX_NOT_IN_ARRAY));
+
+        // Negative tick index
         assert_eq!(get_tick_index_in_array(-830, -880, 10), Ok(5));
         assert_eq!(get_tick_index_in_array(-780, -880, 10), Ok(10));
+
+        // Outside of the tick array
+        assert_eq!(get_tick_index_in_array(880, 0, 10), Err(TICK_INDEX_NOT_IN_ARRAY));
+        assert_eq!(get_tick_index_in_array(-1, 0, 10), Err(TICK_INDEX_NOT_IN_ARRAY));
         assert_eq!(get_tick_index_in_array(-881, -880, 10), Err(TICK_INDEX_NOT_IN_ARRAY));
+
+        // Splash pool tick spacing
+        assert_eq!(get_tick_index_in_array(2861952, 0, 32896), Ok(87));
         assert_eq!(get_tick_index_in_array(-32896, -2894848, 32896), Ok(87));
     }
 }

--- a/rust-sdk/core/src/math/tick.rs
+++ b/rust-sdk/core/src/math/tick.rs
@@ -300,23 +300,22 @@ pub fn is_full_range_only(tick_spacing: u16) -> bool {
 /// - `tick_spacing` - A u16 integer representing the tick spacing
 ///
 /// # Returns
-/// - A u16 integer representing the tick index in the tick array
+/// - A u32 integer representing the tick index in the tick array
 #[cfg_attr(feature = "wasm", wasm_expose)]
 pub fn get_tick_index_in_array(
     tick_index: i32,
     tick_array_start_index: i32,
     tick_spacing: u16,
-) -> Result<u16, ErrorCode> {
-    let tick_spacing_i32 = tick_spacing as i32;
+) -> Result<u32, ErrorCode> {
     if tick_index < tick_array_start_index {
         return Err(TICK_INDEX_NOT_IN_ARRAY);
     }
-    if tick_index >= tick_array_start_index + (TICK_ARRAY_SIZE as i32) * tick_spacing_i32 {
+    if tick_index >= tick_array_start_index + (TICK_ARRAY_SIZE as i32) * (tick_spacing as i32) {
         return Err(TICK_INDEX_NOT_IN_ARRAY);
     }
-    let offset = (tick_index - tick_array_start_index)
-        .unsigned_abs() as u16;
-    Ok(offset / tick_spacing)
+    let result = (tick_index - tick_array_start_index)
+        .unsigned_abs() / (tick_spacing as u32);
+    Ok(result)
 }
 
 // Private functions
@@ -601,6 +600,7 @@ mod tests {
 
     #[test]
     fn test_get_tick_index_in_array() {
+        assert_eq!(get_tick_index_in_array(2861952, 0, 32896), Ok(87));
         assert_eq!(get_tick_index_in_array(880, 0, 10), Err(TICK_INDEX_NOT_IN_ARRAY));
         assert_eq!(get_tick_index_in_array(100, 0, 10), Ok(10));
         assert_eq!(get_tick_index_in_array(50, 0, 10), Ok(5));
@@ -609,5 +609,6 @@ mod tests {
         assert_eq!(get_tick_index_in_array(-830, -880, 10), Ok(5));
         assert_eq!(get_tick_index_in_array(-780, -880, 10), Ok(10));
         assert_eq!(get_tick_index_in_array(-881, -880, 10), Err(TICK_INDEX_NOT_IN_ARRAY));
+        assert_eq!(get_tick_index_in_array(-32896, -2894848, 32896), Ok(87));
     }
 }


### PR DESCRIPTION
Couple issues
1) No tests for this function
2) Think it handled negative tick indexes correctly (negative number minus a larger negative number = positive) but made it more explicit
3) Undefined behaviour if a tick index outside of a tick array was specified