### PR TITLE
[TKN-683] Add `setup.sh` script for local Whirlpools build

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,19 +42,27 @@ This monorepo contains all the code needed to build, deploy and interact with th
 
 ### Getting Started
 
-These instructions are for setting up a development environment on a Mac. If you are using a different operating system, you will need to adjust the instructions accordingly.
+#### Automated Setup Script
 
-* Install NodeJS and gcc-12 using `brew install node gcc@12`.
-* Add gcc-12 headers to your cpath using `export CPATH="/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include"`.
-* Install Rust lang using `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`.
-* Install the Solana CLI using `curl -sSfL https://release.solana.com/v1.17.22/install | sh`.
-* Add the Solana CLI to your path using `export PATH="/Users/$(whoami)/.local/share/solana/install/active_release/bin:$PATH"`.
-* Install Anchor version manager using `cargo install --git https://github.com/coral-xyz/anchor avm --locked --force`.
-* Install the latest Anchor version using `avm install 0.29.0 && avm use 0.29.0`.
-* Clone this repository using `git clone https://github.com/orca-so/whirlpools`.
-* Install the dependencies using `yarn`.
-* Set up a Solana wallet if you don't have one already (see below).
-* Run one of the commands below to get started such as `yarn build`.
+For a complete development environment setup, use the provided setup script:
+
+```bash
+chmod +x scripts/setup.sh
+./scripts/setup.sh
+```
+
+This script installs all required dependencies and builds the project. It's designed for fresh environments (cloud VMs, containers, new machines) and doesn't check for existing versions. The script also serves as a reference for understanding which dependencies are needed at each stage.
+
+#### Manual Setup
+
+If you prefer manual installation or already have some dependencies:
+
+* Install system dependencies (build tools, Node.js, Rust, Solana CLI, Anchor)
+  * Reference `scripts/setup.sh` for the exact versions and installation steps
+* Clone this repository: `git clone https://github.com/orca-so/whirlpools`
+* Install JavaScript dependencies: `yarn`
+* Build the project: `yarn build`
+* Set up a Solana wallet if needed (see below)
 
 #### Setting up a Solana wallet
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve repo root from this script's directory
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." >/dev/null 2>&1 && pwd)"
+echo "=== Repo root: $REPO_ROOT ==="
+
+echo "=== Detecting system ==="
+UNAME_OUT="$(uname -s)"
+case "${UNAME_OUT}" in
+    Linux*)     OS=Linux;;
+    Darwin*)    OS=Mac;;
+    *)          OS="UNKNOWN:${UNAME_OUT}"
+esac
+echo "Detected: $OS"
+
+if [[ "$OS" == "Linux" ]]; then
+    echo "=== Updating system packages (Linux) ==="
+    sudo apt-get update && sudo apt-get upgrade -y
+    sudo apt-get install -y build-essential pkg-config libssl-dev curl git
+elif [[ "$OS" == "Mac" ]]; then
+    echo "=== Installing Xcode Command Line Tools ==="
+    if ! xcode-select -p &>/dev/null; then
+        xcode-select --install || true
+        echo ">>> Please complete the pop-up installation of Xcode Command Line Tools, then rerun the script if it stops."
+    fi
+
+    echo "=== Checking Homebrew installation ==="
+    if ! command -v brew &>/dev/null; then
+        echo "Homebrew not found. Installing..."
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        if [[ -d /opt/homebrew/bin ]]; then
+            eval "$(/opt/homebrew/bin/brew shellenv)"
+        elif [[ -d /usr/local/bin ]]; then
+            eval "$(/usr/local/bin/brew shellenv)"
+        fi
+    else
+        echo "Homebrew found."
+        if [[ -x /opt/homebrew/bin/brew ]]; then
+            eval "$(/opt/homebrew/bin/brew shellenv)"
+        elif [[ -x /usr/local/bin/brew ]]; then
+            eval "$(/usr/local/bin/brew shellenv)"
+        fi
+    fi
+
+    echo "=== Updating Homebrew and installing dependencies ==="
+    brew update
+    brew upgrade
+    brew install pkg-config openssl git
+fi
+
+echo "=== Installing NVM (Node Version Manager) ==="
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+export NVM_DIR="$HOME/.nvm"
+source "$NVM_DIR/nvm.sh"
+
+echo "=== Installing Node.js 22 and Yarn (via Corepack) ==="
+nvm install 22
+nvm use 22
+corepack enable
+corepack prepare yarn@4.6.0 --activate
+
+echo "=== Installing Rust via rustup ==="
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+source "$HOME/.cargo/env"
+rustc -V
+
+echo "=== Installing Solana CLI ==="
+sh -c "$(curl -sSfL https://release.anza.xyz/v1.17.25/install)"
+source "$HOME/.profile" || true
+solana -V
+
+echo "=== Installing Anchor (v0.29.0) ==="
+rustup default 1.76.0
+ANCHOR_TMP_DIR="$(mktemp -d)"
+git clone https://github.com/coral-xyz/anchor "$ANCHOR_TMP_DIR/anchor"
+cd "$ANCHOR_TMP_DIR/anchor"
+git checkout v0.29.0
+cd cli
+cargo build --release
+mkdir -p "$HOME/.cargo/bin"
+ANCHOR_VERSION="0.29.0"
+cp ../target/release/anchor "$HOME/.cargo/bin/anchor-$ANCHOR_VERSION"
+ln -sfn "$HOME/.cargo/bin/anchor-$ANCHOR_VERSION" "$HOME/.cargo/bin/anchor"
+export PATH="$HOME/.cargo/bin:$PATH"
+INSTALLED_ANCHOR_VERSION="$(anchor --version 2>/dev/null || true)"
+echo "$INSTALLED_ANCHOR_VERSION"
+if [[ "$INSTALLED_ANCHOR_VERSION" != *"$ANCHOR_VERSION"* ]]; then
+    echo "Warning: anchor on PATH is not $ANCHOR_VERSION. PATH may prefer another anchor." >&2
+    which anchor || true
+fi
+cd "$REPO_ROOT"
+rm -rf "$ANCHOR_TMP_DIR"
+
+echo "=== Building local Whirlpools repo ==="
+rustup default 1.85.1
+cd "$REPO_ROOT"
+yarn install
+yarn build
+
+echo "=== Setup complete ==="

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -9,8 +9,7 @@ NODE_VERSION="22"
 YARN_VERSION="4.6.0"
 SOLANA_VERSION="v1.17.25"
 ANCHOR_VERSION="v0.29.0"
