### PR TITLE
Increase MAX_FEE_RATE

### DIFF
--- a/legacy-sdk/whirlpool/tests/integration/initialize_fee_tier.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/initialize_fee_tier.test.ts
@@ -87,7 +87,7 @@ describe("initialize_fee_tier", () => {
       configInitInfo,
       configKeypairs.feeAuthorityKeypair,
       testTickSpacing,
-      30_000, // 3 %
+      60_000, // 6 %
     );
 
     const feeTierAccount = (await fetcher.getFeeTier(
@@ -96,7 +96,7 @@ describe("initialize_fee_tier", () => {
 
     assert.ok(feeTierAccount.tickSpacing == params.tickSpacing);
     assert.ok(feeTierAccount.defaultFeeRate == params.defaultFeeRate);
-    assert.ok(params.defaultFeeRate === 30_000);
+    assert.ok(params.defaultFeeRate === 60_000);
   });
 
   it("successfully init a FeeRate with another funder wallet", async () => {
@@ -135,7 +135,7 @@ describe("initialize_fee_tier", () => {
         configInitInfo,
         configKeypairs.feeAuthorityKeypair,
         TickSpacing.Stable,
-        30_000 + 1,
+        60_000 + 1,
       ),
       /0x178c/, // FeeRateMaxExceeded
     );

--- a/legacy-sdk/whirlpool/tests/integration/set_default_fee_rate.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/set_default_fee_rate.test.ts
@@ -93,7 +93,7 @@ describe("set_default_fee_rate", () => {
       configInitInfo.whirlpoolsConfigKeypair.publicKey;
     const feeAuthorityKeypair = configKeypairs.feeAuthorityKeypair;
 
-    const newDefaultFeeRate = 30_000;
+    const newDefaultFeeRate = 60_000;
 
     await toTx(
       ctx,
@@ -148,7 +148,7 @@ describe("set_default_fee_rate", () => {
       configInitInfo.whirlpoolsConfigKeypair.publicKey;
     const feeAuthorityKeypair = configKeypairs.feeAuthorityKeypair;
 
-    const newDefaultFeeRate = 30_000 + 1;
+    const newDefaultFeeRate = 60_000 + 1;
     await assert.rejects(
       toTx(
         ctx,

--- a/legacy-sdk/whirlpool/tests/integration/set_fee_rate.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/set_fee_rate.test.ts
@@ -61,7 +61,7 @@ describe("set_fee_rate", () => {
       configInitInfo.whirlpoolsConfigKeypair.publicKey;
     const feeAuthorityKeypair = configKeypairs.feeAuthorityKeypair;
 
-    const newFeeRate = 30_000;
+    const newFeeRate = 60_000;
 
     let whirlpool = (await fetcher.getPool(
       whirlpoolKey,
@@ -98,7 +98,7 @@ describe("set_fee_rate", () => {
       configInitInfo.whirlpoolsConfigKeypair.publicKey;
     const feeAuthorityKeypair = configKeypairs.feeAuthorityKeypair;
 
-    const newFeeRate = 30_000 + 1;
+    const newFeeRate = 60_000 + 1;
     await assert.rejects(
       toTx(
         ctx,

--- a/programs/whirlpool/src/math/token_math.rs
+++ b/programs/whirlpool/src/math/token_math.rs
@@ -8,8 +8,8 @@ use super::{
 
 // Fee rate is represented as hundredths of a basis point.
 // Fee amount = total_amount * fee_rate / 1_000_000.
-// Max fee rate supported is 3%.
-pub const MAX_FEE_RATE: u16 = 30_000;
+// Max fee rate supported is 6%.
+pub const MAX_FEE_RATE: u16 = 60_000;
 
 // Assuming that FEE_RATE is represented as hundredths of a basis point
 // We want FEE_RATE_MUL_VALUE = 1/FEE_RATE_UNIT, so 1e6


### PR DESCRIPTION
## Motivation
To support more high fee rate for volatile token pairs.

Current max: 30_000 (3%)
Next max: 60_000 (6%)