### PR TITLE
fix: align fetchAllMint imports to use @solana-program/token-2022

### DIFF
--- a/ts-sdk/whirlpool/src/pool.ts
+++ b/ts-sdk/whirlpool/src/pool.ts
@@ -19,7 +19,7 @@ import type {
 import { SPLASH_POOL_TICK_SPACING, WHIRLPOOLS_CONFIG_ADDRESS } from "./config";
 import { orderMints } from "./token";
 import { sqrtPriceToPrice } from "@orca-so/whirlpools-core";
-import { fetchAllMint } from "@solana-program/token";
+import { fetchAllMint } from "@solana-program/token-2022";
 
 /**
  * Type representing a pool that is not yet initialized.

--- a/ts-sdk/whirlpool/src/token.ts
+++ b/ts-sdk/whirlpool/src/token.ts
@@ -1,12 +1,12 @@
 import {
   fetchAllMaybeToken,
-  fetchAllMint,
   findAssociatedTokenPda,
   getCloseAccountInstruction,
   getInitializeAccount3Instruction,
   getSyncNativeInstruction,
   TOKEN_PROGRAM_ADDRESS,
 } from "@solana-program/token";
+import { fetchAllMint } from "@solana-program/token-2022";
 import type {
   Account,
   Address,


### PR DESCRIPTION
## Summary

`pool.ts` and `token.ts` were importing `fetchAllMint` from `@solana-program/token` (classic SPL Token), while all other modules (`createPool.ts`, `swap.ts`, `increaseLiquidity.ts`, `decreaseLiquidity.ts`, `resetPositionRange.ts`) correctly import from `@solana-program/token-2022`.

This creates inconsistent behavior when working with Token-2022 mints — pool and token utilities would fail to handle Token-2022 mints properly.

## Changes

- `pool.ts`: Changed `fetchAllMint` import from `@solana-program/token` → `@solana-program/token-2022`
- `token.ts`: Moved `fetchAllMint` import from `@solana-program/token` → `@solana-program/token-2022`

No functional changes — `@solana-program/token-2022` is already a dependency and supports both classic and Token-2022 mints.

Closes #1278