### PR TITLE
Fix "Transaction failed to sanitize accounts offsets" by matching signature count in simulations

### DIFF
--- a/.changeset/dry-games-walk.md
+++ b/.changeset/dry-games-walk.md
@@ -1,0 +1,5 @@
+---
+"@orca-so/rust-tx-sender": patch
+---
+
+Fix transaction signature mismatch in simulation during compute unit estimation

--- a/.changeset/dry-games-walk.md
+++ b/.changeset/dry-games-walk.md
@@ -1,5 +1,5 @@
 ---
-"@orca-so/rust-tx-sender": patch
+"@orca-so/rust-tx-sender": major
 ---
 
-Fix transaction signature mismatch in simulation during compute unit estimation
+BREAKING: Changed build_transaction to accept signers array instead of single payer. Fixed transaction signature mismatch in compute unit estimation that caused "accounts offsets" errors.

--- a/.changeset/tall-views-visit.md
+++ b/.changeset/tall-views-visit.md
@@ -1,0 +1,5 @@
+---
+"@orca-so/whirlpools-docs": patch
+---
+
+Fix 'action' examples. Add additional_signers handling to Rust examples.

--- a/docs/rust/Cargo.lock
+++ b/docs/rust/Cargo.lock
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "orca_whirlpools_docs"
-version = "0.1.7"
+version = "0.2.0"
 dependencies = [
  "orca_whirlpools",
  "orca_whirlpools_client",

--- a/docs/whirlpool/docs/03-SDKs/03-Whirlpool Management/01-Create Pool.mdx
+++ b/docs/whirlpool/docs/03-SDKs/03-Whirlpool Management/01-Create Pool.mdx
@@ -101,15 +101,21 @@ Liquidity pools are a foundational concept in DeFi, enabling users to trade toke
             create_splash_pool_instructions(&rpc, token_a, token_b, initial_price, funder)
                 .await?;
 
+        // The instructions include new Tick Array accounts that need to be created
+        // and signed for with their corresponding Keypair.
+        let mut signers: Vec<&dyn Signer> = vec![&wallet];
+        signers.extend(result.additional_signers.iter().map(|kp| kp as &dyn Signer));
+
         println!("Pool Address: {:?}", result.pool_address);
         println!(
             "Initialization Cost: {} lamports",
             result.initialization_cost
         );
+        println!("Signers: {:?}", signers);
         
         let signature = build_and_send_transaction(
             result.instructions,
-            &[&wallet],
+            &signers,
             Some(CommitmentLevel::Confirmed),
             None, // No address lookup tables
         ).await?;
@@ -184,12 +190,13 @@ Liquidity pools are a foundational concept in DeFi, enabling users to trade toke
     <ReactMarkdown>{splashPoolSteps}</ReactMarkdown>
 
     ```tsx
-    import { createSplashPool, setWhirlpoolsConfig } from '@orca-so/whirlpools';
+    import { createSplashPool, setWhirlpoolsConfig, setRpc, setPayerFromBytes } from '@orca-so/whirlpools';
     import { generateKeyPairSigner, createSolanaRpc, devnet, address } from '@solana/kit';
+    import secret from "wallet.json";
 
     await setWhirlpoolsConfig('solanaDevnet');
-    const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
-    const wallet = await generateKeyPairSigner(); // CAUTION: This wallet is not persistent.
+    await setRpc('https://api.devnet.solana.com');
+    const signer = await setPayerFromBytes(new Uint8Array(secret));
 
     const tokenMintOne = address("So11111111111111111111111111111111111111112");
     const tokenMintTwo = address("BRjpCHtyQLNCo8gqRUr8jtdAj5AjPYQaoqbvcZiHok1k"); // devUSDC
@@ -200,7 +207,7 @@ Liquidity pools are a foundational concept in DeFi, enabling users to trade toke
         tokenMintOne,
         tokenMintTwo,
         initialPrice,
-        wallet
+        signer
     );
 
     // Use the callback to submit the transaction
@@ -214,12 +221,13 @@ Liquidity pools are a foundational concept in DeFi, enabling users to trade toke
     <ReactMarkdown>{concentratedLiquiditySteps}</ReactMarkdown>
 
     ```tsx
-    import { createConcentratedLiquidityPoolInstructions, setWhirlpoolsConfig } from '@orca-so/whirlpools';
+    import { createConcentratedLiquidityPoolInstructions, setWhirlpoolsConfig, setRpc, setPayerFromBytes } from '@orca-so/whirlpools';
     import { generateKeyPairSigner, createSolanaRpc, devnet, address } from '@solana/kit';
+    import secret from "wallet.json";
 
     await setWhirlpoolsConfig('solanaDevnet');
-    const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
-    const wallet = await generateKeyPairSigner(); // CAUTION: This wallet is not persistent.
+    await setRpc('https://api.devnet.solana.com');
+    const signer = await setPayerFromBytes(new Uint8Array(secret));
 
     const tokenMintOne = address("So11111111111111111111111111111111111111112");
     const tokenMintTwo = address("BRjpCHtyQLNCo8gqRUr8jtdAj5AjPYQaoqbvcZiHok1k"); // devUSDC
@@ -232,7 +240,7 @@ Liquidity pools are a foundational concept in DeFi, enabling users to trade toke
         tokenMintTwo,
         tickSpacing,
         initialPrice,
-        wallet
+        signer
     );
 
     // Use the callback to submit the transaction

