### PR TITLE
[DO NOT MERGE] Relax DefaultAccountState extension restriction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "whirlpool"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/programs/whirlpool/src/util/v2/token.rs
+++ b/programs/whirlpool/src/util/v2/token.rs
@@ -277,15 +277,6 @@ pub fn is_supported_token_mint(
                 if !is_token_badge_initialized {
                     return Ok(false);
                 }
-
-                // reject if default state is not Initialized even if it has token badge
-                let default_state = token_mint_unpacked
-                    .get_extension::<extension::default_account_state::DefaultAccountState>(
-                )?;
-                let initialized: u8 = AccountState::Initialized.into();
-                if default_state.state != initialized {
-                    return Ok(false);
-                }
             }
             // No possibility to support the following extensions
             extension::ExtensionType::NonTransferable => {


### PR DESCRIPTION
Just for devnet release
program hash: `711b2d795b4cf39eaa91f4f08b095fea905d9ef6017c0c00fde4a28789bb2d13`

```
$ solana program show whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc

Program Id: whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc
Owner: BPFLoaderUpgradeab1e11111111111111111111111
ProgramData Address: CtXfPzz36dH5Ws4UYKZvrQ1Xqzn42ecDW6y8NKuiN8nD
Authority: 8rHQUMS8qg4qrQriPpTbrZqk2yjLrUHSLpA6MzgMSiM
Last Deployed In Slot: 383414379
Data Length: 1405440 (0x157200) bytes
Balance: 9.78306648 SOL

$ solana-verify get-program-hash -ud whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc
711b2d795b4cf39eaa91f4f08b095fea905d9ef6017c0c00fde4a28789bb2d13
```