### PR TITLE
add max compute unit limit to simulation instructions if none are provided

### DIFF
--- a/.changeset/ready-ads-sort.md
+++ b/.changeset/ready-ads-sort.md
@@ -2,4 +2,4 @@
 "@orca-so/rust-tx-sender": patch
 ---
 
-Add instruction with max compute unit limit for simulation if none are provided
+Add compute budget instructions during the build transaction process based on what is provided. Use max compute unit limit by default when simulating a transaction to estimate compute units.

--- a/.changeset/ready-ads-sort.md
+++ b/.changeset/ready-ads-sort.md
@@ -2,4 +2,4 @@
 "@orca-so/rust-tx-sender": patch
 ---
 
-Add compute budget instructions during the build transaction process based on what is provided. Use max compute unit limit by default when simulating a transaction to estimate compute units.
+Add instruction with max compute unit limit for simulation if none are provided

--- a/.changeset/ready-ads-sort.md
+++ b/.changeset/ready-ads-sort.md
@@ -1,0 +1,5 @@
+---
+"@orca-so/rust-tx-sender": patch
+---
+
+Add instruction with max compute unit limit for simulation if none are provided

--- a/rust-sdk/tx-sender/Cargo.lock
+++ b/rust-sdk/tx-sender/Cargo.lock
@@ -486,11 +486,11 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.5.5"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5430e3be710b68d984d1391c854eb431a9d548640711faa54eecb1df93db91cc"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
 dependencies = [
- "borsh-derive 1.5.5",
+ "borsh-derive 1.5.7",
  "cfg_aliases 0.2.1",
 ]
 
@@ -509,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.5.5"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b668d39970baad5356d7c83a86fee3a539e6f93bf6764c97368243e17a0487"
+checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
 dependencies = [
  "once_cell",
  "proc-macro-crate 3.2.0",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "orca_tx_sender"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -3460,7 +3460,7 @@ dependencies = [
  "bitflags 2.9.0",
  "blake3",
  "borsh 0.10.4",
- "borsh 1.5.5",
+ "borsh 1.5.7",
  "bs58",
  "bv",
  "bytemuck",
@@ -3672,7 +3672,7 @@ checksum = "0317d412207639326f2393c935769d2d7429d0882d509d0dca8dc0bb55aca6a1"
 dependencies = [
  "bincode",
  "bitflags 2.9.0",
- "borsh 1.5.5",
+ "borsh 1.5.7",
  "bs58",
  "bytemuck",
  "bytemuck_derive",
@@ -3830,7 +3830,7 @@ dependencies = [
  "Inflector",
  "base64 0.22.1",
  "bincode",
- "borsh 1.5.5",
+ "borsh 1.5.7",
  "bs58",
  "lazy_static",
  "log",
@@ -3985,7 +3985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68034596cf4804880d265f834af1ff2f821ad5293e41fa0f8f59086c181fc38e"
 dependencies = [
  "assert_matches",
- "borsh 1.5.5",
+ "borsh 1.5.7",
  "num-derive",
  "num-traits",
  "solana-program",
@@ -4044,7 +4044,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c704c88fc457fa649ba3aabe195c79d885c3f26709efaddc453c8de352c90b87"
 dependencies = [
- "borsh 1.5.5",
+ "borsh 1.5.7",
  "bytemuck",
  "bytemuck_derive",
  "solana-program",
@@ -4149,7 +4149,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6c2318ddff97e006ed9b1291ebec0750a78547f870f62a69c56fe3b46a5d8fc"
 dependencies = [
- "borsh 1.5.5",
+ "borsh 1.5.7",
  "solana-program",
  "spl-discriminator",
  "spl-pod",

--- a/rust-sdk/tx-sender/Cargo.lock
+++ b/rust-sdk/tx-sender/Cargo.lock
@@ -2332,7 +2332,6 @@ dependencies = [
 name = "orca_tx_sender"
 version = "2.0.0"
 dependencies = [
- "borsh 1.5.7",
  "reqwest",
  "serde",
  "serde_json",

--- a/rust-sdk/tx-sender/Cargo.lock
+++ b/rust-sdk/tx-sender/Cargo.lock
@@ -2332,6 +2332,7 @@ dependencies = [
 name = "orca_tx_sender"
 version = "2.0.0"
 dependencies = [
+ "borsh 1.5.7",
  "reqwest",
  "serde",
  "serde_json",

--- a/rust-sdk/tx-sender/Cargo.toml
+++ b/rust-sdk/tx-sender/Cargo.toml
@@ -21,6 +21,7 @@ reqwest = { version = "0.11.27", features = ["json", "stream"] }
 tokio = { version = "1.37.0", features = ["full"] }
 serde = { version = "1.0.202", features = ["derive"] }
 serde_json = { version = "^1.0" }
+borsh = { version = "1.5.7" }
 
 [dev-dependencies]
 solana-cli-config = { version = ">=1.16, <3.0" }

--- a/rust-sdk/tx-sender/Cargo.toml
+++ b/rust-sdk/tx-sender/Cargo.toml
@@ -21,7 +21,6 @@ reqwest = { version = "0.11.27", features = ["json", "stream"] }
 tokio = { version = "1.37.0", features = ["full"] }
 serde = { version = "1.0.202", features = ["derive"] }
 serde_json = { version = "^1.0" }
-borsh = { version = "1.5.7" }
 
 [dev-dependencies]
 solana-cli-config = { version = ">=1.16, <3.0" }

--- a/rust-sdk/tx-sender/src/compute_budget.rs
+++ b/rust-sdk/tx-sender/src/compute_budget.rs
@@ -11,53 +11,6 @@ use solana_sdk::message::{v0::Message, VersionedMessage};
 use solana_sdk::transaction::VersionedTransaction;
 
 const SET_COMPUTE_UNIT_LIMIT_DISCRIMINATOR: u8 = 0x02;
-const SET_COMPUTE_UNIT_PRICE_DISCRIMINATOR: u8 = 0x03;
-
-/// Calculate and return compute budget instructions for a transaction
-pub async fn get_compute_budget_instructions(
-    rpc_client: &RpcClient,
-    instructions: &[Instruction],
-    payer: &Pubkey,
-    alts: Option<Vec<AddressLookupTableAccount>>,
-    rpc_config: &RpcConfig,
-    fee_config: &FeeConfig,
-) -> Result<Vec<Instruction>, String> {
-    let existing = extract_compute_budget_ixs(instructions);
-    let has_unit_limit = existing
-        .iter()
-        .any(|ix| matches!(ix, ComputeBudgetInstruction::SetComputeUnitLimit(_)));
-    let has_unit_price = existing
-        .iter()
-        .any(|ix| matches!(ix, ComputeBudgetInstruction::SetComputeUnitPrice(_)));
-    if has_unit_limit && has_unit_price {
-        return Ok(Vec::new());
-    }
-
-    let mut compute_budget_instructions = Vec::with_capacity(2);
-    if !has_unit_limit {
-        let compute_units =
-            estimate_compute_units(rpc_client, instructions, payer, alts.clone()).await?;
-        compute_budget_instructions.push(generate_compute_unit_limit_ix(
-            compute_units,
-            fee_config.compute_unit_margin_multiplier,
-        ));
-    }
-
-    if !has_unit_price {
-        if let Some(price_ix) = generate_compute_unit_price_ix(
-            rpc_client,
-            rpc_config,
-            &get_writable_accounts(instructions),
-            &fee_config.priority_fee,
-        )
-        .await?
-        {
-            compute_budget_instructions.push(price_ix);
-        }
-    }
-
-    Ok(compute_budget_instructions)
-}
 
 /// Estimate compute units by simulating a transaction
 pub async fn estimate_compute_units(
@@ -73,11 +26,7 @@ pub async fn estimate_compute_units(
         .map_err(|e| format!("Failed to get recent blockhash: {}", e))?;
 
     let mut simulation_instructions = instructions.to_vec();
-    let compute_budget_instructions = extract_compute_budget_ixs(instructions);
-    let has_unit_limit = compute_budget_instructions
-        .iter()
-        .any(|ix| matches!(ix, ComputeBudgetInstruction::SetComputeUnitLimit(_)));
-    if !has_unit_limit {
+    if extract_compute_unit_limit(&instructions).is_none() {
         simulation_instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(1_400_000));
     }
 
@@ -116,6 +65,51 @@ pub async fn estimate_compute_units(
         }
         Err(e) => Err(format!("Transaction simulation failed: {}", e)),
     }
+}
+
+/// Calculate and return compute budget instructions for a transaction
+pub async fn get_compute_budget_instruction(
+    client: &RpcClient,
+    compute_units: u32,
+    _payer: &Pubkey,
+    rpc_config: &RpcConfig,
+    fee_config: &FeeConfig,
+    writable_accounts: &[Pubkey],
+) -> Result<Vec<Instruction>, String> {
+    let mut budget_instructions = Vec::new();
+    let compute_units_with_margin =
+        (compute_units as f64 * (fee_config.compute_unit_margin_multiplier)) as u32;
+
+    budget_instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(
+        compute_units_with_margin,
+    ));
+
+    match &fee_config.priority_fee {
+        PriorityFeeStrategy::Dynamic {
+            percentile,
+            max_lamports,
+        } => {
+            let fee =
+                calculate_dynamic_priority_fee(client, rpc_config, writable_accounts, *percentile)
+                    .await?;
+            let clamped_fee = std::cmp::min(fee, *max_lamports);
+
+            if clamped_fee > 0 {
+                budget_instructions.push(ComputeBudgetInstruction::set_compute_unit_price(
+                    clamped_fee,
+                ));
+            }
+        }
+        PriorityFeeStrategy::Exact(lamports) => {
+            if *lamports > 0 {
+                budget_instructions
+                    .push(ComputeBudgetInstruction::set_compute_unit_price(*lamports));
+            }
+        }
+        PriorityFeeStrategy::Disabled => {}
+    }
+
+    Ok(budget_instructions)
 }
 
 /// Calculate dynamic priority fee based on recent fees
@@ -216,135 +210,37 @@ pub fn get_writable_accounts(instructions: &[Instruction]) -> Vec<Pubkey> {
     writable.into_iter().collect()
 }
 
-/// Return ComputeBudgetInstruction enum variants from a list of instructions
-pub fn extract_compute_budget_ixs(instructions: &[Instruction]) -> Vec<ComputeBudgetInstruction> {
-    instructions
-        .iter()
-        .filter(|ix| ix.program_id == solana_sdk::compute_budget::ID)
-        .map(to_compute_budget_instruction)
-        .filter_map(|ix| ix)
-        .collect()
-}
-
-/// Manually convert an instruction to a compute budget instruction, avoid
-fn to_compute_budget_instruction(ix: &Instruction) -> Option<ComputeBudgetInstruction> {
-    let discriminator = ix.data.first();
-    if discriminator == Some(&SET_COMPUTE_UNIT_LIMIT_DISCRIMINATOR) {
-        let limit_bytes_array: [u8; 4] = ix.data.get(1..5)?.try_into().ok()?;
-        return Some(ComputeBudgetInstruction::SetComputeUnitLimit(
-            u32::from_le_bytes(limit_bytes_array),
-        ));
-    } else if discriminator == Some(&SET_COMPUTE_UNIT_PRICE_DISCRIMINATOR) {
-        let price_bytes_array: [u8; 8] = ix.data.get(1..9)?.try_into().ok()?;
-        return Some(ComputeBudgetInstruction::SetComputeUnitPrice(
-            u64::from_le_bytes(price_bytes_array),
-        ));
-    } else {
-        return None;
-    }
-}
-
-/// Create a compute budget unit limit instruction
-fn generate_compute_unit_limit_ix(compute_units: u32, margin_multiplier: f64) -> Instruction {
-    let units_with_margin = (compute_units as f64 * margin_multiplier) as u32;
-    ComputeBudgetInstruction::set_compute_unit_limit(units_with_margin)
-}
-
-/// Create a compute budget unit price instruction
-async fn generate_compute_unit_price_ix(
-    client: &RpcClient,
-    rpc_config: &RpcConfig,
-    writable_accounts: &[Pubkey],
-    priority_fee: &PriorityFeeStrategy,
-) -> Result<Option<Instruction>, String> {
-    match priority_fee {
-        PriorityFeeStrategy::Disabled => Ok(None),
-
-        PriorityFeeStrategy::Exact(lamports) => {
-            if *lamports > 0 {
-                Ok(Some(ComputeBudgetInstruction::set_compute_unit_price(
-                    *lamports,
-                )))
+/// Extract the compute unit limit from a list of instructions
+fn extract_compute_unit_limit(instructions: &[Instruction]) -> Option<u32> {
+    for ix in instructions {
+        if ix.program_id == solana_sdk::compute_budget::ID {
+            if ix.data.first() == Some(&SET_COMPUTE_UNIT_LIMIT_DISCRIMINATOR) {
+                let limit_bytes_array: [u8; 4] = ix.data.get(1..5)?.try_into().ok()?;
+                return Some(u32::from_le_bytes(limit_bytes_array));
             } else {
-                Ok(None)
-            }
-        }
-
-        PriorityFeeStrategy::Dynamic {
-            percentile,
-            max_lamports,
-        } => {
-            let fee =
-                calculate_dynamic_priority_fee(client, rpc_config, writable_accounts, *percentile)
-                    .await?;
-            let clamped = std::cmp::min(fee, *max_lamports);
-            if clamped > 0 {
-                Ok(Some(ComputeBudgetInstruction::set_compute_unit_price(
-                    clamped,
-                )))
-            } else {
-                Ok(None)
+                return None;
             }
         }
     }
+    None
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solana_sdk::signature::Signer;
-    use solana_sdk::signer::keypair::Keypair;
-    use solana_sdk::system_instruction;
-    use solana_sdk::system_program;
 
-    #[test]
-    fn test_get_writable_accounts() {
-        let keypair = Keypair::new();
-        let recipient = Keypair::new().pubkey();
-
-        let instructions = vec![system_instruction::transfer(
-            &keypair.pubkey(),
-            &recipient,
-            1_000_000,
-        )];
-
-        let writable_accounts = get_writable_accounts(&instructions);
-        assert_eq!(writable_accounts.len(), 2);
-        assert!(writable_accounts.contains(&keypair.pubkey()));
-        assert!(writable_accounts.contains(&recipient));
+    #[tokio::test]
+    async fn test_extract_compute_unit_limit() {
+        let instructions = vec![];
+        let compute_unit_limit = extract_compute_unit_limit(&instructions);
+        assert_eq!(compute_unit_limit, None);
     }
 
-    #[test]
-    fn test_to_compute_budget_instruction_none() {
-        let non_cb_ix = Instruction {
-            program_id: system_program::id(),
-            accounts: vec![],
-            data: vec![],
-        };
-        assert!(to_compute_budget_instruction(&non_cb_ix).is_none());
-    }
+    #[tokio::test]
+    async fn test_extract_compute_unit_limit_with_limit() {
+        let instructions = vec![ComputeBudgetInstruction::set_compute_unit_limit(1_400_000)];
 
-    #[test]
-    fn test_to_compute_budget_instruction_set_compute_unit_limit() {
-        let limit = 1_500_000u32;
-        let ix = ComputeBudgetInstruction::set_compute_unit_limit(limit);
-
-        let result = to_compute_budget_instruction(&ix);
-        assert_eq!(
-            result,
-            Some(ComputeBudgetInstruction::SetComputeUnitLimit(limit))
-        );
-    }
-
-    #[test]
-    fn test_to_compute_budget_instruction_set_compute_unit_price() {
-        let price = 5_000u64;
-        let ix = ComputeBudgetInstruction::set_compute_unit_price(price);
-
-        let result = to_compute_budget_instruction(&ix);
-        assert_eq!(
-            result,
-            Some(ComputeBudgetInstruction::SetComputeUnitPrice(price))
-        );
+        let compute_unit_limit = extract_compute_unit_limit(&instructions);
+        assert_eq!(compute_unit_limit, Some(1_400_000));
     }
 }

--- a/rust-sdk/tx-sender/src/compute_budget.rs
+++ b/rust-sdk/tx-sender/src/compute_budget.rs
@@ -10,10 +10,12 @@ use solana_sdk::compute_budget::ComputeBudgetInstruction;
 use solana_sdk::message::{v0::Message, VersionedMessage};
 use solana_sdk::transaction::VersionedTransaction;
 
+const SET_COMPUTE_UNIT_LIMIT_DISCRIMINATOR: u8 = 0x02;
+
 /// Estimate compute units by simulating a transaction
 pub async fn estimate_compute_units(
     rpc_client: &RpcClient,
-    instructions: Vec<Instruction>,
+    instructions: &[Instruction],
     payer: &Pubkey,
     alts: Option<Vec<AddressLookupTableAccount>>,
 ) -> Result<u32, String> {
@@ -23,7 +25,15 @@ pub async fn estimate_compute_units(
         .await
         .map_err(|e| format!("Failed to get recent blockhash: {}", e))?;
 
-    let message = Message::try_compile(payer, &instructions, &alt_accounts, blockhash)
+    let mut simulation_instructions = instructions.to_vec();
+    if extract_compute_unit_limit(&instructions).is_none() {
+        simulation_instructions.insert(
+            0,
+            ComputeBudgetInstruction::set_compute_unit_limit(1_400_000),
+        );
+    }
+
+    let message = Message::try_compile(payer, &simulation_instructions, &alt_accounts, blockhash)
         .map_err(|e| format!("Failed to compile message: {}", e))?;
 
     let transaction = VersionedTransaction {
@@ -201,4 +211,39 @@ pub fn get_writable_accounts(instructions: &[Instruction]) -> Vec<Pubkey> {
     }
 
     writable.into_iter().collect()
+}
+
+/// Extract the compute unit limit from a list of instructions
+fn extract_compute_unit_limit(instructions: &[Instruction]) -> Option<u32> {
+    for ix in instructions {
+        if ix.program_id == solana_sdk::compute_budget::ID {
+            if ix.data.first() == Some(&SET_COMPUTE_UNIT_LIMIT_DISCRIMINATOR) {
+                let limit_bytes_array: [u8; 4] = ix.data.get(1..5)?.try_into().ok()?;
+                return Some(u32::from_le_bytes(limit_bytes_array));
+            } else {
+                return None;
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_extract_compute_unit_limit() {
+        let instructions = vec![];
+        let compute_unit_limit = extract_compute_unit_limit(&instructions);
+        assert_eq!(compute_unit_limit, None);
+    }
+
+    #[tokio::test]
+    async fn test_extract_compute_unit_limit_with_limit() {
+        let instructions = vec![ComputeBudgetInstruction::set_compute_unit_limit(1_400_000)];
+
+        let compute_unit_limit = extract_compute_unit_limit(&instructions);
+        assert_eq!(compute_unit_limit, Some(1_400_000));
+    }
 }

--- a/rust-sdk/tx-sender/src/lib.rs
+++ b/rust-sdk/tx-sender/src/lib.rs
@@ -109,16 +109,29 @@ pub async fn build_transaction_with_config(
         .await
         .map_err(|e| format!("RPC Error: {}", e))?;
 
-    let budget_ixs = compute_budget::get_compute_budget_instructions(
+    let writable_accounts = compute_budget::get_writable_accounts(&instructions);
+
+    let address_lookup_tables_clone = address_lookup_tables.clone();
+
+    let compute_units = compute_budget::estimate_compute_units(
         rpc_client,
         &instructions,
-        payer,
-        address_lookup_tables.clone(),
-        rpc_config,
-        fee_config,
+        &payer,
+        address_lookup_tables_clone,
     )
     .await?;
-    budget_ixs.into_iter().for_each(|ix| instructions.push(ix));
+    let budget_instructions = compute_budget::get_compute_budget_instruction(
+        rpc_client,
+        compute_units,
+        &payer,
+        rpc_config,
+        fee_config,
+        &writable_accounts,
+    )
+    .await?;
+    for (i, budget_ix) in budget_instructions.into_iter().enumerate() {
+        instructions.insert(i, budget_ix);
+    }
     // Check if network is mainnet before adding Jito tip
     if fee_config.jito != JitoFeeStrategy::Disabled {
         if !rpc_config.is_mainnet() {
@@ -128,11 +141,11 @@ pub async fn build_transaction_with_config(
         }
     }
     // Create versioned transaction message based on whether ALTs are provided
-    let message = if let Some(address_lookup_tables) = address_lookup_tables {
+    let message = if let Some(address_lookup_tables_clone) = address_lookup_tables {
         Message::try_compile(
             &payer,
             &instructions,
-            &address_lookup_tables,
+            &address_lookup_tables_clone,
             recent_blockhash,
         )
         .map_err(|e| format!("Failed to compile message with ALTs: {}", e))?
@@ -274,6 +287,26 @@ pub async fn send_transaction(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::compute_budget;
+    use solana_sdk::signature::{Keypair, Signer};
+    use solana_sdk::system_instruction;
+
+    #[test]
+    fn test_get_writable_accounts() {
+        let keypair = Keypair::new();
+        let recipient = Keypair::new().pubkey();
+
+        let instructions = vec![system_instruction::transfer(
+            &keypair.pubkey(),
+            &recipient,
+            1_000_000,
+        )];
+
+        let writable_accounts = compute_budget::get_writable_accounts(&instructions);
+        assert_eq!(writable_accounts.len(), 2);
+        assert!(writable_accounts.contains(&keypair.pubkey()));
+        assert!(writable_accounts.contains(&recipient));
+    }
 
     #[test]
     fn test_fee_config_default() {

--- a/rust-sdk/tx-sender/src/lib.rs
+++ b/rust-sdk/tx-sender/src/lib.rs
@@ -115,7 +115,7 @@ pub async fn build_transaction_with_config(
 
     let compute_units = compute_budget::estimate_compute_units(
         rpc_client,
-        instructions.clone(),
+        &instructions,
         &payer,
         address_lookup_tables_clone,
     )


### PR DESCRIPTION
# Description

- **Problem**: If compute budget instructions are not provided during simulation, the max compute allowed is 400k. This will cause any simulation with compute unit intensive instructions to fail, which means that calls to `build_transaction` and `build_transaction_with_config` will fail.
- **Solution**: Parse provided instructions and add a compute budget instruction with max units if none exist.
- I ran into borsh versions issues in consuming packages due to the range of allowed solana related crate versions (sample errors below). After like ~1 hour of continuously failing, I pivoted and tried a different approach. The implementation is less maintainable than using `ComputeBudgetInstruction` and borsh directly, but I thought it might be an acceptable trade-off since the logic is consolidated and would allow us to avoid copying the struct and adding borsh as a direct dependency in Cargo.toml.

**Version errors**

These were commands were run from kelpfarm:

```bash
kelpfarm % cargo tree -i borsh
error: There are multiple `borsh` packages in your project, and the specification `borsh` is ambiguous.
Please re-run this command with one of the following specifications:
  borsh@0.9.3
  borsh@0.10.4
  borsh@1.5.7

kelpfarm % cargo update borsh@1.5.7 --precise 0.10.4
    Updating crates.io index
error: failed to select a version for the requirement `borsh = "^1.3.1"`
candidate versions found which didn't match: 0.10.4
location searched: crates.io index
required by package `anchor-lite v0.1.0 (/Users/jacobshiohira/projects/solana/orca/kelpfarm/crates/anchor-lite)`

kelpfarm % cargo update borsh@0.10.4 --precise 1.5.7
    Updating crates.io index
error: failed to select a version for the requirement `borsh = "^0.10"`
candidate versions found which didn't match: 1.5.7
location searched: crates.io index
required by package `orca_whirlpools_client v1.0.3`
    ... which satisfies dependency `orca_whirlpools_client = "^1.0.2"` (locked to 1.0.3) of package `beachhouse-server v0.1.0 (/Users/jacobshiohira/projects/solana/orca/kelpfarm/crates/beachhouse-server)`
```

# Testing

Added unit tests for parsing compute unit limit from a list of provided instructions