--- a/docs/whirlpool/docs/03-SDKs/04-Position Management/01-Open Position.mdx
+++ b/docs/whirlpool/docs/03-SDKs/04-Position Management/01-Open Position.mdx
@@ -125,13 +125,19 @@ After opening a position, you can:
         Some(wallet.pubkey())
       ).await?;
 
+      // The instructions include the position mint and potentially a new token 
+      // account that needs to be created for WSOL.
+      let mut signers: Vec<&dyn Signer> = vec![&wallet];
+      signers.extend(result.additional_signers.iter().map(|kp| kp as &dyn Signer));
+      println!("Signers: {:?}", signers);
+
       println!("Quote token mac B: {:?}", result.quote.token_max_b);
       println!("Initialization cost: {:?}", result.initialization_cost);
       println!("Position mint: {:?}", result.position_mint);
       
       let signature = build_and_send_transaction(
           result.instructions,
-          &[&wallet],
+          &signers,
           Some(CommitmentLevel::Confirmed),
           None, // No address lookup tables
       ).await?;
@@ -177,13 +183,19 @@ After opening a position, you can:
         Some(wallet.pubkey())
       ).await?;
 
+      // The instructions include the position mint and potentially new token 
+      // accounts that need to be created and signed for with their corresponding Keypair.
+      let mut signers: Vec<&dyn Signer> = vec![&wallet];
+      signers.extend(result.additional_signers.iter().map(|kp| kp as &dyn Signer));
+
       println!("Quote token max B: {:?}", result.quote.token_est_b);
       println!("Initialization cost: {:?}", result.initialization_cost);
       println!("Position mint: {:?}", result.position_mint);
-      
+      println!("Signers: {:?}", signers);
+
       let signature = build_and_send_transaction(
           result.instructions,
-          &[&wallet],
+          &signers,
           Some(CommitmentLevel::Confirmed),
           None, // No address lookup tables
       ).await?;
