### PR TITLE
[TKN-703] Add test profile to docker-compose.yml (pending merge of PR 1115)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     working_dir: /usr/src/whirlpools
     command: >
       anchor build
-    profiles: [build]
+    profiles: [build, test]
     volumes:
       - ./:/usr/src/whirlpools
 
@@ -19,7 +19,7 @@ services:
       && apt-get update && apt-get install -y nodejs
       && corepack enable && corepack prepare yarn@4.6.0 --activate
       && yarn install"
-    profiles: [build]
+    profiles: [build, test]
     volumes:
       - ./:/usr/src/whirlpools
       - node_modules:/usr/src/whirlpools/node_modules
@@ -38,7 +38,7 @@ services:
       && yarn workspace @orca-so/tx-sender build
       && yarn workspace @orca-so/whirlpools build
       && yarn workspace @orca-so/whirlpools-lint format"
-    profiles: [build]
+    profiles: [build, test]
     depends_on:
       build-solana-program:
         condition: service_completed_successfully
@@ -59,7 +59,7 @@ services:
       && yarn workspace @orca-so/common-sdk build
       && yarn workspace @orca-so/whirlpools-sdk build
       && yarn workspace @orca-so/whirlpools-sdk-cli build"
-    profiles: [build]
+    profiles: [build, test]
     depends_on:
       build-solana-program:
         condition: service_completed_successfully
@@ -82,7 +82,7 @@ services:
       && cargo build --manifest-path rust-sdk/tx-sender/Cargo.toml --locked
       && cargo clippy --fix --allow-dirty --allow-staged
       && cargo fmt"
-    profiles: [build]
+    profiles: [build, test]
     depends_on:
       build-solana-program:
         condition: service_completed_successfully
@@ -98,7 +98,7 @@ services:
       && corepack enable && corepack prepare yarn@4.6.0 --activate
       && yarn workspace @orca-so/whirlpools-integration build
       && yarn workspace @orca-so/whirlpools-rust-integration build"
-    profiles: [build]
+    profiles: [build, test]
     depends_on:
       build-rust-sdk:
         condition: service_completed_successfully
@@ -176,6 +176,123 @@ services:
       build-examples:
         condition: service_completed_successfully
     profiles: [build]
+    volumes:
+      - ./:/usr/src/whirlpools
+
+  test-ts-sdk:
+    image: rust:1.84.0
+    working_dir: /usr/src/whirlpools
+    command: >
+      sh -c "curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+      && apt-get update && apt-get install -y nodejs
+      && corepack enable && corepack prepare yarn@4.6.0 --activate
+      && yarn workspace @orca-so/whirlpools-client test
+      && yarn workspace @orca-so/whirlpools-core test
+      && yarn workspace @orca-so/tx-sender test
+      && yarn workspace @orca-so/whirlpools test"
+    profiles: [test]
+    depends_on:
+      build-solana-program:
+        condition: service_completed_successfully
+      yarn-install:
+        condition: service_completed_successfully
+      build-ts-sdk:
+        condition: service_completed_successfully
+    volumes:
+      - ./:/usr/src/whirlpools
+      - node_modules:/usr/src/whirlpools/node_modules:ro
+      - yarn_cache:/usr/src/whirlpools/.yarn/cache:ro
+
+  test-program:
+    image: rust:1.84.0
+    working_dir: /usr/src/whirlpools
+    command: >
+      cargo test -p whirlpool --locked
+    profiles: [test]
+    depends_on:
+      build-solana-program:
+        condition: service_completed_successfully
+    volumes:
+      - ./:/usr/src/whirlpools
+
+  test-program-integration:
+    image: rust:1.84.0
+    working_dir: /usr/src/whirlpools
+    command: >
+      sh -c "curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+      && apt-get update && apt-get install -y nodejs
+      && corepack enable && corepack prepare yarn@4.6.0 --activate
+      && yarn workspace @orca-so/whirlpools-sdk-integration test"
+    profiles: [test]
+    depends_on:
+      build-solana-program:
+        condition: service_completed_successfully
+      yarn-install:
+        condition: service_completed_successfully
+      build-legacy-sdk:
+        condition: service_completed_successfully
+    volumes:
+      - ./:/usr/src/whirlpools
+      - node_modules:/usr/src/whirlpools/node_modules:ro
+      - yarn_cache:/usr/src/whirlpools/.yarn/cache:ro
+
+  test-rust-sdk:
+    image: rust:1.84.0
+    working_dir: /usr/src/whirlpools
+    command: >
+      sh -c "cargo test --manifest-path rust-sdk/macros/Cargo.toml --locked
+      && cargo test --manifest-path rust-sdk/core/Cargo.toml --locked
+      && cargo test --manifest-path rust-sdk/client/Cargo.toml --locked
+      && cargo test --manifest-path rust-sdk/whirlpool/Cargo.toml --locked
+      && cargo test --manifest-path rust-sdk/tx-sender/Cargo.toml --locked"
+    profiles: [test]
+    depends_on:
+      build-solana-program:
+        condition: service_completed_successfully
+      build-rust-sdk:
+        condition: service_completed_successfully
+    volumes:
+      - ./:/usr/src/whirlpools
+
+  test-integration:
+    image: rust:1.84.0
+    working_dir: /usr/src/whirlpools
+    command: >
+      sh -c "curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+      && apt-get update && apt-get install -y nodejs
+      && corepack enable && corepack prepare yarn@4.6.0 --activate
+      && yarn workspace @orca-so/whirlpools-integration test
+      && yarn workspace @orca-so/whirlpools-rust-integration test"
+    profiles: [test]
+    depends_on:
+      build-rust-sdk:
+        condition: service_completed_successfully
+      build-ts-sdk:
+        condition: service_completed_successfully
+      build-integration:
+        condition: service_completed_successfully
+    volumes:
+      - ./:/usr/src/whirlpools
+      - node_modules:/usr/src/whirlpools/node_modules:ro
+      - yarn_cache:/usr/src/whirlpools/.yarn/cache:ro
+
+  test:
+    image: alpine:3
+    working_dir: /usr/src/whirlpools
+    command: >
+      echo "Tests Completed"
+    depends_on:
+      test-program:
+        condition: service_completed_successfully
+      test-program-integration:
+        condition: service_completed_successfully
+      test-ts-sdk:
+        condition: service_completed_successfully
+      test-rust-sdk:
+        condition: service_completed_successfully
+      test-integration:
+        condition: service_completed_successfully
+    profiles: [test]
     volumes:
       - ./:/usr/src/whirlpools
 


### PR DESCRIPTION
## Summary

Adds a `test` profile to `docker-compose.yml` that runs all test suites across the monorepo. This PR is designed to work with the upcoming [test migration to LiteSVM](https://github.com/orca-so/whirlpools/pull/1115).

**Draft Status:** Pending merge of `test-migration` branch.

## Usage

Run all tests:
```bash
docker-compose --profile test up
```

Run specific test suite:
```bash
docker-compose up test-ts-sdk
docker-compose up test-rust-sdk
docker-compose up test-program-integration
```

## Test Services Added

1. **test-program** - Solana program unit tests (730+ tests)
2. **test-program-integration** - Program integration tests via LiteSVM + Vitest (~137s)
3. **test-ts-sdk** - TypeScript SDK tests (client, core, tx-sender, whirlpools)
4. **test-rust-sdk** - Rust SDK tests (macros, core, client, whirlpool, tx-sender)
5. **test-integration** - Cross-SDK integration tests (TS + Rust)