### PR TITLE
Add swap feature flag to core sdk

### DIFF
--- a/.changeset/pretty-crabs-smoke.md
+++ b/.changeset/pretty-crabs-smoke.md
@@ -1,0 +1,5 @@
+---
+"@orca-so/whirlpools-rust-core": patch
+---
+
+Add 'swap' feature that enables/disables swap quote. These functions cannot be used on-chain as they would cause a stack overflow. By disabling this feature on-chain you can remove stack-overflow errors when building an on-chain program.

--- a/rust-sdk/core/Cargo.toml
+++ b/rust-sdk/core/Cargo.toml
@@ -12,9 +12,10 @@ authors = ["team@orca.so"]
 edition = "2021"
 
 [features]
-default = ["floats"]
+default = ["floats", "swap"]
 wasm = ["dep:wasm-bindgen", "dep:serde", "dep:serde-big-array", "dep:serde-wasm-bindgen", "dep:js-sys", "dep:tsify"]
 floats = ["dep:libm"]
+swap = []
 
 [dependencies]
 ethnum = { version = "^1.1" }

--- a/rust-sdk/core/src/math/mod.rs
+++ b/rust-sdk/core/src/math/mod.rs
@@ -1,8 +1,10 @@
 mod bundle;
 mod position;
 mod tick;
-mod tick_array;
 mod token;
+
+#[cfg(feature = "swap")]
+mod tick_array;
 
 #[cfg(feature = "floats")]
 mod price;
@@ -10,8 +12,11 @@ mod price;
 pub use bundle::*;
 pub use position::*;
 pub use tick::*;
-pub use tick_array::*;
+
 pub use token::*;
 
 #[cfg(feature = "floats")]
 pub use price::*;
+
+#[cfg(feature = "swap")]
+pub use tick_array::*;

--- a/rust-sdk/core/src/quote/mod.rs
+++ b/rust-sdk/core/src/quote/mod.rs
@@ -1,9 +1,13 @@
 mod fees;
 mod liquidity;
 mod rewards;
+
+#[cfg(feature = "swap")]
 mod swap;
 
 pub use fees::*;
 pub use liquidity::*;
 pub use rewards::*;
+
+#[cfg(feature = "swap")]
 pub use swap::*;

--- a/rust-sdk/core/src/types/mod.rs
+++ b/rust-sdk/core/src/types/mod.rs
@@ -5,12 +5,14 @@ mod position;
 mod rewards;
 mod swap;
 mod tick;
-mod tick_array;
 mod token;
 mod u128;
 
 #[cfg(feature = "wasm")]
 mod u64;
+
+#[cfg(feature = "swap")]
+mod tick_array;
 
 pub use fees::*;
 pub use liquidity::*;
@@ -19,9 +21,11 @@ pub use position::*;
 pub use rewards::*;
 pub use swap::*;
 pub use tick::*;
-pub use tick_array::*;
 pub use token::*;
 pub use u128::*;
 
 #[cfg(feature = "wasm")]
 pub use u64::*;
+
+#[cfg(feature = "swap")]
+pub use tick_array::*;


### PR DESCRIPTION
This feature flag allows not including the swap-quote functions. These functions throw stack-overflow errors when building on-chain. Excluding them by disabling the feature allows callers to remove these errors:

```
Error: Function _ZN4core5slice4sort25insertion_sort_shift_left17hbe22a8e5677a339dE Stack offset of 10568 exceeded max offset of 4096 by 6472 bytes, please minimize large stack variables. Estimated function frame size: 10592 bytes. Exceeding the maximum stack offset may cause undefined behavior during execution.
Error: Function _ZN20orca_whirlpools_core4math10tick_array26TickArraySequence$LT$_$GT$3new17h1e2b4d7697623b0bE Stack offset of 63296 exceeded max offset of 4096 by 59200 bytes, please minimize large stack variables. Estimated function frame size: 63408 bytes. Exceeding the maximum stack offset may cause undefined behavior during execution.
Error: Function _ZN20orca_whirlpools_core5quote4swap25swap_quote_by_input_token17h803c4c1b1c25eaefE Stack offset of 190424 exceeded max offset of 4096 by 186328 bytes, please minimize large stack variables. Estimated function frame size: 190512 bytes. Exceeding the maximum stack offset may cause undefined behavior during execution.
Error: A function call in method _ZN20orca_whirlpools_core5quote4swap25swap_quote_by_input_token17h803c4c1b1c25eaefE overwrites values in the frame. Please, decrease stack usage or remove parameters from the call.The function call may cause undefined behavior during execution.
Error: A function call in method _ZN20orca_whirlpools_core5quote4swap25swap_quote_by_input_token17h803c4c1b1c25eaefE overwrites values in the frame. Please, decrease stack usage or remove parameters from the call.The function call may cause undefined behavior during execution.
Error: Function _ZN20orca_whirlpools_core5quote4swap26swap_quote_by_output_token17hef5d9e837e447f9dE Stack offset of 190440 exceeded max offset of 4096 by 186344 bytes, please minimize large stack variables. Estimated function frame size: 190536 bytes. Exceeding the maximum stack offset may cause undefined behavior during execution.
Error: A function call in method _ZN20orca_whirlpools_core5quote4swap26swap_quote_by_output_token17hef5d9e837e447f9dE overwrites values in the frame. Please, decrease stack usage or remove parameters from the call.The function call may cause undefined behavior during execution.
Error: A function call in method _ZN20orca_whirlpools_core5quote4swap26swap_quote_by_output_token17hef5d9e837e447f9dE overwrites values in the frame. Please, decrease stack usage or remove parameters from the call.The function call may cause undefined behavior during execution.
```