@@ -245,12 +257,12 @@ After opening a position, you can:
 
     ```tsx
     import { openPosition, setWhirlpoolsConfig } from '@orca-so/whirlpools';
-    import { createSolanaRpc, devnet, address } from '@solana/kit';
-    import { loadWallet } from './utils';
+    import { createSolanaRpc, devnet, address, setRpc, setPayerFromBytes } from '@solana/kit';
+    import secret from "wallet.json";
 
     await setWhirlpoolsConfig('solanaDevnet');
-    const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
-    const wallet = await loadWallet(); // load your wallet
+    await setRpc('https://api.devnet.solana.com');
+    const signer = await setPayerFromBytes(new Uint8Array(secret));
 
     const whirlpoolAddress = address("3KBZiL2g8C7tiJ32hTv5v3KM7aK9htpqTw4cTXz1HvPt"); // SOL/devUSDC
 

--- a/docs/whirlpool/docs/03-SDKs/04-Position Management/02-Adjust Liquidity.mdx
+++ b/docs/whirlpool/docs/03-SDKs/04-Position Management/02-Adjust Liquidity.mdx
@@ -98,12 +98,18 @@ By using the SDK to adjust liquidity, you gain flexibility in managing your posi
         )
         .await?;
 
+        // The instructions may include new token accounts that need to be created
+        // and signed for with its corresponding Keypair.
+        let mut signers_increase: Vec<&dyn Signer> = vec![&wallet];
+        signers_increase.extend(increase_result.additional_signers.iter().map(|kp| kp as &dyn Signer));
+        println!("Signers: {:?}", signers_increase);
+
         println!("Liquidity Increase Quote: {:?}", increase_result.quote);
         println!("Number of Instructions: {}", increase_result.instructions.len());
         
         let increase_signature = build_and_send_transaction(
             increase_result.instructions,
-            &[&wallet],
+            &signers_increase,
             Some(CommitmentLevel::Confirmed),
             None, // No address lookup tables
         ).await?;
@@ -119,11 +125,17 @@ By using the SDK to adjust liquidity, you gain flexibility in managing your posi
         )
         .await?;
 
+        // The instructions may include new token accounts that need to be created
+        // and signed for with their corresponding Keypair.
+        let mut signers_decrease: Vec<&dyn Signer> = vec![&wallet];
+        signers_decrease.extend(decrease_result.additional_signers.iter().map(|kp| kp as &dyn Signer));
+
         println!("Liquidity Decrease Quote: {:?}", decrease_result.quote);
+        println!("Signers: {:?}", signers_decrease);
         
         let decrease_signature = build_and_send_transaction(
             decrease_result.instructions,
-            &[&wallet],
+            &signers_decrease,
             Some(CommitmentLevel::Confirmed),
             None, // No address lookup tables
         ).await?;
@@ -148,12 +160,13 @@ By using the SDK to adjust liquidity, you gain flexibility in managing your posi
 
     ```tsx
     import { decreaseLiquidity, increaseLiquidity, setWhirlpoolsConfig } from '@orca-so/whirlpools';
-    import { createSolanaRpc, devnet, address } from '@solana/kit';
-    import { loadWallet } from './utils';
+    import { createSolanaRpc, devnet, address, setRpc, setPayerFromBytes } from '@solana/kit';
+    import secret from "wallet.json";
 
     await setWhirlpoolsConfig('solanaDevnet');
-    const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
-    const wallet = await loadWallet();
+    await setRpc('https://api.devnet.solana.com');
+    const signer = await setPayerFromBytes(new Uint8Array(secret));
+
     const positionMint = address("HqoV7Qv27REUtmd9UKSJGGmCRNx3531t33bDG1BUfo9K");
     const param = { tokenA: 10n };
     
@@ -162,7 +175,7 @@ By using the SDK to adjust liquidity, you gain flexibility in managing your posi
         positionMint,
         param,
         100,
-        wallet
+        signer
     );
 
     const { quote: decreaseQuote, instructions: decreaseInstructions, callback: sendTxDecrease } = await decreaseLiquidity(
@@ -170,7 +183,7 @@ By using the SDK to adjust liquidity, you gain flexibility in managing your posi
         positionMint,
         param,
         100,
-        wallet
+        signer
     );
 
     console.log(`Increase quote estimated token B: ${increaseQuote.tokenEstB}`);

--- a/docs/whirlpool/docs/03-SDKs/04-Position Management/03-Harvest.mdx
+++ b/docs/whirlpool/docs/03-SDKs/04-Position Management/03-Harvest.mdx
@@ -84,13 +84,19 @@ By using the SDK, you can maximize the benefits of providing liquidity while kee
         let result = harvest_position_instructions(&rpc, position_mint_address, Some(wallet.pubkey()))
             .await?;
 
