### PR TITLE
Reduce stack size usage on initializePoolWithAdaptiveFee

### DIFF
--- a/.changeset/true-items-cross.md
+++ b/.changeset/true-items-cross.md
@@ -1,0 +1,5 @@
+---
+"@orca-so/whirlpools-program": patch
+---
+
+Reduce stack usage in initializePoolWithAdaptiveFee

--- a/programs/whirlpool/src/instructions/adaptive_fee/initialize_pool_with_adaptive_fee.rs
+++ b/programs/whirlpool/src/instructions/adaptive_fee/initialize_pool_with_adaptive_fee.rs
@@ -12,8 +12,8 @@ use crate::{
 pub struct InitializePoolWithAdaptiveFee<'info> {
     pub whirlpools_config: Box<Account<'info, WhirlpoolsConfig>>,
 
-    pub token_mint_a: InterfaceAccount<'info, Mint>,
-    pub token_mint_b: InterfaceAccount<'info, Mint>,
+    pub token_mint_a: Box<InterfaceAccount<'info, Mint>>,
+    pub token_mint_b: Box<InterfaceAccount<'info, Mint>>,
 
     #[account(seeds = [b"token_badge", whirlpools_config.key().as_ref(), token_mint_a.key().as_ref()], bump)]
     /// CHECK: checked in the handler
@@ -64,7 +64,7 @@ pub struct InitializePoolWithAdaptiveFee<'info> {
     pub token_vault_b: Box<InterfaceAccount<'info, TokenAccount>>,
 
     #[account(has_one = whirlpools_config)]
-    pub adaptive_fee_tier: Account<'info, AdaptiveFeeTier>,
+    pub adaptive_fee_tier: Box<Account<'info, AdaptiveFeeTier>>,
 
     #[account(address = *token_mint_a.to_account_info().owner)]
     pub token_program_a: Interface<'info, TokenInterface>,

--- a/programs/whirlpool/src/instructions/v2/swap.rs
+++ b/programs/whirlpool/src/instructions/v2/swap.rs
@@ -4,7 +4,7 @@ use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
 
 use crate::util::{
     calculate_transfer_fee_excluded_amount, calculate_transfer_fee_included_amount,
-    parse_remaining_accounts, token, AccountsType, RemainingAccountsInfo,
+    parse_remaining_accounts, AccountsType, RemainingAccountsInfo,
 };
 use crate::{
     constants::transfer_memo,


### PR DESCRIPTION
stack usage on initializePoolWithAdaptiveFee: 4040 bytes -> 3672 bytes

4040 is less than 4KB, but `access violation` error has been detected in mainnet.
(but not detected on solana-test-validator)

rsp operation check (this fix is included)
[Stack size est - try_accounts check.pdf](https://github.com/user-attachments/files/20162591/Stack.size.est.-.try_accounts.check.pdf)
