### PR TITLE
Fix: [Rust SDK] Dynamic TickArray handling in swap_instructions

### DIFF
--- a/.changeset/quiet-tires-repair.md
+++ b/.changeset/quiet-tires-repair.md
@@ -1,0 +1,5 @@
+---
+"@orca-so/whirlpools-rust": patch
+---
+
+Fix Dynamic TickArray handling in swap_instructions function

--- a/docs/rust/Cargo.lock
+++ b/docs/rust/Cargo.lock
@@ -2205,7 +2205,7 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "orca_whirlpools"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bincode",
  "orca_whirlpools_client",
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "orca_whirlpools_docs"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "orca_whirlpools",
  "orca_whirlpools_client",

--- a/rust-sdk/whirlpool/src/swap.rs
+++ b/rust-sdk/whirlpool/src/swap.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use orca_whirlpools_client::{
-    get_oracle_address, get_tick_array_address, AccountsType, FixedTickArray, Oracle,
+    get_oracle_address, get_tick_array_address, AccountsType, TickArray, Oracle,
     RemainingAccountsInfo, RemainingAccountsSlice, SwapV2, SwapV2InstructionArgs, Whirlpool,
 };
 use orca_whirlpools_core::{
@@ -102,7 +102,7 @@ async fn fetch_tick_arrays_or_default(
         .iter()
         .map(|x| {
             x.as_ref()
-                .and_then(|y| FixedTickArray::from_bytes(&y.data).ok())
+                .and_then(|y| TickArray::from_bytes(&y.data).ok())
         })
         .map(|x| x.map(|y| y.into()))
         .collect();


### PR DESCRIPTION
In the Rust SDK’s `orca_whirlpools crate`, the high-level function `swap_instructions` had an issue where decoding Dynamic TickArray accounts failed, so TickArrays initialized as Dynamic TickArray were not recognized.

We will change the decoding method to correctly recognize Dynamic TickArray accounts.