### PR TITLE
Align Rust SDK `collect_reward_quote` calculation with on-chain program

### DIFF
--- a/.changeset/silent-flowers-thank.md
+++ b/.changeset/silent-flowers-thank.md
@@ -1,0 +1,5 @@
+---
+"@orca-so/whirlpools-rust-core": patch
+---
+
+Fix error in collect_reward_quote where u64 mount owned could overflow. The fix reflects the logic used in the program and Legacy SDK.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "whirlpool"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/docs/rust/Cargo.lock
+++ b/docs/rust/Cargo.lock
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "orca_whirlpools_docs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "orca_whirlpools",
  "orca_whirlpools_client",

--- a/rust-sdk/core/src/math/tick_array.rs
+++ b/rust-sdk/core/src/math/tick_array.rs
@@ -6,7 +6,7 @@ use crate::{
 
 use super::{
     get_initializable_tick_index, get_next_initializable_tick_index,
-    get_prev_initializable_tick_index, get_tick_array_start_tick_index,
+    get_prev_initializable_tick_index,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -146,6 +146,7 @@ fn ticks(tick_array: &Option<TickArrayFacade>) -> &[TickFacade] {
 #[cfg(all(test, not(feature = "wasm")))]
 mod tests {
     use super::*;
+    use crate::get_tick_array_start_tick_index;
 
     fn test_tick(initialized: bool, liquidity_net: i128) -> TickFacade {
         TickFacade {

--- a/rust-sdk/core/src/quote/rewards.rs
+++ b/rust-sdk/core/src/quote/rewards.rs
@@ -47,7 +47,7 @@ pub fn collect_rewards_quote(
                 / whirlpool.liquidity;
             reward_growth += <u128>::try_from(reward_growth_delta).unwrap();
         }
-        println!("reward_growth: {}", reward_growth);
+
         let mut reward_growth_below = tick_lower.reward_growths_outside[i];
         let mut reward_growth_above = tick_upper.reward_growths_outside[i];
 
@@ -66,11 +66,9 @@ pub fn collect_rewards_quote(
         let reward_growth_delta =
             reward_growth_inside.wrapping_sub(position.reward_infos[i].growth_inside_checkpoint);
 
-        // Calculate reward_owed_delta using checked_mul_shift_right logic
         let reward_owed_delta = if reward_growth_delta == 0 || position.liquidity == 0 {
             0
         } else {
-            // If multiplication overflows, return 0 (matching on-chain behavior)
             let product = position
                 .liquidity
                 .checked_mul(reward_growth_delta)
@@ -78,7 +76,6 @@ pub fn collect_rewards_quote(
 
             (product >> 64) as u64
         };
-        println!("reward_owed_delta: {}", reward_owed_delta);
         let withdrawable_reward = position.reward_infos[i].amount_owed + reward_owed_delta;
 
         let rewards_owed =

--- a/rust-sdk/tx-sender/Cargo.lock
+++ b/rust-sdk/tx-sender/Cargo.lock
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "orca_tx_sender"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "reqwest",
  "serde",

--- a/ts-sdk/core/tests/smoke.test.ts
+++ b/ts-sdk/core/tests/smoke.test.ts
@@ -179,8 +179,8 @@ describe("WASM bundle smoke test", () => {
       { feeBps: 2000, maxFee: 100000n },
       { feeBps: 3000, maxFee: 100000n },
     );
-    assert.strictEqual(result.rewards[0].rewardsOwed, 21690n);
-    assert.strictEqual(result.rewards[1].rewardsOwed, 22560n);
-    assert.strictEqual(result.rewards[2].rewardsOwed, 22610n);
+    assert.strictEqual(result.rewards[0].rewardsOwed, 90n);
+    assert.strictEqual(result.rewards[1].rewardsOwed, 160n);
+    assert.strictEqual(result.rewards[2].rewardsOwed, 210n);
   });
 });


### PR DESCRIPTION
This PR aligns the calculation for reward collection with that of the on-chain program and the Legacy SDK.

**Before**:
- `liquidity` × `reward_growth` multiplication in `U256`
- Cast result to `U64`

This led to a bug where the casting would throw an overflow error.

**Now**:
- `liquidity` × `reward_growth` multiplication in `U128`
- Bit shift right by 64
  - Returns 0 if overflow (matching on-chain behavior)
- Cast to `U64`

**Testing**:
- Expected values in tests are verified against the `collectRewardQuote` function of the Legacy SDK
- Added test case to verify overflow handling behavior