+        // The instructions may include new token accounts that need to be created
+        // and signed for with their corresponding Keypair.
+        let mut signers: Vec<&dyn Signer> = vec![&wallet];
+        signers.extend(result.additional_signers.iter().map(|kp| kp as &dyn Signer));
+
         println!("Fees Quote: {:?}", result.fees_quote);
         println!("Rewards Quote: {:?}", result.rewards_quote);
         println!("Number of Instructions: {}", result.instructions.len());
+        println!("Signers: {:?}", signers);
         
         let signature = build_and_send_transaction(
             result.instructions,
-            &[&wallet],
+            &signers,
             Some(CommitmentLevel::Confirmed),
             None, // No address lookup tables
         ).await?;
@@ -116,18 +122,18 @@ By using the SDK, you can maximize the benefits of providing liquidity while kee
 
     ```tsx
     import { harvestPosition, setWhirlpoolsConfig } from '@orca-so/whirlpools';
-    import { createSolanaRpc, devnet, address } from '@solana/kit';
-    import { loadWallet } from './utils';
+    import { createSolanaRpc, devnet, address, setRpc, setPayerFromBytes } from '@solana/kit';
+    import secret from "wallet.json";
 
     await setWhirlpoolsConfig('solanaDevnet');
-    const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
-    const wallet = await loadWallet();
+    await setRpc('https://api.devnet.solana.com');
+    const signer = await setPayerFromBytes(new Uint8Array(secret));
     const positionMint = address("HqoV7Qv27REUtmd9UKSJGGmCRNx3531t33bDG1BUfo9K");
 
     const { feesQuote, rewardsQuote, instructions, callback: sendTx } = await harvestPosition(
       devnetRpc,
       positionMint,
-      wallet
+      signer
     );
 
     // Use the callback to submit the transaction

--- a/docs/whirlpool/docs/03-SDKs/04-Position Management/04-Close Position.mdx
+++ b/docs/whirlpool/docs/03-SDKs/04-Position Management/04-Close Position.mdx
@@ -92,14 +92,21 @@ After closing a position, you can:
         )
         .await?;
 
+        // The instructions may include new token accounts that need to be created
+        // and signed for with their corresponding Keypair.
+        let mut signers: Vec<&dyn Signer> = vec![&wallet];
+        signers.extend(result.additional_signers.iter().map(|kp| kp as &dyn Signer));
+
         println!("Quote token max B: {:?}", result.quote.token_est_b);
         println!("Fees Quote: {:?}", result.fees_quote);
         println!("Rewards Quote: {:?}", result.rewards_quote);
         println!("Number of Instructions: {}", result.instructions.len());
+        println!("Signers: {:?}", signers);
+
         
         let signature = build_and_send_transaction(
             result.instructions,
-            &[&wallet],
+            &signers,
             Some(CommitmentLevel::Confirmed),
             None, // No address lookup tables
         ).await?;
@@ -125,19 +132,19 @@ After closing a position, you can:
 
     ```tsx
     import { closePosition, setWhirlpoolsConfig } from '@orca-so/whirlpools';
-    import { createSolanaRpc, devnet, address } from '@solana/kit';
-    import { loadWallet } from './utils';
+    import { createSolanaRpc, devnet, address, setRpc, setPayerFromBytes } from '@solana/kit';
+    import secret from "wallet.json";
 
     await setWhirlpoolsConfig('solanaDevnet');
-    const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
-    const wallet = await loadWallet();
+    await setRpc('https://api.devnet.solana.com');
+    const signer = await setPayerFromBytes(new Uint8Array(secret));
     const positionMint = address("HqoV7Qv27REUtmd9UKSJGGmCRNx3531t33bDG1BUfo9K");
 
     const { instructions, quote, feesQuote, rewardsQuote, callback: sendTx } = await closePosition(
       devnetRpc,
       positionMint,
       100,
-      wallet
+      signer
     );
 
     // Use the callback to submit the transaction 

