### PR TITLE
Security Fix: Protocol fee accumulator overflow via wrapping_add

### DIFF
--- a/programs/whirlpool/src/manager/swap_manager.rs
+++ b/programs/whirlpool/src/manager/swap_manager.rs
@@ -281,7 +281,7 @@ fn calculate_fees(
     if protocol_fee_rate > 0 {
         let delta = calculate_protocol_fee(global_fee, protocol_fee_rate);
         global_fee -= delta;
-        next_protocol_fee = next_protocol_fee.wrapping_add(delta);
+        next_protocol_fee = next_protocol_fee.saturating_add(delta);
     }
 
     if curr_liquidity > 0 {


### PR DESCRIPTION
## Security Finding

### [HIGH] Protocol Fee Accumulator Uses wrapping_add — Can Silently Lose Fees
**File:** `programs/whirlpool/src/manager/swap_manager.rs:284`

**Issue:**
The protocol fee accumulator `next_protocol_fee` uses `wrapping_add(delta)` which silently wraps around on overflow, resetting accumulated fees to near-zero.

Unlike `fee_growth_global` which intentionally uses wrapping arithmetic (standard in Uniswap V3's cumulative fee tracking where positions calculate deltas), `protocol_fee` is an **absolute balance** that gets collected via `collect_protocol_fees`. If it wraps:
- All accrued protocol fees are permanently lost
- The protocol treasury receives significantly less than owed

**Severity:** High (theoretical — requires extreme volume, but the fix is trivial and defensive)

**Fix:** Changed `wrapping_add` to `saturating_add`, which caps at `u64::MAX` (~18.4 quintillion) instead of wrapping to 0.

---
*Found during a Solana security audit*