### PR TITLE
Allow locking concentrated positions

### DIFF
--- a/.changeset/common-apples-sin.md
+++ b/.changeset/common-apples-sin.md
@@ -5,4 +5,4 @@
 "@orca-so/whirlpools-client": patch
 ---
 
-Add reset position range feature
+Add reset position range feature, lock concentrated positions feature

--- a/.changeset/common-apples-sin.md
+++ b/.changeset/common-apples-sin.md
@@ -5,4 +5,4 @@
 "@orca-so/whirlpools-client": patch
 ---
 
-Add reset position range feature, lock concentrated positions feature
+Add reset position range feature, lock concentrated positions feature, transfer locked position feature

--- a/legacy-sdk/whirlpool/src/instructions/index.ts
+++ b/legacy-sdk/whirlpool/src/instructions/index.ts
@@ -30,6 +30,7 @@ export * from "./set-reward-authority-ix";
 export * from "./set-reward-emissions-ix";
 export * from "./set-reward-emissions-super-authority-ix";
 export * from "./swap-ix";
+export * from "./transfer-locked-position";
 export * from "./two-hop-swap-ix";
 export * from "./update-fees-and-rewards-ix";
 export * from "./v2";

--- a/legacy-sdk/whirlpool/src/instructions/transfer-locked-position.ts
+++ b/legacy-sdk/whirlpool/src/instructions/transfer-locked-position.ts
@@ -1,0 +1,59 @@
+import type { Program } from "@coral-xyz/anchor";
+import type { Instruction } from "@orca-so/common-sdk";
+import type { PublicKey } from "@solana/web3.js";
+import type { Whirlpool } from "../artifacts/whirlpool";
+import { TOKEN_2022_PROGRAM_ID } from "@solana/spl-token";
+
+/**
+ * Parameters to transfer a position.
+ *
+ * @category Instruction Types
+ * @param receiver - PublicKey for the wallet that will receive the rented lamports.
+ * @param position - PublicKey for the position.
+ * @param positionMint - PublicKey for the mint token for the Position token.
+ * @param positionTokenAccount - The associated token address for the position token in the owners wallet.
+ * @param destinationTokenAccount - The associated token address for the position token in the destination wallet.
+ * @param positionAuthority - The authority that owns the position.
+ * @param lockConfig - PublicKey for the lock config for the locked position.
+ */
+export type TransferLockedPositionParams = {
+  receiver: PublicKey;
+  position: PublicKey;
+  positionMint: PublicKey;
+  positionTokenAccount: PublicKey;
+  destinationTokenAccount: PublicKey;
+  positionAuthority: PublicKey;
+  lockConfig: PublicKey;
+};
+
+/**
+ * Transfer the position to to a different token account. This instruction also works for locked positions.
+ *
+ * @category Instructions
+ * @param program - program object containing services required to generate the instruction
+ * @param params - LockPositionParams object.
+ * @returns - Instruction to perform the action.
+ */
+export function transferLockedPositionIx(
+  program: Program<Whirlpool>,
+  params: TransferLockedPositionParams,
+): Instruction {
+  const ix = program.instruction.transferLockedPosition({
+    accounts: {
+      receiver: params.receiver,
+      positionAuthority: params.positionAuthority,
+      position: params.position,
+      positionMint: params.positionMint,
+      positionTokenAccount: params.positionTokenAccount,
+      destinationTokenAccount: params.destinationTokenAccount,
+      token2022Program: TOKEN_2022_PROGRAM_ID,
+      lockConfig: params.lockConfig,
+    },
+  });
+
+  return {
+    instructions: [ix],
+    cleanupInstructions: [],
+    signers: [],
+  };
+}

--- a/legacy-sdk/whirlpool/src/ix.ts
+++ b/legacy-sdk/whirlpool/src/ix.ts
@@ -641,6 +641,20 @@ export class WhirlpoolIx {
     return ix.lockPositionIx(program, params);
   }
 
