### PR TITLE
Remove specified rust version from anchor action

### DIFF
--- a/.github/actions/anchor/action.yml
+++ b/.github/actions/anchor/action.yml
@@ -1,5 +1,5 @@
-name: 'Setup Anchor'
-description: 'Sets up an Anchor development environment.'
+name: "Setup Anchor"
+description: "Sets up an Anchor development environment."
 
 branding:
   icon: anchor
@@ -7,53 +7,31 @@ branding:
 
 inputs:
   solana-cluster:
-    description: 'The cluster to use for the solana sdk.'
+    description: "The cluster to use for the solana sdk."
     required: false
-    default: 'devnet'
+    default: "devnet"
   solana-key:
-    description: 'The private key to use for the solana sdk.'
+    description: "The private key to use for the solana sdk."
     required: false
-  rustc-version:
-    description: 'The version of rustc to use.'
-    default: 'v1.84.0'
   node-version:
-    description: 'The version of node to use.'
-    default: 'v22.8.0'
+    description: "The version of node to use."
+    default: "v22.8.0"
   solana-version:
-    description: 'The version of solana to use.'
-    default: 'v1.17.25'
+    description: "The version of solana to use."
+    default: "v1.17.25"
   anchor-version:
-    description: 'The version of anchor to use.'
-    default: 'v0.29.0'
+    description: "The version of anchor to use."
+    default: "v0.29.0"
 
 runs:
   using: "composite"
   steps:
-    - name: Setup rustc
-      run: |
-        rust_version=${{ inputs.rustc-version }}
-        rustup toolchain install ${rust_version#v}
-        rustup default ${rust_version#v}
-        rustup component add rustfmt clippy
-        echo "RUST_LOG=" >> $GITHUB_ENV
-      shell: bash
-    - name: Cache rust
-      uses: actions/cache@v4
-      continue-on-error: true
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          **/target/
-        key: rust-cache-${{ inputs.rustc-version }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}
     - name: Setup node
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-        cache: 'yarn'
-        registry-url: 'https://registry.npmjs.org'
+        cache: "yarn"
+        registry-url: "https://registry.npmjs.org"
     - name: Install Solana CLI
       run: |
         wget -qO- "https://release.anza.xyz/${{ inputs.solana-version }}/solana-release-x86_64-unknown-linux-gnu.tar.bz2" | tar -xvj


### PR DESCRIPTION
The Publish workflow seems to fail on the build step. One identified difference compared to the Checks and PR workflows is that the Publish workflow uses a specified version of Rust, while the others do not.