--- a/docs/whirlpool/docs/03-SDKs/05-Trade.mdx
+++ b/docs/whirlpool/docs/03-SDKs/05-Trade.mdx
@@ -74,9 +74,22 @@ This guide explains how to use the SDK to perform a token swap in an Orca Whirlp
         .await
         .unwrap();
 
+        // The instructions may include new token accounts that need to be created
+        // and signed for with their corresponding Keypair.
+        let mut signers: Vec<&dyn Signer> = vec![&wallet];
+        signers.extend(result.additional_signers.iter().map(|kp| kp as &dyn Signer));
+
+        let signature = build_and_send_transaction(
+            result.instructions,
+            &signers,
+            Some(CommitmentLevel::Confirmed),
+            None, // No address lookup tables
+        ).await?;
+
         println!("Quote estimated token out: {:?}", result.quote);
         println!("Number of Instructions: {}", result.instructions.len());
-    }
+        println!("Signers: {:?}", signers);        
+        println!("Transaction sent: {}", signature);
     ```
 
     7. **Submit Transaction**: Include the generated instructions in a Solana transaction and send it to the network using the Solana SDK.
@@ -128,12 +141,12 @@ This guide explains how to use the SDK to perform a token swap in an Orca Whirlp
 
     ```tsx
     import { setWhirlpoolsConfig, swap } from '@orca-so/whirlpools';
-    import { createSolanaRpc, address } from '@solana/kit';
-    import { loadWallet } from './utils';
+    import { createSolanaRpc, address, setRpc, setPayerFromBytes } from '@solana/kit';
+    import secret from "wallet.json";
 
     await setWhirlpoolsConfig('solanaDevnet');
-    const devnetRpc = createSolanaRpc('https://api.devnet.solana.com');
-    const wallet = await loadWallet();
+    await setRpc('https://api.devnet.solana.com');
+    const signer = await setPayerFromBytes(new Uint8Array(secret));
     const whirlpoolAddress = address("3KBZiL2g8C7tiJ32hTv5v3KM7aK9htpqTw4cTXz1HvPt");
     const mintAddress = address("BRjpCHtyQLNCo8gqRUr8jtdAj5AjPYQaoqbvcZiHok1k");
     const inputAmount = 1_000_000n;
@@ -143,7 +156,7 @@ This guide explains how to use the SDK to perform a token swap in an Orca Whirlp
       { inputAmount, mint: mintAddress },
       whirlpoolAddress,
       100,
-      wallet
+      signer
     );
 
     // Use the callback to submit the transaction

--- a/docs/whirlpool/docs/03-SDKs/06-Send Transaction.mdx
+++ b/docs/whirlpool/docs/03-SDKs/06-Send Transaction.mdx
@@ -57,10 +57,14 @@ import TabItem from "@theme/TabItem";
             // Get instructions from Whirlpools SDK
             let instructions_result = // your whirlpool instructions here
 
+            // Some instructions may require additional signers
+            let mut signers: Vec<&dyn Signer> = vec![&wallet];
+            signers.extend(instructions_result.additional_signers.iter().map(|kp| kp as &dyn Signer));            
+            
             // Build and send transaction
             let signature = build_and_send_transaction(
                 instructions_result.instructions,
-                &[&wallet], // signers array including your wallet and any additional signers
+                &signers, // signers array including your wallet and any additional signers
                 Some(CommitmentLevel::Confirmed),
                 None, // No address lookup tables
             ).await?;

--- a/rust-sdk/tx-sender/src/compute_budget.rs
+++ b/rust-sdk/tx-sender/src/compute_budget.rs
@@ -8,6 +8,7 @@ use solana_rpc_client_api::response::RpcPrioritizationFee;
 use solana_sdk::address_lookup_table::AddressLookupTableAccount;
 use solana_sdk::compute_budget::ComputeBudgetInstruction;
 use solana_sdk::message::{v0::Message, VersionedMessage};
+use solana_sdk::signature::Signer;
 use solana_sdk::transaction::VersionedTransaction;
 
 /// Estimate compute units by simulating a transaction