+  /**
+   * Transfer a position in a Whirlpool.
+   *
+   * @param program - program object containing services required to generate the instruction
+   * @param params - TransferPositionParams object
+   * @returns - Instruction to perform the action.
+   */
+  public static transferLockedPositionIx(
+    program: Program<Whirlpool>,
+    params: ix.TransferLockedPositionParams,
+  ) {
+    return ix.transferLockedPositionIx(program, params);
+  }
+
   // V2 instructions
   // TODO: comments
   public static collectFeesV2Ix(

--- a/legacy-sdk/whirlpool/tests/integration/transfer_locked_position.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/transfer_locked_position.test.ts
@@ -1,0 +1,424 @@
+import * as anchor from "@coral-xyz/anchor";
+import { BN } from "@coral-xyz/anchor";
+import type { PDA } from "@orca-so/common-sdk";
+import { Percentage } from "@orca-so/common-sdk";
+import {
+  TOKEN_2022_PROGRAM_ID,
+  createApproveCheckedInstruction,
+  createAssociatedTokenAccountIdempotentInstruction,
+  getAssociatedTokenAddressSync,
+} from "@solana/spl-token";
+import type { Keypair } from "@solana/web3.js";
+import type { PublicKey } from "@solana/web3.js";
+import * as assert from "assert";
+import type { InitPoolParams, WhirlpoolData } from "../../src";
+import {
+  LockConfigUtil,
+  NO_TOKEN_EXTENSION_CONTEXT,
+  PDAUtil,
+  SPLASH_POOL_TICK_SPACING,
+  TickUtil,
+  WhirlpoolContext,
+  WhirlpoolIx,
+  increaseLiquidityQuoteByLiquidityWithParams,
+  toTx,
+} from "../../src";
+import { ONE_SOL, systemTransferTx } from "../utils";
+import { defaultConfirmOptions } from "../utils/const";
+import { generateDefaultOpenPositionWithTokenExtensionsParams } from "../utils/test-builders";
+import type {
+  LockPositionParams,
+  OpenPositionWithTokenExtensionsParams,
+} from "../../src/instructions";
+import { useMaxCU } from "../utils/v2/init-utils-v2";
+import { WhirlpoolTestFixtureV2 } from "../utils/v2/fixture-v2";
+import { IGNORE_CACHE } from "../../dist/network/public/fetcher/fetcher-types";
+
+describe("transfer_locked_position", () => {
+  const provider = anchor.AnchorProvider.local(
+    undefined,
+    defaultConfirmOptions,
+  );
+
+  const program = anchor.workspace.Whirlpool;
+  const ctx = WhirlpoolContext.fromWorkspace(provider, program);
+
+  const funderKeypair = anchor.web3.Keypair.generate();
+  const delegatedAuthority = anchor.web3.Keypair.generate();
+
+  const splashPoolTickSpacing = SPLASH_POOL_TICK_SPACING;
+  let splashPoolFixture: WhirlpoolTestFixtureV2;
+  let splashPoolFullRange: [number, number];
+
+  beforeAll(async () => {
+    splashPoolFullRange = TickUtil.getFullRangeTickIndex(splashPoolTickSpacing);
+
+    // initialize pools
+    splashPoolFixture = await new WhirlpoolTestFixtureV2(ctx).init({
+      tokenTraitA: { isToken2022: false },
+      tokenTraitB: { isToken2022: false },
+      tickSpacing: splashPoolTickSpacing,
+      positions: [
+        // to init TAs
+        {
+          liquidityAmount: new BN(1_000_000),
+          tickLowerIndex: splashPoolFullRange[0],
+          tickUpperIndex: splashPoolFullRange[1],
+        },
+      ],
+      rewards: [],
+    });
+
+    // setup other wallets
+    await systemTransferTx(
+      provider,
+      funderKeypair.publicKey,
+      100 * ONE_SOL,
+    ).buildAndExecute();
+    await systemTransferTx(
+      provider,
+      delegatedAuthority.publicKey,
+      100 * ONE_SOL,
+    ).buildAndExecute();
+  });
+
+  async function increaseLiquidity(
+    poolInitInfo: InitPoolParams,
+    positionAddress: PublicKey,
+    positionTokenAccount: PublicKey,
+    tickLowerIndex: number,
+    tickUpperIndex: number,
+    liquidity: BN,
+    tokenAccountA: PublicKey,
+    tokenAccountB: PublicKey,
+  ) {
+    const poolData = (await ctx.fetcher.getPool(
+      poolInitInfo.whirlpoolPda.publicKey,
+    )) as WhirlpoolData;
+    const depositQuote = increaseLiquidityQuoteByLiquidityWithParams({
+      liquidity,
+      slippageTolerance: Percentage.fromFraction(0, 1000),
+      tickLowerIndex,
+      tickUpperIndex,
+      sqrtPrice: poolData.sqrtPrice,
+      tickCurrentIndex: poolData.tickCurrentIndex,
+      tokenExtensionCtx: NO_TOKEN_EXTENSION_CONTEXT,
+    });
+    await toTx(
+      ctx,
+      WhirlpoolIx.increaseLiquidityIx(ctx.program, {
+        liquidityAmount: depositQuote.liquidityAmount,
+        tokenMaxA: depositQuote.tokenMaxA,
+        tokenMaxB: depositQuote.tokenMaxB,
+        whirlpool: poolInitInfo.whirlpoolPda.publicKey,
+        position: positionAddress,
+        positionAuthority: ctx.wallet.publicKey,
+        positionTokenAccount: positionTokenAccount,
+        tokenVaultA: poolData.tokenVaultA,
+        tokenVaultB: poolData.tokenVaultB,
+        tickArrayLower: PDAUtil.getTickArrayFromTickIndex(
+          tickLowerIndex,
+          poolInitInfo.tickSpacing,
+          poolInitInfo.whirlpoolPda.publicKey,
+          ctx.program.programId,
+        ).publicKey,
+        tickArrayUpper: PDAUtil.getTickArrayFromTickIndex(
+          tickUpperIndex,
+          poolInitInfo.tickSpacing,
+          poolInitInfo.whirlpoolPda.publicKey,
+          ctx.program.programId,
+        ).publicKey,
+        tokenOwnerAccountA: tokenAccountA,
+        tokenOwnerAccountB: tokenAccountB,
+      }),
+    ).buildAndExecute();
+  }
+
+  async function openTokenExtensionsBasedPositionWithLiquidity(
+    poolFixture: WhirlpoolTestFixtureV2,
+    tickLowerIndex: number,
+    tickUpperIndex: number,
+    liquidity: BN,
+  ) {
+    const poolInitInfo = poolFixture.getInfos().poolInitInfo;
+
+    const withTokenMetadataExtension = true;
+    const { params: positionParams, mint } =
+      await generateDefaultOpenPositionWithTokenExtensionsParams(
+        ctx,
+        poolInitInfo.whirlpoolPda.publicKey,
+        withTokenMetadataExtension,
+        tickLowerIndex,
+        tickUpperIndex,
+        ctx.wallet.publicKey,
+      );
+    await toTx(
+      ctx,
+      WhirlpoolIx.openPositionWithTokenExtensionsIx(
+        ctx.program,
+        positionParams,
+      ),
+    )
+      .addSigner(mint)
+      .prependInstruction(useMaxCU())
+      .buildAndExecute();
+
+    // deposit (empty position is not lockable)
+    await increaseLiquidity(
+      poolInitInfo,
+      positionParams.positionPda.publicKey,
+      positionParams.positionTokenAccount,
+      tickLowerIndex,
+      tickUpperIndex,
+      liquidity,
+      poolFixture.getInfos().tokenAccountA,
+      poolFixture.getInfos().tokenAccountB,
+    );
+
+    return positionParams;
+  }
+
+  async function lockPosition(
+    positionParams: OpenPositionWithTokenExtensionsParams,
+    positionAuthority?: Keypair,
+  ) {
+    const lockParams: LockPositionParams = {
+      funder: ctx.wallet.publicKey,
+      position: positionParams.positionPda.publicKey,
+      positionMint: positionParams.positionMint,
+      positionTokenAccount: positionParams.positionTokenAccount,
+      whirlpool: positionParams.whirlpool,
+      positionAuthority: positionAuthority?.publicKey ?? ctx.wallet.publicKey,
+      lockType: LockConfigUtil.getPermanentLockType(),
+      lockConfigPda: PDAUtil.getLockConfig(
+        ctx.program.programId,
+        positionParams.positionPda.publicKey,
+      ),
+    };
+
+    const tx = toTx(ctx, WhirlpoolIx.lockPositionIx(ctx.program, lockParams));
+
+    if (positionAuthority) {
+      tx.addSigner(positionAuthority);
+    }
+
+    await tx.buildAndExecute();
+  }
+
+  async function transferPosition(
+    position: PublicKey,
+    positionMint: PublicKey,
+    positionTokenAccount: PublicKey,
+    destinationWallet: PublicKey,
+    authority?: Keypair,
+    receiver?: PublicKey,
+  ) {
+    const destinationTokenAccount = getAssociatedTokenAddressSync(
+      positionMint,
+      destinationWallet,
+      false,
+      TOKEN_2022_PROGRAM_ID,
+    );
+
+    await toTx(ctx, {
+      instructions: [
+        createAssociatedTokenAccountIdempotentInstruction(
+          ctx.wallet.publicKey,
+          destinationTokenAccount,
+          destinationWallet,
+          positionMint,
+          TOKEN_2022_PROGRAM_ID,
+        ),
+      ],
+      cleanupInstructions: [],
+      signers: [],
+    }).buildAndExecute();
+
+    const tx = toTx(
+      ctx,
+      WhirlpoolIx.transferLockedPositionIx(ctx.program, {
+        position,
+        positionMint,
+        positionTokenAccount,
+        destinationTokenAccount,
+        positionAuthority: authority?.publicKey ?? ctx.wallet.publicKey,
+        lockConfig: PDAUtil.getLockConfig(ctx.program.programId, position)
+          .publicKey,
+        receiver: receiver ?? ctx.wallet.publicKey,
+      }),
+    );
+
+    if (authority) {
+      tx.addSigner(authority);
+    }
+
+    await tx.buildAndExecute();
+
+    const walletTokenAccountData = await ctx.fetcher.getTokenInfo(
+      positionTokenAccount,
+      IGNORE_CACHE,
+    );
+
+    assert.ok(walletTokenAccountData == null);
+
+    const destinationTokenAccountData = await ctx.fetcher.getTokenInfo(
+      destinationTokenAccount,
+    );
+
+    assert.strictEqual(destinationTokenAccountData?.amount, 1n);
+    assert.strictEqual(destinationTokenAccountData?.isFrozen, true);
+  }
+
+  async function approveDelegate(
+    positionMint: PublicKey,
+    positionTokenAccount: PublicKey,
+  ) {
+    await toTx(ctx, {
+      instructions: [
+        createApproveCheckedInstruction(
+          positionTokenAccount,
+          positionMint,
+          delegatedAuthority.publicKey,
+          ctx.wallet.publicKey,
+          1n,
+          0,
+          [],
+          TOKEN_2022_PROGRAM_ID,
+        ),
+      ],
+      cleanupInstructions: [],
+      signers: [],
+    }).buildAndExecute();
+  }
+
+  it("Should transfer a locked position token", async () => {
+    const positionParams = await openTokenExtensionsBasedPositionWithLiquidity(
+      splashPoolFixture,
+      splashPoolFullRange[0],
+      splashPoolFullRange[1],
+      new BN(1_000_000),
+    );
+    await lockPosition(positionParams);
+
+    await transferPosition(
+      positionParams.positionPda.publicKey,
+      positionParams.positionMint,
+      positionParams.positionTokenAccount,
+      funderKeypair.publicKey,
+    );
+  });
+
+  it("Should transfer a locked position token, different receiver", async () => {
+    const positionParams = await openTokenExtensionsBasedPositionWithLiquidity(
+      splashPoolFixture,
+      splashPoolFullRange[0],
+      splashPoolFullRange[1],
+      new BN(1_000_000),
+    );
+    await lockPosition(positionParams);
+
+    const receiver = anchor.web3.Keypair.generate().publicKey;
+    const rent = (
+      await provider.connection.getAccountInfo(
+        positionParams.positionTokenAccount,
+      )
+    )?.lamports;
+    assert.ok(rent != null && rent > 0);
+
+    await transferPosition(
+      positionParams.positionPda.publicKey,
+      positionParams.positionMint,
+      positionParams.positionTokenAccount,
+      funderKeypair.publicKey,
+      undefined,
+      receiver,
+    );
+
+    const balance = await provider.connection.getBalance(receiver);
+    assert.equal(balance, rent);
+  });
+
+  it("Should not be able to transfer an unlocked position token", async () => {
+    const positionParams = await openTokenExtensionsBasedPositionWithLiquidity(
+      splashPoolFixture,
+      splashPoolFullRange[0],
+      splashPoolFullRange[1],
+      new BN(1_000_000),
+    );
+
+    assert.rejects(
+      transferPosition(
+        positionParams.positionPda.publicKey,
+        positionParams.positionMint,
+        positionParams.positionTokenAccount,
+        funderKeypair.publicKey,
+      ),
+      /0xbc4/, // AccountNotInitialized.
+    );
+  });
+
+  it("Should not be able to transfer a position not owned by the signer", async () => {
+    const positionParams = await openTokenExtensionsBasedPositionWithLiquidity(
+      splashPoolFixture,
+      splashPoolFullRange[0],
+      splashPoolFullRange[1],
+      new BN(1_000_000),
+    );
+    await lockPosition(positionParams);
+    await assert.rejects(
+      transferPosition(
+        positionParams.positionPda.publicKey,
+        positionParams.positionMint,
+        positionParams.positionTokenAccount,
+        funderKeypair.publicKey,
+        funderKeypair,
+      ),
+      /0x1783/, // MissingOrInvalidDelegate
+    );
+  });
+
+  it("Should fail if trying to send to the same address", async () => {
+    const positionParams = await openTokenExtensionsBasedPositionWithLiquidity(
+      splashPoolFixture,
+      splashPoolFullRange[0],
+      splashPoolFullRange[1],
+      new BN(1_000_000),
+    );
+    await lockPosition(positionParams);
+    await assert.rejects(
+      transferPosition(
+        positionParams.positionPda.publicKey,
+        positionParams.positionMint,
+        positionParams.positionTokenAccount,
+        ctx.wallet.publicKey,
+      ),
+      /0x7d3/, // ConstraintRaw
+    );
+  });
+
+  it("Should not be able to transfer a delegated position token", async () => {
+    const positionParams = await openTokenExtensionsBasedPositionWithLiquidity(
+      splashPoolFixture,
+      splashPoolFullRange[0],
+      splashPoolFullRange[1],
+      new BN(1_000_000),
+    );
+    await approveDelegate(
+      positionParams.positionMint,
+      positionParams.positionTokenAccount,
+    );
+
+    await lockPosition(positionParams, delegatedAuthority);
+
+    await assert.rejects(
+      transferPosition(
+        positionParams.positionPda.publicKey,
+        positionParams.positionMint,
+        positionParams.positionTokenAccount,
+        delegatedAuthority.publicKey,
+        delegatedAuthority,
+      ),
+      /0x1783/, // MissingOrInvalidDelegate
+    );
+  });
+});

--- a/programs/whirlpool/src/instructions/lock_position.rs
+++ b/programs/whirlpool/src/instructions/lock_position.rs
@@ -63,15 +63,6 @@ pub fn handler(ctx: Context<LockPosition>, lock_type: LockType) -> Result<()> {
         return Err(ErrorCode::PositionNotLockable.into());
     }
 
-    // only full range positions can be locked at initial implementation (no technical reason)
-    let (full_range_lower_index, full_range_upper_index) =
-        Tick::full_range_indexes(ctx.accounts.whirlpool.tick_spacing);
-    if ctx.accounts.position.tick_lower_index != full_range_lower_index
-        || ctx.accounts.position.tick_upper_index != full_range_upper_index
-    {
-        return Err(ErrorCode::PositionNotLockable.into());
-    }
-
     freeze_user_position_token_2022(
         &ctx.accounts.position_mint,
         &ctx.accounts.position_token_account,

--- a/programs/whirlpool/src/instructions/mod.rs
+++ b/programs/whirlpool/src/instructions/mod.rs
@@ -33,6 +33,7 @@ pub mod set_reward_authority_by_super_authority;
 pub mod set_reward_emissions;
 pub mod set_reward_emissions_super_authority;
 pub mod swap;
+pub mod transfer_locked_position;
 pub mod two_hop_swap;
 pub mod update_fees_and_rewards;
 
@@ -69,8 +70,8 @@ pub use set_reward_authority_by_super_authority::*;
 pub use set_reward_emissions::*;
 pub use set_reward_emissions_super_authority::*;
 pub use swap::*;
+pub use transfer_locked_position::*;
 pub use two_hop_swap::*;
 pub use update_fees_and_rewards::*;
-
 pub mod v2;
 pub use v2::*;

--- a/programs/whirlpool/src/instructions/transfer_locked_position.rs
+++ b/programs/whirlpool/src/instructions/transfer_locked_position.rs
@@ -1,0 +1,111 @@
+use anchor_lang::prelude::*;
+use anchor_spl::{
+    token_2022::{self, Token2022},
+    token_interface::{Mint, TokenAccount},
+};
+
+use crate::{
+    state::*,
+    util::{
+        close_empty_token_account_2022, freeze_user_position_token_2022, is_locked_position,
+        transfer_user_position_token_2022, unfreeze_user_position_token_2022, validate_owner,
+    },
+};
+
+#[derive(Accounts)]
+pub struct TransferLockedPosition<'info> {
+    pub position_authority: Signer<'info>,
+
+    /// CHECK: safe, for receiving rent only
+    #[account(mut)]
+    pub receiver: UncheckedAccount<'info>,
+
+    #[account(
+        seeds = [b"position".as_ref(), position_mint.key().as_ref()],
+        bump,
+    )]
+    pub position: Account<'info, Position>,
+
+    #[account(address = position.position_mint)]
+    pub position_mint: InterfaceAccount<'info, Mint>,
+
+    #[account(mut,
+        constraint = position_token_account.amount == 1,
+        constraint = position_token_account.mint == position.position_mint,
+    )]
+    pub position_token_account: InterfaceAccount<'info, TokenAccount>,
+
+    #[account(mut,
+      constraint = destination_token_account.mint == position.position_mint,
+      constraint = destination_token_account.key() != position_token_account.key(),
+    )]
+    pub destination_token_account: InterfaceAccount<'info, TokenAccount>,
+
+    #[account(
+      mut,
+      has_one = position
+    )]
+    pub lock_config: Box<Account<'info, LockConfig>>,
+
+    #[account(address = token_2022::ID)]
+    pub token_2022_program: Program<'info, Token2022>,
+}
+
+pub fn handler(ctx: Context<TransferLockedPosition>) -> Result<()> {
+    // Only allow the owner of the position to transfer this and not the delegate.
+    // * Once a position is locked the delegate cannot be changed
+    // * The delegate gets removed once it transfers the position, meaning the subsequent ixs fails here
+    validate_owner(
+        &ctx.accounts.position_token_account.owner,
+        &ctx.accounts.position_authority.to_account_info(),
+    )?;
+
+    if !is_locked_position(&ctx.accounts.position_token_account) {
+        unreachable!("Position has to be locked for this instruction");
+    }
+
+    unfreeze_user_position_token_2022(
+        &ctx.accounts.position_mint,
+        &ctx.accounts.position_token_account,
+        &ctx.accounts.token_2022_program,
+        &ctx.accounts.position,
+        &[
+            b"position".as_ref(),
+            ctx.accounts.position_mint.key().as_ref(),
+            &[ctx.bumps.position],
+        ],
+    )?;
+
+    transfer_user_position_token_2022(
+        &ctx.accounts.position_authority,
+        &ctx.accounts.position_mint,
+        &ctx.accounts.position_token_account,
+        &ctx.accounts.destination_token_account,
+        &ctx.accounts.token_2022_program,
+    )?;
+
+    freeze_user_position_token_2022(
+        &ctx.accounts.position_mint,
+        &ctx.accounts.destination_token_account,
+        &ctx.accounts.token_2022_program,
+        &ctx.accounts.position,
+        &[
+            b"position".as_ref(),
+            ctx.accounts.position_mint.key().as_ref(),
+            &[ctx.bumps.position],
+        ],
+    )?;
+
+    close_empty_token_account_2022(
+        &ctx.accounts.position_authority,
+        &ctx.accounts.position_token_account,
+        &ctx.accounts.token_2022_program,
+        &ctx.accounts.receiver,
+    )?;
+
+    ctx.accounts
+        .lock_config
+        .update_position_owner(ctx.accounts.destination_token_account.owner);
+
+    Ok(())
+}

