### PR TITLE
Fix potential overflow issue

### DIFF
--- a/rust-sdk/core/src/math/tick_array.rs
+++ b/rust-sdk/core/src/math/tick_array.rs
@@ -30,8 +30,8 @@ impl<const SIZE: usize> TickArraySequence<SIZE> {
         for i in 0..tick_arrays.len() - 1 {
             let current_start_tick_index = start_tick_index(&tick_arrays[i]);
             let next_start_tick_index = start_tick_index(&tick_arrays[i + 1]);
-            if next_start_tick_index - current_start_tick_index != required_tick_array_spacing
-                && next_start_tick_index != <i32>::MAX
+            if next_start_tick_index != <i32>::MAX
+                && next_start_tick_index - current_start_tick_index != required_tick_array_spacing
             {
                 return Err(TICK_ARRAY_NOT_EVENLY_SPACED);
             }


### PR DESCRIPTION
Hi Orca team,

I found a potential overflow when I was trying to calculate quote for SOL -> USDC using `orca_whirlpools_core` in debug mode.

More specifically, `next_start_tick_index` might be `i32::MAX` and `current_start_tick_index` might be negative value like `-13728`, Rust would panic with error: `attempt to subtract with overflow`

This fix uses  short-circuit evaluation to work around this check, maybe a more explicit fix is to convert `next_start_tick_index` to `i64`?