### PR TITLE
fix: allow whirlpool_repositioning_bot work on pools paired with SOL

### DIFF
--- a/.changeset/mean-cows-flow.md
+++ b/.changeset/mean-cows-flow.md
@@ -1,0 +1,5 @@
+---
+"@orca-so/whirlpools-example-rust-repositioning-bot": patch
+---
+
+Update to work on SOL paired pools

--- a/examples/rust-sdk/whirlpool_repositioning_bot/Cargo.toml
+++ b/examples/rust-sdk/whirlpool_repositioning_bot/Cargo.toml
@@ -13,7 +13,8 @@ serde_json = { version = "^1.0" }
 solana-client = { version = "^1.18" }
 solana-sdk = { version = "^1.18" }
 spl-token-2022 = { version = "^3.0" }
+spl-token = { version = "^3.0" }
 spl-associated-token-account = { version = "^3.0" }
 tokio = { version = "^1.41.1" }
 tokio-retry = { version = "^0.3.0" }
-dotenv = { version = "^0.15.0"}
+dotenv = { version = "^0.15.0" }


### PR DESCRIPTION
## Description
This change extends the `fetch_token_balance` function to support fetching the balance of the native SOL mint in addition to existing SPL token balance retrieval.

## Changes
- Added a special case for the native SOL mint address
- Uses `get_balance()` RPC method to fetch SOL balance
- Converts lamports to SOL using `lamports_to_sol()` function
- Adds a constant `NATIVE_MINT_ADDRESS` for clarity

## Rationale
Previously, the utility function only supported fetching balances for SPL tokens. This change allows fetching the SOL balance using the same method, improving the utility's flexibility.