--- a/programs/whirlpool/src/lib.rs
+++ b/programs/whirlpool/src/lib.rs
@@ -628,7 +628,7 @@ pub mod whirlpool {
 
     /// Lock the position to prevent any liquidity changes.
     ///
-    /// ### Authority       
+    /// ### Authority
     /// - `position_authority` - The authority that owns the position token.
     ///
     /// #### Special Errors
@@ -658,6 +658,14 @@ pub mod whirlpool {
         new_tick_upper_index: i32,
     ) -> Result<()> {
         instructions::reset_position_range::handler(ctx, new_tick_lower_index, new_tick_upper_index)
+    }
+
+    /// Transfer a locked position to to a different token account.
+    ///
+    /// ### Authority
+    /// - `position_authority` - The authority that owns the position token.
+    pub fn transfer_locked_position(ctx: Context<TransferLockedPosition>) -> Result<()> {
+        instructions::transfer_locked_position::handler(ctx)
     }
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/programs/whirlpool/src/state/lock_config.rs
+++ b/programs/whirlpool/src/state/lock_config.rs
@@ -43,6 +43,10 @@ impl LockConfig {
         }
         Ok(())
     }
+
+    pub fn update_position_owner(&mut self, position_owner: Pubkey) {
+        self.position_owner = position_owner;
+    }
 }
 
 #[cfg(test)]

