### PR TITLE
docs: rename function get_positions_for_owner to fetch_positions_for_owner

### DIFF
--- a/docs/whirlpool/docs/03-Whirlpools SDKs/01-Whirlpools/04-Position Management/02-Fetch Positions.mdx
+++ b/docs/whirlpool/docs/03-Whirlpools SDKs/01-Whirlpools/04-Position Management/02-Fetch Positions.mdx
@@ -41,7 +41,7 @@ Fetching positions is a straightforward process:
   <TabItem value="rust" label="Rust">
     ```rust
     use orca_whirlpools::{
-        get_positions_for_owner, set_whirlpools_config_address, WhirlpoolsConfigInput
+        fetch_positions_for_owner, set_whirlpools_config_address, WhirlpoolsConfigInput
     };
     use solana_client::nonblocking::rpc_client::RpcClient;
     use solana_sdk::pubkey::Pubkey;
@@ -54,7 +54,7 @@ Fetching positions is a straightforward process:
         let whirlpool_address =
             Pubkey::from_str("3KBZiL2g8C7tiJ32hTv5v3KM7aK9htpqTw4cTXz1HvPt").unwrap();
 
-        let positions = get_positions_for_owner(&rpc, whirlpool_address)
+        let positions = fetch_positions_for_owner(&rpc, whirlpool_address)
             .await
             .unwrap();
 


### PR DESCRIPTION
The get_positions_for_owner is not available in orca_whirlpools and fetch_positions_for_owner is working.

<!--
**Title**
A brief description of the pull request.

**Details**
A clear and concise description of what this pull request solves.
-->
