### PR TITLE
Add support for solana v2 crates to rust client

### DIFF
--- a/.changeset/stupid-rats-laugh.md
+++ b/.changeset/stupid-rats-laugh.md
@@ -1,0 +1,6 @@
+---
+"@orca-so/whirlpools-rust-client": major
+"@orca-so/whirlpools-rust": major
+---
+
+Add support for solana v2 crates, to use solana v1 with orca_whirlpools_client please use the `solana-v1` feature

--- a/.changeset/stupid-rats-laugh2.md
+++ b/.changeset/stupid-rats-laugh2.md
@@ -1,0 +1,6 @@
+---
+"@orca-so/whirlpools-example-rust-repositioning-bot": minor
+"@orca-so/whirlpools-rust-integration": minor
+---
+
+Add support for solana v2 crates

--- a/docs/rust/Cargo.toml
+++ b/docs/rust/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 
 [dependencies]
 orca_whirlpools_core = { path = "../../rust-sdk/core", features = ["floats"] }
-orca_whirlpools_client = { path = "../../rust-sdk/client", features = ["anchor", "core-types"] }
+orca_whirlpools_client = { path = "../../rust-sdk/client" }
 orca_whirlpools = { path = "../../rust-sdk/whirlpool" }
 

--- a/examples/rust-sdk/whirlpool_repositioning_bot/Cargo.toml
+++ b/examples/rust-sdk/whirlpool_repositioning_bot/Cargo.toml
@@ -10,10 +10,10 @@ orca_whirlpools = { path = '../../../rust-sdk/whirlpool' }
 orca_whirlpools_client = { path = '../../../rust-sdk/client' }
 orca_whirlpools_core = { path = '../../../rust-sdk/core' }
 serde_json = { version = "^1.0" }
-solana-client = { version = "^1.18" }
-solana-sdk = { version = "^1.18" }
-spl-token-2022 = { version = "^3.0" }
-spl-associated-token-account = { version = "^3.0" }
+solana-client = { version = "^2.1" }
+solana-sdk = { version = "^2.1" }
+spl-token-2022 = { version = "^7.0" }
+spl-associated-token-account = { version = "^6.0" }
 tokio = { version = "^1.41.1" }
 tokio-retry = { version = "^0.3.0" }
 dotenv = { version = "^0.15.0"}

--- a/examples/rust-sdk/whirlpool_repositioning_bot/Cargo.toml
+++ b/examples/rust-sdk/whirlpool_repositioning_bot/Cargo.toml
@@ -12,7 +12,7 @@ orca_whirlpools_core = { path = '../../../rust-sdk/core' }
 serde_json = { version = "^1.0" }
 solana-client = { version = "^2.1" }
 solana-sdk = { version = "^2.1" }
-spl-token-2022 = { version = "^7.0" }
+spl-token-2022 = { version = "^7.0", features = ["no-entrypoint"] }
 spl-associated-token-account = { version = "^6.0" }
 tokio = { version = "^1.41.1" }
 tokio-retry = { version = "^0.3.0" }

--- a/programs/whirlpool/src/util/test_utils/swap_test_fixture.rs
+++ b/programs/whirlpool/src/util/test_utils/swap_test_fixture.rs
@@ -52,7 +52,7 @@ pub struct SwapTestFixtureInfo<'info> {
     pub protocol_fee_rate: u16,
 }
 
