### PR TITLE
Small improvement to fetchPositionsForOwner

### DIFF
--- a/ts-sdk/whirlpool/src/position.ts
+++ b/ts-sdk/whirlpool/src/position.ts
@@ -117,7 +117,7 @@ export async function fetchPositionsForOwner(
   const potentialTokens = [...tokenAccounts.value, ...token2022Accounts.value]
     .map((x) => ({
       ...decoder.decode(encoder.encode(x.account.data[0])),
-      owner: x.account.owner,
+      tokenProgram: x.account.owner,
     }))
     .filter((x) => x.amount === 1n);
 
@@ -162,7 +162,7 @@ export async function fetchPositionsForOwner(
     if (position.exists) {
       positionsOrBundles.push({
         ...position,
-        tokenProgram: token.owner,
+        tokenProgram: token.tokenProgram,
         isPositionBundle: false,
       });
     }
@@ -173,7 +173,7 @@ export async function fetchPositionsForOwner(
       positionsOrBundles.push({
         ...positionBundle,
         positions,
-        tokenProgram: token.owner,
+        tokenProgram: token.tokenProgram,
         isPositionBundle: true,
       });
     }


### PR DESCRIPTION
Internally we used the property `owner` to store the `tokenProgram` in a `Token` object. This might create confusion since `Token` already has `owner` which is the owner of the token account. 

Externally this doesn't change anything since the `Token` object is not returned by the function.