--- a/programs/whirlpool/src/util/shared.rs
+++ b/programs/whirlpool/src/util/shared.rs
@@ -58,7 +58,7 @@ pub fn verify_position_authority_interface(
     Ok(())
 }
 
-fn validate_owner(expected_owner: &Pubkey, owner_account_info: &AccountInfo) -> Result<()> {
+pub fn validate_owner(expected_owner: &Pubkey, owner_account_info: &AccountInfo) -> Result<()> {
     if expected_owner != owner_account_info.key || !owner_account_info.is_signer {
         return Err(ErrorCode::MissingOrInvalidDelegate.into());
     }

--- a/programs/whirlpool/src/util/token_2022.rs
+++ b/programs/whirlpool/src/util/token_2022.rs
@@ -370,3 +370,85 @@ pub fn freeze_user_position_token_2022<'info>(
 
     Ok(())
 }
+
+pub fn unfreeze_user_position_token_2022<'info>(
+    position_mint: &InterfaceAccount<'info, Mint>,
+    position_token_account: &InterfaceAccount<'info, TokenAccount>,
+    token_2022_program: &Program<'info, Token2022>,
+    position: &Account<'info, Position>,
+    position_seeds: &[&[u8]],
+) -> Result<()> {
+    // Note: Token-2022 program rejects the unfreeze instruction if the account is not frozen.
+    invoke_signed(
+        &spl_token_2022::instruction::thaw_account(
+            token_2022_program.key,
+            position_token_account.to_account_info().key,
+            position_mint.to_account_info().key,
+            &position.key(),
+            &[],
+        )?,
+        &[
+            token_2022_program.to_account_info(),
+            position_token_account.to_account_info(),
+            position_mint.to_account_info(),
+            position.to_account_info(),
+        ],
+        &[position_seeds],
+    )?;
+
+    Ok(())
+}
+
+pub fn transfer_user_position_token_2022<'info>(
+    authority: &Signer<'info>,
+    position_mint: &InterfaceAccount<'info, Mint>,
+    position_token_account: &InterfaceAccount<'info, TokenAccount>,
+    destination_token_account: &InterfaceAccount<'info, TokenAccount>,
+    token_2022_program: &Program<'info, Token2022>,
+) -> Result<()> {
+    invoke(
+        &spl_token_2022::instruction::transfer_checked(
+            token_2022_program.key,
+            position_token_account.to_account_info().key,
+            position_mint.to_account_info().key,
+            destination_token_account.to_account_info().key,
+            authority.key,
+            &[],
+            1,
+            position_mint.decimals,
+        )?,
+        &[
+            token_2022_program.to_account_info(),
+            position_token_account.to_account_info(),
+            position_mint.to_account_info(),
+            destination_token_account.to_account_info(),
+            authority.to_account_info(),
+        ],
+    )?;
+    Ok(())
+}
+
+pub fn close_empty_token_account_2022<'info>(
+    token_authority: &Signer<'info>,
+    token_account: &InterfaceAccount<'info, TokenAccount>,
+    token_2022_program: &Program<'info, Token2022>,
+    receiver: &AccountInfo<'info>,
+) -> Result<()> {
+    invoke(
+        &spl_token_2022::instruction::close_account(
+            token_2022_program.key,
+            token_account.to_account_info().key,
+            receiver.key,
+            token_authority.key,
+            &[],
+        )?,
+        &[
+            token_2022_program.to_account_info(),
+            token_account.to_account_info(),
+            receiver.to_account_info(),
+            token_authority.to_account_info(),
+        ],
+    )?;
+
+    Ok(())
+}


### PR DESCRIPTION
The initial LL implementation doesn't allow locking concentrated positions. (non FullRange positions)

This was not technical limitation.
This restriction was introduced to simplify the calculation of the proportion of locked liquidity.
We will relax the restriction in the contract.

Note: PR79 on dev repo

## tweak
- no tweak

## conflicts
- no conflict
- no error code conflict
