### PR TITLE
Update `send_transaction()` in example Rust project

### DIFF
--- a/examples/rust-sdk/whirlpool_repositioning_bot/src/utils.rs
+++ b/examples/rust-sdk/whirlpool_repositioning_bot/src/utils.rs
@@ -183,10 +183,11 @@ pub async fn send_transaction(
         sleep(Duration::from_millis(100)).await;
     };
     send_transaction_result.and_then(|(status, signature)| {
-        status
-            .status
-            .map(|_| signature)
-            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
+        if status.err.is_none() {
+            Ok(signature)
+        } else {
+            Err(Box::new(status.err.unwrap()))
+        }
     })
 }
 

--- a/examples/rust-sdk/whirlpool_repositioning_bot/src/utils.rs
+++ b/examples/rust-sdk/whirlpool_repositioning_bot/src/utils.rs
@@ -183,10 +183,10 @@ pub async fn send_transaction(
         sleep(Duration::from_millis(100)).await;
     };
     send_transaction_result.and_then(|(status, signature)| {
-        if status.err.is_none() {
-            Ok(signature)
+        if let Some(err) = status.err {
+            Err(Box::new(err))
         } else {
-            Err(Box::new(status.err.unwrap()))
+            Ok(signature)
         }
     })
 }


### PR DESCRIPTION
**TITLE**
Replace deprecated `status` check with `err` validation

**DESCRIPTION**
This PR updates the signature status check logic in the example Rust project to align with the latest [Solana RPC documentation](https://solana.com/docs/rpc/http/getsignaturestatuses).

The status field in the response of `getSignatureStatuses` has been deprecated. The logic has been updated to validate the `err` field instead, which determines whether a transaction was successful or failed.