-RUST_VERSION_FOR_ANCHOR="1.76.0"    # Required for building Anchor v0.29.0
-RUST_VERSION_FOR_PROJECT="1.85.1"   # Required for building Whirlpools project
+RUST_VERSION_FOR_PROJECT="1.84.0"
 
 # Resolve repo root from this script's directory
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
@@ -56,6 +55,7 @@ corepack prepare yarn@${YARN_VERSION} --activate
 echo "=== Installing Rust via rustup ==="
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 source "$HOME/.cargo/env"
+rustup default stable
 rustc -V
 
 echo "=== Installing Solana CLI ==="
@@ -64,19 +64,9 @@ source "$HOME/.profile" || true
 solana -V
 
 echo "=== Installing Anchor (${ANCHOR_VERSION}) ==="
-rustup default ${RUST_VERSION_FOR_ANCHOR}
-ANCHOR_TMP_DIR="$(mktemp -d)"
-git clone https://github.com/coral-xyz/anchor "$ANCHOR_TMP_DIR/anchor"
-cd "$ANCHOR_TMP_DIR/anchor"
-git checkout ${ANCHOR_VERSION}
-cd cli
-cargo build --release
-mkdir -p "$HOME/.cargo/bin"
-cp ../target/release/anchor "$HOME/.cargo/bin/anchor-${ANCHOR_VERSION}"
-ln -sfn "$HOME/.cargo/bin/anchor-${ANCHOR_VERSION}" "$HOME/.cargo/bin/anchor"
+cargo install --git https://github.com/coral-xyz/anchor --tag ${ANCHOR_VERSION} anchor-cli --force
 export PATH="$HOME/.cargo/bin:$PATH"
 cd "$REPO_ROOT"
-rm -rf "$ANCHOR_TMP_DIR"
 
 echo "=== Building local Whirlpools repo ==="
 rustup default ${RUST_VERSION_FOR_PROJECT}


### PR DESCRIPTION
Added a setup script to streamline development environment setup:

**New Setup Script (`scripts/setup.sh`):**
- One-stop installation of all required dependencies (Node.js, Rust, Solana CLI, Anchor)
- Supports both Linux and macOS environments
- Installs specific versions required by the project (clearly defined at the top)
- Designed for fresh environments (cloud VMs, containers, new machines)

**Updated Documentation:**
- Update "Getting Started" section featuring the automated setup script
- Provides clear instructions for making script executable and running it
- Maintains manual setup option with reference to script for exact versions