### PR TITLE
make ADMINS multi-sig

### DIFF
--- a/.changeset/modern-hands-learn.md
+++ b/.changeset/modern-hands-learn.md
@@ -1,0 +1,5 @@
+---
+"@orca-so/whirlpools-program": patch
+---
+
+make ADMINS (solana) multi-sig

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "whirlpool"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/programs/whirlpool/src/auth/admin.rs
+++ b/programs/whirlpool/src/auth/admin.rs
@@ -20,8 +20,8 @@ pub const ADMINS: [Pubkey; 2] = [
 
 #[cfg(feature = "mainnet")]
 pub const ADMINS: [Pubkey; 2] = [
-    // fee authority of 2LecshUwdy9xi7meFgHtFJQNSKk4KdTrcpvaB56dP2NQ (Solana)
-    pubkey!("6BLTtBS9miUZruZtR9reTzp6ctGc4kVY4xrcxQwurYtw"),
+    // program upgrade authority, multi-sig (Solana)
+    pubkey!("GwH3Hiv5mACLX3ufTw1pFsrhSPon5tdw252DBs4Rx4PV"),
     // fee authority of FVG4oDbGv16hqTUbovjyGmtYikn6UBEnazz6RVDMEFwv (Eclipse)
     pubkey!("AqiJTdr9jLPDAk5prGhWFHtSM1qJszAsdZVV7oeinxhh"),
 ];


### PR DESCRIPTION
use program upgrade authority (multi-sig) as ADMINS.
(Solana only)

Please check upgrade authority here: https://solscan.io/account/whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc
