### PR TITLE
Fix a bug in version setting action

### DIFF
--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -58,6 +58,6 @@ runs:
         awk -v version="${{ steps.version.outputs.VERSION }}" '
           /^\[dependencies\]/ { in_dependencies=1 }
           /^\[/ && !/^\[dependencies\]/ { in_dependencies=0 }
-          in_dependencies && /path = ".*"/ { sub(/path = ".*"/, "version = \"" version "\"") } { print }
+          in_dependencies && /path = "[^"]*"/ { sub(/path = "[^"]*"/, "version = \"" version "\"") } { print }
         ' ${{ inputs.manifest-file }} > tmp.toml && mv tmp.toml ${{ inputs.manifest-file }}
       shell: bash


### PR DESCRIPTION
Right now the following gets replaced incorrectly:
```
orca_whirlpools_core = { path = "../core", features = ["floats"] }
```

Before this change it would turn into
```
orca_whirlpools_core = { version = "x.x.x"] }
```

After this change it turns into
```
orca_whirlpools_core = { version = "x.x.x", features = ["floats"] }
```