@@ -15,6 +16,7 @@ pub async fn estimate_compute_units(
     rpc_client: &RpcClient,
     instructions: Vec<Instruction>,
     payer: &Pubkey,
+    signers: &[&dyn Signer],
     alts: Option<Vec<AddressLookupTableAccount>>,
 ) -> Result<u32, String> {
     let alt_accounts = alts.unwrap_or_default();
@@ -27,7 +29,7 @@ pub async fn estimate_compute_units(
         .map_err(|e| format!("Failed to compile message: {}", e))?;
 
     let transaction = VersionedTransaction {
-        signatures: vec![solana_sdk::signature::Signature::default()],
+        signatures: vec![solana_sdk::signature::Signature::default(); signers.len()],
         message: VersionedMessage::V0(message),
     };
 

--- a/rust-sdk/tx-sender/src/lib.rs
+++ b/rust-sdk/tx-sender/src/lib.rs
@@ -28,7 +28,7 @@ pub async fn build_and_send_transaction(
         .first()
         .ok_or_else(|| "At least one signer is required".to_string())?;
     // Build transaction with compute budget and priority fees
-    let mut tx = build_transaction(instructions, *payer, signers, address_lookup_tables).await?;
+    let mut tx = build_transaction(instructions, signers, address_lookup_tables).await?;
     // Serialize the message once instead of for each signer
     let serialized_message = tx.message.serialize();
     tx.signatures = signers
@@ -48,10 +48,13 @@ pub async fn build_and_send_transaction(
 /// 4. Supporting address lookup tables for account compression
 pub async fn build_transaction(
     mut instructions: Vec<Instruction>,
-    payer: &dyn Signer,
     signers: &[&dyn Signer],
     address_lookup_tables: Option<Vec<AddressLookupTableAccount>>,
 ) -> Result<VersionedTransaction, String> {
+    // Get the payer (first signer)
+    let payer = signers
+        .first()
+        .ok_or_else(|| "At least one signer is required".to_string())?;
     let config = config::get_global_config()
         .read()
         .map_err(|e| format!("Lock error: {}", e))?;

--- a/rust-sdk/tx-sender/src/lib.rs
+++ b/rust-sdk/tx-sender/src/lib.rs
@@ -28,7 +28,7 @@ pub async fn build_and_send_transaction(
         .first()
         .ok_or_else(|| "At least one signer is required".to_string())?;
     // Build transaction with compute budget and priority fees
-    let mut tx = build_transaction(instructions, *payer, address_lookup_tables).await?;
+    let mut tx = build_transaction(instructions, *payer, signers, address_lookup_tables).await?;
     // Serialize the message once instead of for each signer
     let serialized_message = tx.message.serialize();
     tx.signatures = signers
@@ -49,6 +49,7 @@ pub async fn build_and_send_transaction(
 pub async fn build_transaction(
     mut instructions: Vec<Instruction>,
     payer: &dyn Signer,
+    signers: &[&dyn Signer],
     address_lookup_tables: Option<Vec<AddressLookupTableAccount>>,
 ) -> Result<VersionedTransaction, String> {
     let config = config::get_global_config()
@@ -70,6 +71,7 @@ pub async fn build_transaction(
         &rpc_client,
         instructions.clone(),
         &payer.pubkey(),
+        signers,
         address_lookup_tables_clone,
     )
     .await?;


### PR DESCRIPTION
### Background
The tx-sender SDK encountered "Transaction failed to sanitize accounts offsets correctly" errors in certain multi-signer scenarios. We identified that the `estimate_compute_units` function was simulating transactions with a fixed signature count that didn't match the actual number of signers used in the final transaction, causing a mismatch between simulation and execution.

### Changes
- Added signers parameter to `estimate_compute_units` function to ensure consistent signature counts
- Updated transaction simulation to use `vec![Signature::default(); signers.len()]` for creating properly sized signature arrays
#### After comments:
- removed `payer` from `build_transaction` and kept `signers`, bringing it in line with `build_and_send_transaction`.
- Updated Rust docs with example handling of `additional_signers`.
- Fixed `actions` examples

### Testing
Manually verified that transactions with multiple signers now compile, sign, and submit correctly.