### PR TITLE
use slice discriminator for anchor >=0.31 compatibility

### DIFF
--- a/.changeset/vast-bugs-repeat.md
+++ b/.changeset/vast-bugs-repeat.md
@@ -1,0 +1,5 @@
+---
+"@orca-so/whirlpools-rust-client": patch
+---
+
+use slice discriminator for TickArray

--- a/rust-sdk/client/src/state/tick_array.rs
+++ b/rust-sdk/client/src/state/tick_array.rs
@@ -254,7 +254,7 @@ impl anchor_lang::IdlBuild for TickArray {}
 
 #[cfg(feature = "anchor-idl-build")]
 impl anchor_lang::Discriminator for TickArray {
-    const DISCRIMINATOR: [u8; 8] = [0; 8];
+    const DISCRIMINATOR: &[u8] = &[0; 8];
 }
 
 // For backwards compatibility with


### PR DESCRIPTION
## Description

use slice discriminator for anchor >=0.31 ([changelog](https://www.anchor-lang.com/docs/updates/release-notes/0-31-0#discriminator-trait)) compatibility

### How did we miss this error?

we don't run cargo check or build with `--all-features`, so we missed this feature based error. there are other feature gated errors, but we can address those in a follow up PR to keep this one focused on addressing the specified issue. further, we can update the the CI build scripts to try and catch these.

## Testing

Reproducing error before change. This same error is resolved with the change in this PR.

```bash
whirlpools % cargo +stable check --manifest-path rust-sdk/client/Cargo.toml --features anchor-idl-build
    Checking orca_whirlpools_client v7.2.0 (/Users/jacobshiohira/projects/solana/orca/whirlpools/rust-sdk/client)
error[E0326]: implemented const `DISCRIMINATOR` has an incompatible type for trait
   --> src/state/tick_array.rs:257:26
    |
257 |     const DISCRIMINATOR: [u8; 8] = [0; 8];
    |                          ^^^^^^^ expected `&[u8]`, found `[u8; 8]`

For more information about this error, try `rustc --explain E0326`.
```

Closes #1285