-impl<'info> Default for SwapTestFixtureInfo<'info> {
+impl Default for SwapTestFixtureInfo<'_> {
     fn default() -> Self {
         SwapTestFixtureInfo {
             tick_spacing: TS_128,

--- a/rust-sdk/client/Cargo.toml
+++ b/rust-sdk/client/Cargo.toml
@@ -12,12 +12,13 @@ authors = ["team@orca.so"]
 edition = "2021"
 
 [features]
-default = ["core-types", "fetch"]
+default = ["core-types"]
 anchor = ["dep:anchor-lang"]
 anchor-idl-build = []
 core-types = ["dep:orca_whirlpools_core"]
-serde = ["dep:serde", "dep:serde_with"]
+serde = ["dep:serde", "dep:serde_with", "dep:serde-big-array"]
 fetch = ["dep:solana-client", "dep:solana-sdk", "dep:solana-account-decoder"]
+solana-v1 = []
 
 [dependencies]
 anchor-lang = { version = ">=0.28, <0.31", optional = true }
@@ -27,8 +28,9 @@ num-traits = { version = "^0.2" }
 orca_whirlpools_core = { path = "../core", optional = true }
 serde = { version = "^1.0", features = ["derive"], optional = true }
 serde_with = { version = "^3.10", optional = true }
-solana-program = { version = "^1.16" }
-solana-sdk = { version = "^1.16", optional = true }
-solana-client = { version = "^1.16", optional = true }
-solana-account-decoder = { version = "^1.16", optional = true }
+serde-big-array = { version = "^0.5", optional = true }
+solana-program = { version = ">=1.16, <3.0" }
+solana-sdk = { version = ">=1.16, <3.0", optional = true }
+solana-client = { version = ">=1.16, <3.0", optional = true }
+solana-account-decoder = { version = ">=1.16, <3.0", optional = true }
 thiserror = { version = "^2.0" }

--- a/rust-sdk/client/src/lib.rs
+++ b/rust-sdk/client/src/lib.rs
@@ -14,8 +14,12 @@ pub use generated::errors::*;
 pub use generated::instructions::*;
 pub use generated::programs::WHIRLPOOL_ID as ID;
 pub use generated::programs::*;
-pub use generated::shared::*;
 pub use generated::types::*;
+
+#[cfg(feature = "fetch")]
+pub use generated::shared::*;
+
+#[cfg(feature = "fetch")]
 pub(crate) use generated::*;
 
 pub use pda::*;

--- a/rust-sdk/integration/client/anchor v0.28/Cargo.toml
+++ b/rust-sdk/integration/client/anchor v0.28/Cargo.toml
@@ -7,4 +7,5 @@ path = "../../lib.rs"
 
 [dependencies]
 anchor-lang = { version = "~0.28.0" }
+solana-program = { version = "~1.16.25" }
 orca_whirlpools_client = { path = "../../../client", features = ["anchor"] }

--- a/rust-sdk/integration/client/anchor v0.29/Cargo.toml
+++ b/rust-sdk/integration/client/anchor v0.29/Cargo.toml
@@ -7,4 +7,5 @@ path = "../../lib.rs"
 
 [dependencies]
 anchor-lang = { version = "~0.29.0" }
+solana-program = { version = "~1.18.26" }
 orca_whirlpools_client = { path = "../../../client", features = ["anchor"] }

--- a/rust-sdk/integration/client/anchor v0.30/Cargo.toml
+++ b/rust-sdk/integration/client/anchor v0.30/Cargo.toml
@@ -7,4 +7,5 @@ path = "../../lib.rs"
 
 [dependencies]
 anchor-lang = { version = "~0.30.1" }
+solana-program = { version = "~1.18.26" }
 orca_whirlpools_client = { path = "../../../client", features = ["anchor"] }

--- a/rust-sdk/integration/client/solana v1.16/Cargo.toml
+++ b/rust-sdk/integration/client/solana v1.16/Cargo.toml
@@ -7,7 +7,4 @@ path = "../../lib.rs"
 
 [dependencies]
 solana-program = { version = "~1.16.27" }
-solana-sdk = { version = "~1.16.27" }
-solana-client = { version = "~1.16.27" }
-solana-account-decoder = { version = "~1.16.27" }
-orca_whirlpools_client = { path = "../../../client" }
+orca_whirlpools_client = { path = "../../../client", features = ["solana-v1"] }

--- a/rust-sdk/integration/client/solana v1.17/Cargo.toml
+++ b/rust-sdk/integration/client/solana v1.17/Cargo.toml
@@ -7,7 +7,4 @@ path = "../../lib.rs"
 
 [dependencies]
 solana-program = { version = "~1.17.3" }
-solana-sdk = { version = "~1.17.3" }
-solana-client = { version = "~1.17.3" }
-solana-account-decoder = { version = "~1.17.3" }
-orca_whirlpools_client = { path = "../../../client" }
+orca_whirlpools_client = { path = "../../../client", features = ["solana-v1"] }

--- a/rust-sdk/integration/client/solana v1.18/Cargo.toml
+++ b/rust-sdk/integration/client/solana v1.18/Cargo.toml
@@ -7,7 +7,4 @@ path = "../../lib.rs"
 
 [dependencies]
 solana-program = { version = "~1.18.26" }
-solana-sdk = { version = "~1.18.26" }
-solana-client = { version = "~1.18.26" }
-solana-account-decoder = { version = "~1.18.26" }
-orca_whirlpools_client = { path = "../../../client" }
+orca_whirlpools_client = { path = "../../../client", features = ["solana-v1"] }

--- a/rust-sdk/integration/client/solana v2.0/Cargo.toml
+++ b/rust-sdk/integration/client/solana v2.0/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "orca_whirlpools_client_integration_solana_v2_0"
+edition = "2021"
+
+[lib]
+path = "../../lib.rs"
+
+[dependencies]
+solana-program = { version = "~2.0.25" }
+orca_whirlpools_client = { path = "../../../client" }

--- a/rust-sdk/integration/client/solana v2.1/Cargo.toml
+++ b/rust-sdk/integration/client/solana v2.1/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "orca_whirlpools_client_integration_solana_v2_1"
+edition = "2021"
+
+[lib]
+path = "../../lib.rs"
+
+[dependencies]
+solana-program = { version = "~2.1.13" }
+orca_whirlpools_client = { path = "../../../client" }

--- a/rust-sdk/integration/client/solana v2.2/Cargo.toml
+++ b/rust-sdk/integration/client/solana v2.2/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "orca_whirlpools_client_integration_solana_v2_2"
+edition = "2021"
+
+[lib]
+path = "../../lib.rs"
+
+[dependencies]
+solana-program = { version = "~2.2.0" }
+orca_whirlpools_client = { path = "../../../client" }

--- a/rust-sdk/integration/package.json
+++ b/rust-sdk/integration/package.json
@@ -5,13 +5,15 @@
   "private": true,
   "scripts": {
     "build": "tsc --noEmit",
-    "test": "vitest run index.test.ts --test-timeout 60000",
-    "clean": "rimraf --glob ./**/Cargo.lock ./**/target || true"
+    "test": "vitest run index.test.ts --test-timeout 60000"
   },
   "devDependencies": {
     "@orca-so/whirlpools-rust": "*",
     "@orca-so/whirlpools-rust-client": "*",
     "@orca-so/whirlpools-rust-core": "*",
+    "@types/semver": "^7.5.8",
+    "semver": "^7.7.1",
+    "smol-toml": "^1.3.1",
     "typescript": "^5.7.3"
   }
 }

--- a/rust-sdk/integration/whirlpool/solana v1.17/Cargo.toml
+++ b/rust-sdk/integration/whirlpool/solana v1.17/Cargo.toml
@@ -9,8 +9,8 @@ path = "../../lib.rs"
 solana-account-decoder = { version = "~1.17.3" }
 solana-sdk = { version = "~1.17.3" }
 spl-associated-token-account = { version = "~2.3.0" }
-spl-token = { version = "~3.5.0" }
-spl-memo = { version = "~3.0.1" }
-spl-token-2022 = { version = "~1.0.0" }
+spl-token = { version = "~3.5.0", features = ["no-entrypoint"] }
+spl-memo = { version = "~3.0.1", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "~1.0.0", features = ["no-entrypoint"] }
 solana-program = { version = "~1.17.3" }
 orca_whirlpools = { path = "../../../whirlpool", features = ["solana-v1"] }

--- a/rust-sdk/integration/whirlpool/solana v1.17/Cargo.toml
+++ b/rust-sdk/integration/whirlpool/solana v1.17/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "orca_whirlpools_integration_solana_v1_17"
+edition = "2021"
+
+[lib]
+path = "../../lib.rs"
+
+[dependencies]
+solana-account-decoder = { version = "~1.17.3" }
+solana-sdk = { version = "~1.17.3" }
+spl-associated-token-account = { version = "~2.3.0" }
+spl-token = { version = "~3.5.0" }
+spl-memo = { version = "~3.0.1" }
+spl-token-2022 = { version = "~1.0.0" }
+solana-program = { version = "~1.17.3" }
+orca_whirlpools = { path = "../../../whirlpool", features = ["solana-v1"] }

--- a/rust-sdk/integration/whirlpool/solana v1.18/Cargo.toml
+++ b/rust-sdk/integration/whirlpool/solana v1.18/Cargo.toml
@@ -9,8 +9,8 @@ path = "../../lib.rs"
 solana-account-decoder = { version = "~1.18.26" }
 solana-sdk = { version = "~1.18.26" }
 spl-associated-token-account = { version = "~3.0.4" }
-spl-token = { version = "~4.0.0" }
-spl-memo = { version = "~4.0.4" }
-spl-token-2022 = { version = "~3.0.5" }
+spl-token = { version = "~4.0.0", features = ["no-entrypoint"] }
+spl-memo = { version = "~4.0.4", features = ["no-entrypoint"] }
+spl-token-2022 = { version = "~3.0.5", features = ["no-entrypoint"] }
 solana-program = { version = "~1.18.26" }
 orca_whirlpools = { path = "../../../whirlpool", features = ["solana-v1"] }

--- a/rust-sdk/integration/whirlpool/solana v1.18/Cargo.toml
+++ b/rust-sdk/integration/whirlpool/solana v1.18/Cargo.toml
@@ -6,8 +6,11 @@ edition = "2021"
 path = "../../lib.rs"
 
 [dependencies]
-solana-program = { version = "~1.18.26" }
-solana-sdk = { version = "~1.18.26" }
-solana-client = { version = "~1.18.26" }
 solana-account-decoder = { version = "~1.18.26" }
-orca_whirlpools = { path = "../../../whirlpool" }
+solana-sdk = { version = "~1.18.26" }
+spl-associated-token-account = { version = "~3.0.4" }
+spl-token = { version = "~4.0.0" }
+spl-memo = { version = "~4.0.4" }
+spl-token-2022 = { version = "~3.0.5" }
+solana-program = { version = "~1.18.26" }
+orca_whirlpools = { path = "../../../whirlpool", features = ["solana-v1"] }

--- a/rust-sdk/integration/whirlpool/solana v2.0/Cargo.toml
+++ b/rust-sdk/integration/whirlpool/solana v2.0/Cargo.toml
@@ -9,8 +9,8 @@ path = "../../lib.rs"
 solana-account-decoder = { version = "~2.0.25" }
 solana-sdk = { version = "~2.0.25" }
 spl-associated-token-account = { version = "~4.0.0" }
-spl-token = { version = "~6.0.0" }
-spl-memo = { version = "~5.0.0" }
+spl-token = { version = "~6.0.0", features = ["no-entrypoint"] }
+spl-memo = { version = "~5.0.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "~4.0.0" }
 solana-program = { version = "~2.0.25" }
 orca_whirlpools = { path = "../../../whirlpool" }

--- a/rust-sdk/integration/whirlpool/solana v2.0/Cargo.toml
+++ b/rust-sdk/integration/whirlpool/solana v2.0/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "orca_whirlpools_integration_solana_v2_0"
+edition = "2021"
+
+[lib]
+path = "../../lib.rs"
+
+[dependencies]
+solana-account-decoder = { version = "~2.0.25" }
+solana-sdk = { version = "~2.0.25" }
+spl-associated-token-account = { version = "~4.0.0" }
+spl-token = { version = "~6.0.0" }
+spl-memo = { version = "~5.0.0" }
+spl-token-2022 = { version = "~4.0.0" }
+solana-program = { version = "~2.0.25" }
+orca_whirlpools = { path = "../../../whirlpool" }

--- a/rust-sdk/integration/whirlpool/solana v2.0/Cargo.toml
+++ b/rust-sdk/integration/whirlpool/solana v2.0/Cargo.toml
@@ -11,6 +11,6 @@ solana-sdk = { version = "~2.0.25" }
 spl-associated-token-account = { version = "~4.0.0" }
 spl-token = { version = "~6.0.0", features = ["no-entrypoint"] }
 spl-memo = { version = "~5.0.0", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "~4.0.0" }
+spl-token-2022 = { version = "~4.0.0", features = ["no-entrypoint"] }
 solana-program = { version = "~2.0.25" }
 orca_whirlpools = { path = "../../../whirlpool" }

--- a/rust-sdk/integration/whirlpool/solana v2.1/Cargo.toml
+++ b/rust-sdk/integration/whirlpool/solana v2.1/Cargo.toml
@@ -9,8 +9,8 @@ path = "../../lib.rs"
 solana-account-decoder = { version = "~2.1.13" }
 solana-sdk = { version = "~2.1.13" }
 spl-associated-token-account = { version = "~5.0.1" }
-spl-token = { version = "~6.0.0" }
-spl-memo = { version = "~6.0.0" }
+spl-token = { version = "~6.0.0", features = ["no-entrypoint"] }
+spl-memo = { version = "~6.0.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "~6.0.0" }
 solana-program = { version = "~2.1.13" }
 orca_whirlpools = { path = "../../../whirlpool" }

--- a/rust-sdk/integration/whirlpool/solana v2.1/Cargo.toml
+++ b/rust-sdk/integration/whirlpool/solana v2.1/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "orca_whirlpools_integration_solana_v2_1"
+edition = "2021"
+
+[lib]
+path = "../../lib.rs"
+
+[dependencies]
+solana-account-decoder = { version = "~2.1.13" }
+solana-sdk = { version = "~2.1.13" }
+spl-associated-token-account = { version = "~5.0.1" }
+spl-token = { version = "~6.0.0" }
+spl-memo = { version = "~6.0.0" }
+spl-token-2022 = { version = "~6.0.0" }
+solana-program = { version = "~2.1.13" }
+orca_whirlpools = { path = "../../../whirlpool" }

--- a/rust-sdk/integration/whirlpool/solana v2.1/Cargo.toml
+++ b/rust-sdk/integration/whirlpool/solana v2.1/Cargo.toml
@@ -11,6 +11,6 @@ solana-sdk = { version = "~2.1.13" }
 spl-associated-token-account = { version = "~5.0.1" }
 spl-token = { version = "~6.0.0", features = ["no-entrypoint"] }
 spl-memo = { version = "~6.0.0", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "~6.0.0" }
+spl-token-2022 = { version = "~6.0.0", features = ["no-entrypoint"] }
 solana-program = { version = "~2.1.13" }
 orca_whirlpools = { path = "../../../whirlpool" }

--- a/rust-sdk/integration/whirlpool/solana v2.2/Cargo.toml
+++ b/rust-sdk/integration/whirlpool/solana v2.2/Cargo.toml
@@ -11,6 +11,6 @@ solana-sdk = { version = "~2.2.0" }
 spl-associated-token-account = { version = "~6.0.0" }
 spl-token = { version = "~7.0.0", features = ["no-entrypoint"] }
 spl-memo = { version = "~6.0.0", features = ["no-entrypoint"] }
-spl-token-2022 = { version = "~7.0.0" }
+spl-token-2022 = { version = "~7.0.0", features = ["no-entrypoint"] }
 solana-program = { version = "~2.2.0" }
 orca_whirlpools = { path = "../../../whirlpool" }

--- a/rust-sdk/integration/whirlpool/solana v2.2/Cargo.toml
+++ b/rust-sdk/integration/whirlpool/solana v2.2/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "orca_whirlpools_integration_solana_v2_2"
+edition = "2021"
+
+[lib]
+path = "../../lib.rs"
+
+[dependencies]
+solana-account-decoder = { version = "~2.2.0" }
+solana-sdk = { version = "~2.2.0" }
+spl-associated-token-account = { version = "~6.0.0" }
+spl-token = { version = "~7.0.0" }
+spl-memo = { version = "~6.0.0" }
+spl-token-2022 = { version = "~7.0.0" }
+solana-program = { version = "~2.2.0" }
+orca_whirlpools = { path = "../../../whirlpool" }

--- a/rust-sdk/integration/whirlpool/solana v2.2/Cargo.toml
+++ b/rust-sdk/integration/whirlpool/solana v2.2/Cargo.toml
@@ -9,8 +9,8 @@ path = "../../lib.rs"
 solana-account-decoder = { version = "~2.2.0" }
 solana-sdk = { version = "~2.2.0" }
 spl-associated-token-account = { version = "~6.0.0" }
-spl-token = { version = "~7.0.0" }
-spl-memo = { version = "~6.0.0" }
+spl-token = { version = "~7.0.0", features = ["no-entrypoint"] }
+spl-memo = { version = "~6.0.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "~7.0.0" }
 solana-program = { version = "~2.2.0" }
 orca_whirlpools = { path = "../../../whirlpool" }

--- a/rust-sdk/whirlpool/Cargo.toml
+++ b/rust-sdk/whirlpool/Cargo.toml
@@ -21,7 +21,7 @@ solana-client = { version = ">=1.17, <3.0" }
 solana-sdk = { version = ">=1.17, <3.0" }
 solana-account-decoder = { version = ">=1.17, <3.0" }
 spl-token = { version = ">=3.0, <8.0", features = ["no-entrypoint"] }
-spl-token-2022 = { version = ">=1.0, <8.0" }
+spl-token-2022 = { version = ">=1.0, <8.0", features = ["no-entrypoint"] }
 spl-memo = { version = ">=3.0, <7.0", features = ["no-entrypoint"] }
 spl-associated-token-account = { version = ">=2.0, <7.0" }
 orca_whirlpools_core = { path = "../core", features = ["floats"] }

--- a/rust-sdk/whirlpool/Cargo.toml
+++ b/rust-sdk/whirlpool/Cargo.toml
@@ -13,29 +13,31 @@ edition = "2021"
 
 [features]
 default = []
+solana-v1 = ["orca_whirlpools_client/solana-v1"]
 
 [dependencies]
-solana-program = { version = "^1.18" }
-solana-client = { version = "^1.18" }
-solana-sdk = { version = "^1.18" }
-solana-account-decoder = { version = "^1.18" }
-spl-token = { version = "^4.0" }
-spl-token-2022 = { version = "^3.0" }
-spl-memo = { version = "^4.0" }
-spl-associated-token-account = { version = "^3.0" }
+solana-program = { version = ">=1.17, <3.0" }
+solana-client = { version = ">=1.17, <3.0" }
+solana-sdk = { version = ">=1.17, <3.0" }
+solana-account-decoder = { version = ">=1.17, <3.0" }
+spl-token = { version = ">=3.0, <8.0" }
+spl-token-2022 = { version = ">=1.0, <8.0" }
+spl-memo = { version = ">=3.0, <7.0" }
+spl-associated-token-account = { version = ">=2.0, <7.0" }
 orca_whirlpools_core = { path = "../core", features = ["floats"] }
-orca_whirlpools_client = { path = "../client", features = ["core-types"] }
+orca_whirlpools_client = { path = "../client", features = ["fetch"] }
 bincode = { version = "^1.3" }
 serde = { version = "^1.0" }
 serde_json = { version = "^1.0" }
 
 [dev-dependencies]
 serial_test = { version = "^3.1" }
-solana-program-test = { version = "^1.18" }
-solana-version = { version = "^1.18" }
+solana-program-test = { version = "^2.1" }
+solana-version = { version = "^2.1" }
 async-trait = { version = "^0.1" }
 base64 = { version = "^0.20" }
 toml = { version = "^0.7" }
 tokio = { version = "^1.0", features = ["sync"] }
-spl-pod = { version = "^0.1" }
+spl-pod = { version = "^0.5" }
+lazy_static = { version = "^1.4" }
 rstest = "0.18.2"

--- a/rust-sdk/whirlpool/Cargo.toml
+++ b/rust-sdk/whirlpool/Cargo.toml
@@ -20,9 +20,9 @@ solana-program = { version = ">=1.17, <3.0" }
 solana-client = { version = ">=1.17, <3.0" }
 solana-sdk = { version = ">=1.17, <3.0" }
 solana-account-decoder = { version = ">=1.17, <3.0" }
-spl-token = { version = ">=3.0, <8.0" }
+spl-token = { version = ">=3.0, <8.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = ">=1.0, <8.0" }
-spl-memo = { version = ">=3.0, <7.0" }
+spl-memo = { version = ">=3.0, <7.0", features = ["no-entrypoint"] }
 spl-associated-token-account = { version = ">=2.0, <7.0" }
 orca_whirlpools_core = { path = "../core", features = ["floats"] }
 orca_whirlpools_client = { path = "../client", features = ["fetch"] }

--- a/rust-sdk/whirlpool/src/increase_liquidity.rs
+++ b/rust-sdk/whirlpool/src/increase_liquidity.rs
@@ -852,10 +852,6 @@ mod tests {
         Ok(out)
     }
 
-    fn is_te_scenario(pool_name: &str, position_name: &str) -> bool {
-        pool_name.contains("TE") || position_name.contains("TE")
-    }
-
     pub fn parse_pool_name(pool_name: &str) -> (&'static str, &'static str) {
         match pool_name {
             "A-B" => ("A", "B"),

--- a/rust-sdk/whirlpool/src/position.rs
+++ b/rust-sdk/whirlpool/src/position.rs
@@ -314,8 +314,6 @@ mod tests {
     use solana_sdk::signer::Signer;
     use std::error::Error;
 
-    const DEFAULT_TICK_RANGE: (i32, i32) = (-100, 100);
-
     #[tokio::test]
     #[serial]
     #[ignore = "Skipped until solana-bankrun supports gpa"]

--- a/rust-sdk/whirlpool/src/swap.rs
+++ b/rust-sdk/whirlpool/src/swap.rs
@@ -438,20 +438,20 @@ mod tests {
     async fn verify_swap(
         ctx: &RpcContext,
         swap_ix: &SwapInstructions,
-        user_ata_for_finalA: Pubkey,
-        user_ata_for_finalB: Pubkey,
+        user_ata_for_final_a: Pubkey,
+        user_ata_for_final_b: Pubkey,
         a_to_b: bool,
     ) -> Result<(), Box<dyn Error>> {
-        let before_a = get_token_balance(&ctx.rpc, user_ata_for_finalA).await?;
-        let before_b = get_token_balance(&ctx.rpc, user_ata_for_finalB).await?;
+        let before_a = get_token_balance(&ctx.rpc, user_ata_for_final_a).await?;
+        let before_b = get_token_balance(&ctx.rpc, user_ata_for_final_b).await?;
 
         // do swap
         let signers: Vec<&Keypair> = swap_ix.additional_signers.iter().collect();
         ctx.send_transaction_with_signers(swap_ix.instructions.clone(), signers)
             .await?;
 
-        let after_a = get_token_balance(&ctx.rpc, user_ata_for_finalA).await?;
-        let after_b = get_token_balance(&ctx.rpc, user_ata_for_finalB).await?;
+        let after_a = get_token_balance(&ctx.rpc, user_ata_for_final_a).await?;
+        let after_b = get_token_balance(&ctx.rpc, user_ata_for_final_b).await?;
 
         let used_a = before_a.saturating_sub(after_a);
         let used_b = before_b.saturating_sub(after_b);
@@ -552,12 +552,12 @@ mod tests {
             .await
             .unwrap();
 
-            let user_ata_for_finalA = if final_a == pubkey_a {
+            let user_ata_for_final_a = if final_a == pubkey_a {
                 user_atas[mkey_a]
             } else {
                 user_atas[mkey_b]
             };
-            let user_ata_for_finalB = if final_b == pubkey_b {
+            let user_ata_for_final_b = if final_b == pubkey_b {
                 user_atas[mkey_b]
             } else {
                 user_atas[mkey_a]
@@ -595,8 +595,8 @@ mod tests {
             verify_swap(
                 &ctx,
                 &swap_ix,
-                user_ata_for_finalA,
-                user_ata_for_finalB,
+                user_ata_for_final_a,
+                user_ata_for_final_b,
                 a_to_b,
             )
             .await

--- a/rust-sdk/whirlpool/src/tests/anchor.rs
+++ b/rust-sdk/whirlpool/src/tests/anchor.rs
@@ -3,7 +3,7 @@ use std::{env::set_var, error::Error, fs::read_to_string, path::PathBuf, str::Fr
 use solana_sdk::pubkey::Pubkey;
 use toml::Table;
 
-pub fn anchor_programs(path: String) -> Result<Vec<(String, Pubkey)>, Box<dyn Error>> {
+pub fn anchor_programs(path: &str) -> Result<Vec<(String, Pubkey)>, Box<dyn Error>> {
     let mut programs: Vec<(String, Pubkey)> = Vec::new();
     let mut sbf_out_dir: PathBuf = path.parse()?;
     let mut anchor_toml_path = sbf_out_dir.clone();

--- a/rust-sdk/whirlpool/src/tests/token_extensions.rs
+++ b/rust-sdk/whirlpool/src/tests/token_extensions.rs
@@ -45,18 +45,15 @@ pub async fn setup_mint_te(
 
     // 2. Initialize extensions first
     for extension in extensions {
-        match extension {
-            ExtensionType::TransferFeeConfig => {
-                instructions.push(initialize_transfer_fee_config(
-                    &TOKEN_2022_PROGRAM_ID,
-                    &mint.pubkey(),
-                    Some(&ctx.signer.pubkey()),
-                    Some(&ctx.signer.pubkey()),
-                    100,           // 1% (matching program)
-                    1_000_000_000, // 1 token (matching program)
-                )?);
-            }
-            _ => {} // Handle other extension types here if needed
+        if extension == &ExtensionType::TransferFeeConfig {
+            instructions.push(initialize_transfer_fee_config(
+                &TOKEN_2022_PROGRAM_ID,
+                &mint.pubkey(),
+                Some(&ctx.signer.pubkey()),
+                Some(&ctx.signer.pubkey()),
+                100,           // 1% (matching program)
+                1_000_000_000, // 1 token (matching program)
+            )?);
         }
     }
 
@@ -71,18 +68,15 @@ pub async fn setup_mint_te(
 
     // 4. Set extension configurations
     for extension in extensions {
-        match extension {
-            ExtensionType::TransferFeeConfig => {
-                instructions.push(set_transfer_fee(
-                    &TOKEN_2022_PROGRAM_ID,
-                    &mint.pubkey(),
-                    &ctx.signer.pubkey(),
-                    &[],
-                    150,           // 1.5% (matching program)
-                    1_000_000_000, // 1 token
-                )?);
-            }
-            _ => {} // Handle other extension types here if needed
+        if extension == &ExtensionType::TransferFeeConfig {
+            instructions.push(set_transfer_fee(
+                &TOKEN_2022_PROGRAM_ID,
+                &mint.pubkey(),
+                &ctx.signer.pubkey(),
+                &[],
+                150,           // 1.5% (matching program)
+                1_000_000_000, // 1 token
+            )?);
         }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4492,6 +4492,9 @@ __metadata:
     "@orca-so/whirlpools-rust": "npm:*"
     "@orca-so/whirlpools-rust-client": "npm:*"
     "@orca-so/whirlpools-rust-core": "npm:*"
+    "@types/semver": "npm:^7.5.8"
+    semver: "npm:^7.7.1"
+    smol-toml: "npm:^1.3.1"
     typescript: "npm:^5.7.3"
   languageName: unknown
   linkType: soft
@@ -6373,6 +6376,13 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/d077a761a0753b079bf8279b3993948030ca86ed9125437b9b29c1de40db9b2deb7fddc369f014b58861d450e8b8cc75f163aa29dc8cea81952efbfd859168cf
+  languageName: node
+  linkType: hard
+
+"@types/semver@npm:^7.5.8":
+  version: 7.5.8
+  resolution: "@types/semver@npm:7.5.8"
+  checksum: 10c0/8663ff927234d1c5fcc04b33062cb2b9fcfbe0f5f351ed26c4d1e1581657deebd506b41ff7fdf89e787e3d33ce05854bc01686379b89e9c49b564c4cfa988efa
   languageName: node
   linkType: hard
 
@@ -16889,6 +16899,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.7.1":
+  version: 7.7.1
+  resolution: "semver@npm:7.7.1"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/fd603a6fb9c399c6054015433051bdbe7b99a940a8fb44b85c2b524c4004b023d7928d47cb22154f8d054ea7ee8597f586605e05b52047f048278e4ac56ae958
+  languageName: node
+  linkType: hard
+
 "send@npm:0.19.0":
   version: 0.19.0
   resolution: "send@npm:0.19.0"
@@ -17218,6 +17237,13 @@ __metadata:
   version: 4.2.0
   resolution: "smart-buffer@npm:4.2.0"
   checksum: 10c0/a16775323e1404dd43fabafe7460be13a471e021637bc7889468eb45ce6a6b207261f454e4e530a19500cc962c4cc5348583520843b363f4193cee5c00e1e539
+  languageName: node
+  linkType: hard
+
+"smol-toml@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "smol-toml@npm:1.3.1"
+  checksum: 10c0/bac5bf4f2655fd561fe41f9426d70ab68b486631beff97a7f127f5d2f811b5e247d50a06583be03d35a625dcb05b7984b94a61a81c68ea2810ac7a9bf4edc64d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Since this is a breaking change, I will bump the major version of the orca_whirlpools_client crate. This version is still backwards compatible with solana v1 crates but the consumer will need to enable the `solana-v1` feature.

Theoretically I could have also done non-breaking:
* Use a solana-v2 feature that a user explicitly needs to enable. Imo this makes it more difficult down the line to make solana v2 the default/recommended
* Add solana-v1 to the default features. This would be non-breaking but would just add the breaking-change and major version bump for a later date. This would make the consumers cargo.toml less clean as having to disable the default features is less nice than having to enable a feature