### PR TITLE
Fix a bug in legacy-sdk with closing position

### DIFF
--- a/legacy-sdk/whirlpool/package.json
+++ b/legacy-sdk/whirlpool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orca-so/whirlpools-sdk",
-  "version": "0.13.12",
+  "version": "0.13.13",
   "description": "Typescript SDK to interact with Orca's Whirlpool program.",
   "license": "Apache-2.0",
   "main": "dist/index.js",

--- a/legacy-sdk/whirlpool/src/impl/whirlpool-impl.ts
+++ b/legacy-sdk/whirlpool/src/impl/whirlpool-impl.ts
@@ -599,7 +599,8 @@ export class WhirlpoolImpl implements Whirlpool {
     const shouldDecreaseLiquidity = positionData.liquidity.gtn(0);
 
     const rewardsToCollect = this.data.rewardInfos
-      .filter((info, index) => {
+      .map((info, index) => ({ info, index }))
+      .filter(({ info, index }) => {
         if (!PoolUtil.isRewardInitialized(info)) {
           return false;
         }
@@ -609,8 +610,7 @@ export class WhirlpoolImpl implements Whirlpool {
             0,
           )
         );
-      })
-      .map((info, index) => ({ info, index }));
+      });
 
     const shouldCollectRewards = rewardsToCollect.length > 0;
 
@@ -772,7 +772,7 @@ export class WhirlpoolImpl implements Whirlpool {
             positionTokenAccount,
             rewardIndex,
             rewardOwnerAccount,
-            rewardVault: whirlpool.rewardInfos[rewardIndex].vault,
+            rewardVault: info.vault,
           };
 
           const ix = !TokenExtensionUtil.isV2IxRequiredReward(


### PR DESCRIPTION
#588 didn't actually fix the issue fully yet. My guess is that the issue stopped happening because rewards expired.

There was one small thing still wrong with the rewardIndex as it takes the index of the reward after filtering but is should take the index before filtering.