### PR TITLE
Remove solana airdrop command (devnet is halted)

### DIFF
--- a/.github/actions/anchor/action.yml
+++ b/.github/actions/anchor/action.yml
@@ -72,7 +72,6 @@ runs:
         else
           echo "${{ inputs.solana-key }}" > ~/.config/solana/id.json
         fi
-        solana airdrop 1 || true
       shell: bash
     - name: Log Installed Tools
       run: |


### PR DESCRIPTION
Now devnet is halted (planned shutdown)
https://github.com/anza-xyz/agave/wiki/2025-07-03-Devnet-rollback-and-restart

The current github action contains `solana airdrop 1` (devnet) as quick check for Solana CLI installation.
But now devnet doesn't produce new block, so transaction will not land and  will not expire forever...

To unblock Publish action, I'd like to remove this check for now.