### PR TITLE
No need to hold a reference to a mutex during an async call

### DIFF
--- a/rust-sdk/whirlpool/Cargo.lock
+++ b/rust-sdk/whirlpool/Cargo.lock
@@ -2594,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "orca_whirlpools"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "async-trait",
  "base64 0.20.0",

--- a/rust-sdk/whirlpool/Cargo.toml
+++ b/rust-sdk/whirlpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orca_whirlpools"
-version = "3.1.0"
+version = "3.1.1"
 description = "Orca's high-level rust sdk to interact with Orca's on-chain Whirlpool program."
 include = ["src/*"]
 documentation = "https://dev.orca.so/"

--- a/rust-sdk/whirlpool/src/create_pool.rs
+++ b/rust-sdk/whirlpool/src/create_pool.rs
@@ -221,21 +221,15 @@ pub async fn create_concentrated_liquidity_pool_instructions(
 
     let initial_sqrt_price: u128 = price_to_sqrt_price(initial_price, decimals_a, decimals_b);
 
-    let pool_address = get_whirlpool_address(
-        &*WHIRLPOOLS_CONFIG_ADDRESS.try_lock()?,
-        &token_a,
-        &token_b,
-        tick_spacing,
-    )?
-    .0;
+    let whirlpools_config_address = *WHIRLPOOLS_CONFIG_ADDRESS.try_lock()?;
+    let pool_address =
+        get_whirlpool_address(&whirlpools_config_address, &token_a, &token_b, tick_spacing)?.0;
 
-    let fee_tier = get_fee_tier_address(&*WHIRLPOOLS_CONFIG_ADDRESS.try_lock()?, tick_spacing)?.0;
+    let fee_tier = get_fee_tier_address(&whirlpools_config_address, tick_spacing)?.0;
 
-    let token_badge_a =
-        get_token_badge_address(&*WHIRLPOOLS_CONFIG_ADDRESS.try_lock()?, &token_a)?.0;
+    let token_badge_a = get_token_badge_address(&whirlpools_config_address, &token_a)?.0;
 
-    let token_badge_b =
-        get_token_badge_address(&*WHIRLPOOLS_CONFIG_ADDRESS.try_lock()?, &token_b)?.0;
+    let token_badge_b = get_token_badge_address(&whirlpools_config_address, &token_b)?.0;
 
     let token_vault_a = Keypair::new();
     let token_vault_b = Keypair::new();
@@ -245,7 +239,7 @@ pub async fn create_concentrated_liquidity_pool_instructions(
 
     instructions.push(
         InitializePoolV2 {
-            whirlpools_config: *WHIRLPOOLS_CONFIG_ADDRESS.try_lock()?,
+            whirlpools_config: whirlpools_config_address,
             token_mint_a: token_a,
             token_mint_b: token_b,
             token_badge_a,


### PR DESCRIPTION
**Title**
Holding a reference to a `std::sync::Mutex` in an async function

**Details**
`WHIRLPOOLS_CONFIG_ADDRESS` is a `std::sync::Mutex` which is not `Send` so golding a reference to it in an async function will not work if that async funtion need to be sent to another thread.

It could use the [Mutex from tokio](https://docs.rs/tokio/latest/tokio/sync/struct.Mutex.html) (which implements `Send`), but since it does not really need to hold the reference, so it does not need to add a dependency I'm suggesting this change.
