### PR TITLE
Update docs to reflect sdk changes

### DIFF
--- a/.changeset/docs-upgrade.md
+++ b/.changeset/docs-upgrade.md
@@ -1,0 +1,5 @@
+---
+"@orca-so/whirlpools-docs": major
+---
+
+Update the docs to reflect changes to the TypeScript and Rust SDKs made when updating extensibility for immutable whirlpools.

--- a/docs/whirlpool/docs/03-SDKs/02-Environment Setup.mdx
+++ b/docs/whirlpool/docs/03-SDKs/02-Environment Setup.mdx
@@ -87,8 +87,8 @@ This document covers the essential setup required to start building on Orca's SD
     Available deployments:
     
     - `WhirlpoolDeployment::mainnet()` — mutable mainnet program + mainnet config
-    - `WhirlpoolDeployment::devnet()` — mutable mainnet program + devnet config
-    - `WhirlpoolDeployment::mainnet_immutable()` — immutable mainnet program + its config
+    - `WhirlpoolDeployment::devnet()` — mutable devnet program + devnet config
+    - `WhirlpoolDeployment::mainnet_immutable()` — immutable mainnet program + immutable mainnet config
     - `WhirlpoolDeployment::custom(program_id, config)` — for forks or local validators
     
     ## 4. Airdrop SOL to Your Wallet
@@ -187,8 +187,8 @@ This document covers the essential setup required to start building on Orca's SD
     Available deployments:
     
     - `WhirlpoolDeployment.mainnet` — mutable mainnet program + mainnet config
-    - `WhirlpoolDeployment.devnet` — mutable mainnet program + devnet config
-    - `WhirlpoolDeployment.mainnetImmutable` — immutable mainnet program + its config
+    - `WhirlpoolDeployment.devnet` — mutable devnet program + devnet config
+    - `WhirlpoolDeployment.mainnetImmutable` — immutable mainnet program + immutable mainnet config
     - `WhirlpoolDeployment.custom(programId, configAddress)` — for forks or local validators
     
     ## 4. Airdrop SOL to Your Wallet

--- a/docs/whirlpool/docs/03-SDKs/02-Environment Setup.mdx
+++ b/docs/whirlpool/docs/03-SDKs/02-Environment Setup.mdx
@@ -71,27 +71,25 @@ This document covers the essential setup required to start building on Orca's SD
     
     > ⚠️ Important: Never share your private key publicly.
     
-    ## 3. Configure the Whirlpools SDK for Your Network
+    ## 3. Select a Whirlpool Deployment
     
-    Orca's Whirlpools SDK supports several networks: Solana Mainnet, Solana Devnet, Eclipse Mainnet, and Eclipse Testnet. To select a network, use the `setWhirlpoolsConfig` function.
+    Each SDK function targets a `WhirlpoolDeployment` — a `program_id` + `WhirlpoolsConfig` pair. Pass one of the named constructors (or a `custom` one) to any SDK function or PDA helper that takes a `whirlpool_deployment` argument. If omitted, the SDK defaults to `WhirlpoolDeployment::mainnet()` (the mutable mainnet program with the mainnet config).
     
     ```rust
-    use orca_whirlpools::{WhirlpoolsConfigInput, set_whirlpools_config_address};
+    use orca_whirlpools::WhirlpoolDeployment;
 
     fn main() {
-      set_whirlpools_config_address(WhirlpoolsConfigInput::SolanaDevnet).unwrap();
+      let _deployment = WhirlpoolDeployment::devnet();
       // Rest of the code
     }
     ```
     
-    Available networks are:
+    Available deployments:
     
-    - solanaMainnet
-    - solanaDevnet
-    - eclipseMainnet
-    - eclipseTestnet
-    
-    > ℹ️ The `set_whirlpools_config_address` function accepts either one of Orca's default network keys or a custom address. This allows you to specify a WhirlpoolsConfig account of your choice, including configurations not owned by Orca.
+    - `WhirlpoolDeployment::mainnet()` — mutable mainnet program + mainnet config
+    - `WhirlpoolDeployment::devnet()` — mutable mainnet program + devnet config
+    - `WhirlpoolDeployment::mainnet_immutable()` — immutable mainnet program + its config
+    - `WhirlpoolDeployment::custom(program_id, config)` — for forks or local validators
     
     ## 4. Airdrop SOL to Your Wallet
     
@@ -176,24 +174,22 @@ This document covers the essential setup required to start building on Orca's SD
     
     > ⚠️ Important: Never share your private key publicly.
     
-    ## 3. Configure the Whirlpools SDK for Your Network
+    ## 3. Select a Whirlpool Deployment
     
-    Orca's Whirlpools SDK supports several networks: Solana Mainnet, Solana Devnet, Eclipse Mainnet, and Eclipse Testnet. To select a network, use the `setWhirlpoolsConfig` function.
+    Each SDK function targets a `WhirlpoolDeployment` — a `programId` + `WhirlpoolsConfig` pair. Pass one of the named constants (or a `custom` one) to any SDK function or PDA helper that takes a `whirlpoolDeployment` argument. If omitted, the SDK defaults to `WhirlpoolDeployment.mainnet` (the mutable mainnet program with the mainnet config).
     
     ```tsx
-    import { setWhirlpoolsConfig } from '@orca-so/whirlpools';
+    import { WhirlpoolDeployment } from '@orca-so/whirlpools';
 
-    await setWhirlpoolsConfig('solanaDevnet');
+    const deployment = WhirlpoolDeployment.devnet;
     ```
     
-    Available networks are:
+    Available deployments:
     
-    - solanaMainnet
-    - solanaDevnet
-    - eclipseMainnet
-    - eclipseTestnet
-    
-    > ℹ️ The `setWhirlpoolsConfig` function accepts either one of Orca's default network keys or a custom `Address`. This allows you to specify a WhirlpoolsConfig account of your choice, including configurations not owned by Orca.
+    - `WhirlpoolDeployment.mainnet` — mutable mainnet program + mainnet config
+    - `WhirlpoolDeployment.devnet` — mutable mainnet program + devnet config
+    - `WhirlpoolDeployment.mainnetImmutable` — immutable mainnet program + its config
+    - `WhirlpoolDeployment.custom(programId, configAddress)` — for forks or local validators
     
     ## 4. Airdrop SOL to Your Wallet
     

--- a/docs/whirlpool/docs/03-SDKs/03-Whirlpool Management/01-Create Pool.mdx
+++ b/docs/whirlpool/docs/03-SDKs/03-Whirlpool Management/01-Create Pool.mdx
@@ -214,7 +214,8 @@ Liquidity pools are a foundational concept in DeFi, enabling users to trade toke
         },
     );
 
-    // Use the callback to submit the transaction
+    // Use the callback to submit the transaction.
+    // Add a payer explicitly (e.g. `sendTx(payer)`) or default to the global payer from `setPayerFromBytes()`
     const txId = await sendTx();
 
     console.log(`Pool Address: ${poolAddress}`);
@@ -247,6 +248,7 @@ Liquidity pools are a foundational concept in DeFi, enabling users to trade toke
     );
 
     // Use the callback to submit the transaction
+    // Add a payer explicitly (e.g. `sendTx(payer)`) or default to the global payer from `setPayerFromBytes()`    
     const txId = await sendTx();
 
 

--- a/docs/whirlpool/docs/03-SDKs/03-Whirlpool Management/01-Create Pool.mdx
+++ b/docs/whirlpool/docs/03-SDKs/03-Whirlpool Management/01-Create Pool.mdx
@@ -73,7 +73,7 @@ Liquidity pools are a foundational concept in DeFi, enabling users to trade toke
 
     ```rust
     use orca_whirlpools::{
-        create_splash_pool_instructions, set_whirlpools_config_address, WhirlpoolsConfigInput,
+        create_splash_pool_instructions, CreateSplashPoolConfig, WhirlpoolDeployment,
     };
     use solana_client::nonblocking::rpc_client::RpcClient;
     use solana_sdk::{pubkey::Pubkey, signature::Signer, signer::keypair::Keypair};
@@ -88,18 +88,23 @@ Liquidity pools are a foundational concept in DeFi, enabling users to trade toke
     #[tokio::main]
     async fn main() -> Result<(), Box<dyn std::error::Error>> {
         set_rpc("https://api.devnet.solana.com").await?;
-        set_whirlpools_config_address(WhirlpoolsConfigInput::SolanaDevnet).unwrap();
-        
+
         let token_a = Pubkey::from_str("So11111111111111111111111111111111111111112").unwrap();
         let token_b = Pubkey::from_str("BRjpCHtyQLNCo8gqRUr8jtdAj5AjPYQaoqbvcZiHok1k").unwrap(); // devUSDC
-        let initial_price = Some(0.01);
         let wallet = Keypair::new(); // CAUTION: This wallet is not persistent.
-        let funder = Some(wallet.pubkey());
         let rpc = get_rpc_client()?;
 
-        let result =
-            create_splash_pool_instructions(&rpc, token_a, token_b, initial_price, funder)
-                .await?;
+        let result = create_splash_pool_instructions(
+            &rpc,
+            token_a,
+            token_b,
+            CreateSplashPoolConfig {
+                initial_price: Some(0.01),
+                funder: Some(wallet.pubkey()),
+                whirlpool_deployment: Some(WhirlpoolDeployment::devnet()),
+            },
+        )
+        .await?;
 
         // The instructions include new Tick Array accounts that need to be created
         // and signed for with their corresponding Keypair.
@@ -129,8 +134,8 @@ Liquidity pools are a foundational concept in DeFi, enabling users to trade toke
 
     ```rust
     use orca_whirlpools::{
-        create_concentrated_liquidity_pool_instructions, set_whirlpools_config_address,
-        WhirlpoolsConfigInput,
+        create_concentrated_liquidity_pool_instructions,
+        CreateConcentratedLiquidityPoolConfig, WhirlpoolDeployment,
     };
     use solana_client::nonblocking::rpc_client::RpcClient;
     use solana_sdk::{pubkey::Pubkey, signature::Signer, signer::keypair::Keypair};
@@ -145,14 +150,11 @@ Liquidity pools are a foundational concept in DeFi, enabling users to trade toke
     #[tokio::main]
     async fn main() -> Result<(), Box<dyn std::error::Error>> {
         set_rpc("https://api.devnet.solana.com").await?;
-        set_whirlpools_config_address(WhirlpoolsConfigInput::SolanaDevnet).unwrap();
-        
+
         let token_a = Pubkey::from_str("So11111111111111111111111111111111111111112").unwrap();
         let token_b = Pubkey::from_str("BRjpCHtyQLNCo8gqRUr8jtdAj5AjPYQaoqbvcZiHok1k").unwrap(); // devUSDC
         let tick_spacing = 64;
-        let initial_price = Some(0.01);
         let wallet = Keypair::new(); // CAUTION: This wallet is not persistent.
-        let funder = Some(wallet.pubkey());
         let rpc = get_rpc_client()?;
 
         let result = create_concentrated_liquidity_pool_instructions(
@@ -160,8 +162,11 @@ Liquidity pools are a foundational concept in DeFi, enabling users to trade toke
             token_a,
             token_b,
             tick_spacing,
-            initial_price,
-            funder,
+            CreateConcentratedLiquidityPoolConfig {
+                initial_price: Some(0.01),
+                funder: Some(wallet.pubkey()),
+                whirlpool_deployment: Some(WhirlpoolDeployment::devnet()),
+            },
         )
         .await?;
 
@@ -190,24 +195,23 @@ Liquidity pools are a foundational concept in DeFi, enabling users to trade toke
     <ReactMarkdown>{splashPoolSteps}</ReactMarkdown>
 
     ```tsx
-    import { createSplashPool, setWhirlpoolsConfig, setRpc, setPayerFromBytes } from '@orca-so/whirlpools';
-    import { generateKeyPairSigner, createSolanaRpc, devnet, address } from '@solana/kit';
+    import { createSplashPool, WhirlpoolDeployment, setRpc, setPayerFromBytes } from '@orca-so/whirlpools';
+    import { address } from '@solana/kit';
     import secret from "wallet.json";
 
-    await setWhirlpoolsConfig('solanaDevnet');
     await setRpc('https://api.devnet.solana.com');
-    const signer = await setPayerFromBytes(new Uint8Array(secret));
+    await setPayerFromBytes(new Uint8Array(secret));
 
     const tokenMintOne = address("So11111111111111111111111111111111111111112");
     const tokenMintTwo = address("BRjpCHtyQLNCo8gqRUr8jtdAj5AjPYQaoqbvcZiHok1k"); // devUSDC
-    const initialPrice = 0.01;
 
-    const { poolAddress, instructions, initializationCost, callback: sendTx } = await createSplashPool(
-        devnetRpc,
+    const { poolAddress, initializationCost, callback: sendTx } = await createSplashPool(
         tokenMintOne,
         tokenMintTwo,
-        initialPrice,
-        signer
+        {
+            initialPrice: 0.01,
+            whirlpoolDeployment: WhirlpoolDeployment.devnet,
+        },
     );
 
     // Use the callback to submit the transaction
@@ -221,26 +225,25 @@ Liquidity pools are a foundational concept in DeFi, enabling users to trade toke
     <ReactMarkdown>{concentratedLiquiditySteps}</ReactMarkdown>
 
     ```tsx
-    import { createConcentratedLiquidityPoolInstructions, setWhirlpoolsConfig, setRpc, setPayerFromBytes } from '@orca-so/whirlpools';
-    import { generateKeyPairSigner, createSolanaRpc, devnet, address } from '@solana/kit';
+    import { createConcentratedLiquidityPool, WhirlpoolDeployment, setRpc, setPayerFromBytes } from '@orca-so/whirlpools';
+    import { address } from '@solana/kit';
     import secret from "wallet.json";
 
-    await setWhirlpoolsConfig('solanaDevnet');
     await setRpc('https://api.devnet.solana.com');
-    const signer = await setPayerFromBytes(new Uint8Array(secret));
+    await setPayerFromBytes(new Uint8Array(secret));
 
     const tokenMintOne = address("So11111111111111111111111111111111111111112");
     const tokenMintTwo = address("BRjpCHtyQLNCo8gqRUr8jtdAj5AjPYQaoqbvcZiHok1k"); // devUSDC
     const tickSpacing = 64;
-    const initialPrice = 0.01;
 
-    const { poolAddress, instructions, initializationCost, callback: sendTx } = await createConcentratedLiquidityPool(
-        devnetRpc,
+    const { poolAddress, initializationCost, callback: sendTx } = await createConcentratedLiquidityPool(
         tokenMintOne,
         tokenMintTwo,
         tickSpacing,
-        initialPrice,
-        signer
+        {
+            initialPrice: 0.01,
+            whirlpoolDeployment: WhirlpoolDeployment.devnet,
+        },
     );
 
     // Use the callback to submit the transaction

--- a/docs/whirlpool/docs/03-SDKs/03-Whirlpool Management/02-Monitor pools.mdx
+++ b/docs/whirlpool/docs/03-SDKs/03-Whirlpool Management/02-Monitor pools.mdx
@@ -69,16 +69,13 @@ The SDKs offer three main functions to help developers monitor the pools:
     <ReactMarkdown>{byAddressFetching}</ReactMarkdown>
 
     ```rust
-    use orca_whirlpools::{
-        fetch_whirlpool, set_whirlpools_config_address, WhirlpoolsConfigInput,
-    };
+    use orca_whirlpools_client::fetch_whirlpool;
     use solana_client::nonblocking::rpc_client::RpcClient;
     use solana_sdk::pubkey::Pubkey;
     use std::str::FromStr;
 
     #[tokio::main]
     async fn main() {
-        set_whirlpools_config_address(WhirlpoolsConfigInput::SolanaDevnet).unwrap();
         let rpc = RpcClient::new("https://api.devnet.solana.com".to_string());
         let whirlpool_address = Pubkey::from_str("3KBZiL2g8C7tiJ32hTv5v3KM7aK9htpqTw4cTXz1HvPt").unwrap(); // SOL/devUSDC
 
@@ -91,20 +88,20 @@ The SDKs offer three main functions to help developers monitor the pools:
     <ReactMarkdown>{splashPoolFetching}</ReactMarkdown>
 
     ```rust
-    use orca_whirlpools::{
-        fetch_splash_pool, set_whirlpools_config_address, PoolInfo, WhirlpoolsConfigInput,
-    };
+    use orca_whirlpools::{fetch_splash_pool, PoolInfo, WhirlpoolDeployment};
     use solana_client::nonblocking::rpc_client::RpcClient;
     use solana_sdk::pubkey::Pubkey;
     use std::str::FromStr;
 
     async fn main() {
-        set_whirlpools_config_address(WhirlpoolsConfigInput::SolanaDevnet).unwrap();
         let rpc = RpcClient::new("https://api.devnet.solana.com".to_string());
         let token_a = Pubkey::from_str("So11111111111111111111111111111111111111112").unwrap();
         let token_b = Pubkey::from_str("BRjpCHtyQLNCo8gqRUr8jtdAj5AjPYQaoqbvcZiHok1k").unwrap(); // devUSDC
 
-        let pool_info = fetch_splash_pool(&rpc, token_a, token_b).await.unwrap();
+        let pool_info =
+            fetch_splash_pool(&rpc, token_a, token_b, Some(WhirlpoolDeployment::devnet()))
+                .await
+                .unwrap();
 
         match pool_info {
             PoolInfo::Initialized(pool) => println!("Pool is initialized: {:?}", pool),
@@ -117,7 +114,7 @@ The SDKs offer three main functions to help developers monitor the pools:
 
     ```rust
     use orca_whirlpools::{
-        fetch_concentrated_liquidity_pool, set_whirlpools_config_address, PoolInfo, WhirlpoolsConfigInput
+        fetch_concentrated_liquidity_pool, PoolInfo, WhirlpoolDeployment,
     };
     use solana_client::nonblocking::rpc_client::RpcClient;
     use solana_sdk::pubkey::Pubkey;
@@ -125,13 +122,20 @@ The SDKs offer three main functions to help developers monitor the pools:
 
     #[tokio::main]
     async fn main() {
-        set_whirlpools_config_address(WhirlpoolsConfigInput::SolanaDevnet).unwrap();
         let rpc = RpcClient::new("https://api.devnet.solana.com".to_string());
         let token_a = Pubkey::from_str("So11111111111111111111111111111111111111112").unwrap();
         let token_b = Pubkey::from_str("BRjpCHtyQLNCo8gqRUr8jtdAj5AjPYQaoqbvcZiHok1k").unwrap(); // devUSDC
         let tick_spacing = 64;
 
-        let pool_info = fetch_concentrated_liquidity_pool(&rpc, token_a, token_b, tick_spacing).await.unwrap();
+        let pool_info = fetch_concentrated_liquidity_pool(
+            &rpc,
+            token_a,
+            token_b,
+            tick_spacing,
+            Some(WhirlpoolDeployment::devnet()),
+        )
+        .await
+        .unwrap();
 
         match pool_info {
             PoolInfo::Initialized(pool) => println!("Pool is initialized: {:?}", pool),
@@ -144,7 +148,7 @@ The SDKs offer three main functions to help developers monitor the pools:
 
     ```rust
     use orca_whirlpools::{
-        fetch_whirlpools_by_token_pair, set_whirlpools_config_address, PoolInfo, WhirlpoolsConfigInput,
+        fetch_whirlpools_by_token_pair, PoolInfo, WhirlpoolDeployment,
     };
     use solana_client::nonblocking::rpc_client::RpcClient;
     use solana_sdk::pubkey::Pubkey;
@@ -152,14 +156,18 @@ The SDKs offer three main functions to help developers monitor the pools:
 
     #[tokio::main]
     async fn main() {
-        set_whirlpools_config_address(WhirlpoolsConfigInput::SolanaDevnet).unwrap();
         let rpc = RpcClient::new("https://api.devnet.solana.com".to_string());
         let token_a = Pubkey::from_str("So11111111111111111111111111111111111111112").unwrap();
         let token_b = Pubkey::from_str("BRjpCHtyQLNCo8gqRUr8jtdAj5AjPYQaoqbvcZiHok1k").unwrap(); // devUSDC
 
-        let pool_infos = fetch_whirlpools_by_token_pair(&rpc, token_a, token_b)
-            .await
-            .unwrap();
+        let pool_infos = fetch_whirlpools_by_token_pair(
+            &rpc,
+            token_a,
+            token_b,
+            Some(WhirlpoolDeployment::devnet()),
+        )
+        .await
+        .unwrap();
 
         for pool_info in pool_infos {
             match pool_info {
@@ -175,10 +183,9 @@ The SDKs offer three main functions to help developers monitor the pools:
     <ReactMarkdown>{byAddressFetching}</ReactMarkdown>
 
     ```tsx
-    import { fetchWhirlpool, setWhirlpoolsConfig } from '@orca-so/whirlpools';
+    import { fetchWhirlpool } from '@orca-so/whirlpools-client';
     import { createSolanaRpc, devnet, address } from '@solana/kit';
 
-    await setWhirlpoolsConfig('solanaDevnet');
     const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
     const whirlpoolAddress = address("3KBZiL2g8C7tiJ32hTv5v3KM7aK9htpqTw4cTXz1HvPt"); // SOL/devUSDC
 
@@ -193,10 +200,9 @@ The SDKs offer three main functions to help developers monitor the pools:
     <ReactMarkdown>{splashPoolFetching}</ReactMarkdown>
 
     ```tsx
-    import { fetchSplashPool, setWhirlpoolsConfig } from '@orca-so/whirlpools';
+    import { fetchSplashPool, WhirlpoolDeployment } from '@orca-so/whirlpools';
     import { createSolanaRpc, devnet, address } from '@solana/kit';
 
-    await setWhirlpoolsConfig('solanaDevnet');
     const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
     const tokenMintOne = address("So11111111111111111111111111111111111111112");
     const tokenMintTwo = address("BRjpCHtyQLNCo8gqRUr8jtdAj5AjPYQaoqbvcZiHok1k"); //devUSDC
@@ -204,7 +210,8 @@ The SDKs offer three main functions to help developers monitor the pools:
     const poolInfo = await fetchSplashPool(
       devnetRpc,
       tokenMintOne,
-      tokenMintTwo
+      tokenMintTwo,
+      WhirlpoolDeployment.devnet,
     );
 
     if (poolInfo.initialized) {
@@ -217,10 +224,9 @@ The SDKs offer three main functions to help developers monitor the pools:
     <ReactMarkdown>{concentratedPoolFetching}</ReactMarkdown>
 
     ```tsx
-    import { fetchConcentratedLiquidityPool, setWhirlpoolsConfig } from '@orca-so/whirlpools';
+    import { fetchConcentratedLiquidityPool, WhirlpoolDeployment } from '@orca-so/whirlpools';
     import { createSolanaRpc, devnet, address } from '@solana/kit';
 
-    await setWhirlpoolsConfig('solanaDevnet');
     const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
 
     const tokenMintOne = address("So11111111111111111111111111111111111111112");
@@ -231,7 +237,8 @@ The SDKs offer three main functions to help developers monitor the pools:
       devnetRpc,
       tokenMintOne,
       tokenMintTwo,
-      tickSpacing
+      tickSpacing,
+      WhirlpoolDeployment.devnet,
     );
 
     if (poolInfo.initialized) {
@@ -244,10 +251,9 @@ The SDKs offer three main functions to help developers monitor the pools:
     <ReactMarkdown>{allPoolsFetching}</ReactMarkdown>
 
     ```tsx
-    import { fetchWhirlpoolsByTokenPair, setWhirlpoolsConfig } from '@orca-so/whirlpools';
+    import { fetchWhirlpoolsByTokenPair, WhirlpoolDeployment } from '@orca-so/whirlpools';
     import { createSolanaRpc, devnet, address } from '@solana/kit';
 
-    await setWhirlpoolsConfig('solanaDevnet');
     const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
 
     const tokenMintOne = address("So11111111111111111111111111111111111111112");
@@ -256,7 +262,8 @@ The SDKs offer three main functions to help developers monitor the pools:
     const poolInfos = await fetchWhirlpoolsByTokenPair(
       devnetRpc,
       tokenMintOne,
-      tokenMintTwo
+      tokenMintTwo,
+      WhirlpoolDeployment.devnet,
     );
 
     poolInfos.forEach((poolInfo) => {

--- a/docs/whirlpool/docs/03-SDKs/04-Position Management/01-Open Position.mdx
+++ b/docs/whirlpool/docs/03-SDKs/04-Position Management/01-Open Position.mdx
@@ -89,8 +89,8 @@ After opening a position, you can:
 
     ```rust
     use orca_whirlpools::{
-      open_full_range_position_instructions, set_whirlpools_config_address,
-      IncreaseLiquidityParam, WhirlpoolsConfigInput
+      open_full_range_position_instructions, IncreaseLiquidityParam,
+      OpenFullRangePositionConfig, WhirlpoolDeployment,
     };
     use solana_client::nonblocking::rpc_client::RpcClient;
     use solana_sdk::pubkey::Pubkey;
@@ -103,7 +103,6 @@ After opening a position, you can:
     #[tokio::main]
     async fn main() -> Result<(), Box<dyn std::error::Error>> {
       set_rpc("https://api.devnet.solana.com").await?;
-      set_whirlpools_config_address(WhirlpoolsConfigInput::SolanaDevnet).unwrap();
       let wallet = Keypair::new(); // Replace with your wallet loader
       let rpc = get_rpc_client()?;
       let whirlpool_address = Pubkey::from_str("3KBZiL2g8C7tiJ32hTv5v3KM7aK9htpqTw4cTXz1HvPt").unwrap();
@@ -113,8 +112,11 @@ After opening a position, you can:
         &rpc,
         whirlpool_address,
         param,
-        Some(100),
-        Some(wallet.pubkey())
+        OpenFullRangePositionConfig {
+          slippage_tolerance_bps: Some(100),
+          funder: Some(wallet.pubkey()),
+          whirlpool_deployment: Some(WhirlpoolDeployment::devnet()),
+        },
       ).await?;
 
       let mut signers: Vec<&dyn Signer> = vec![&wallet];
@@ -139,8 +141,8 @@ After opening a position, you can:
 
     ```rust
     use orca_whirlpools::{
-      open_position_instructions, set_whirlpools_config_address,
-      IncreaseLiquidityParam, WhirlpoolsConfigInput
+      open_position_instructions, IncreaseLiquidityParam, OpenPositionConfig,
+      WhirlpoolDeployment,
     };
     use solana_client::nonblocking::rpc_client::RpcClient;
     use solana_sdk::pubkey::Pubkey;
@@ -153,7 +155,6 @@ After opening a position, you can:
     #[tokio::main]
     async fn main() -> Result<(), Box<dyn std::error::Error>> {
       set_rpc("https://api.devnet.solana.com").await?;
-      set_whirlpools_config_address(WhirlpoolsConfigInput::SolanaDevnet).unwrap();
       let wallet = Keypair::new(); // Replace with your wallet loader
       let rpc = get_rpc_client()?;
       let whirlpool_address = Pubkey::from_str("3KBZiL2g8C7tiJ32hTv5v3KM7aK9htpqTw4cTXz1HvPt").unwrap();
@@ -165,8 +166,11 @@ After opening a position, you can:
         0.001,
         100.0,
         param,
-        Some(100),
-        Some(wallet.pubkey())
+        OpenPositionConfig {
+          slippage_tolerance_bps: Some(100),
+          funder: Some(wallet.pubkey()),
+          whirlpool_deployment: Some(WhirlpoolDeployment::devnet()),
+        },
       ).await?;
 
       let mut signers: Vec<&dyn Signer> = vec![&wallet];
@@ -206,10 +210,9 @@ After opening a position, you can:
     <ReactMarkdown>{splashPoolOpeningSteps}</ReactMarkdown>
 
     ```tsx
-    import { openFullRangePositionInstructions, setWhirlpoolsConfig } from '@orca-so/whirlpools';
+    import { openFullRangePositionInstructions, WhirlpoolDeployment } from '@orca-so/whirlpools';
     import { createSolanaRpc, devnet, address, generateKeyPairSigner } from '@solana/kit';
 
-    await setWhirlpoolsConfig('solanaDevnet');
     const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
     const wallet = await generateKeyPairSigner();
 
@@ -222,9 +225,11 @@ After opening a position, you can:
       devnetRpc,
       whirlpoolAddress,
       param,
-      100,
-      true,
-      wallet
+      {
+        slippageToleranceBps: 100,
+        funder: wallet,
+        whirlpoolDeployment: WhirlpoolDeployment.devnet,
+      },
     );
 
     // Build and send the transaction using your preferred method
@@ -235,10 +240,9 @@ After opening a position, you can:
     <ReactMarkdown>{concentratedPoolOpeningSteps}</ReactMarkdown>
 
     ```tsx
-    import { openPositionInstructions, setWhirlpoolsConfig } from '@orca-so/whirlpools';
+    import { openPositionInstructions, WhirlpoolDeployment } from '@orca-so/whirlpools';
     import { createSolanaRpc, devnet, address, generateKeyPairSigner } from '@solana/kit';
 
-    await setWhirlpoolsConfig('solanaDevnet');
     const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
     const wallet = await generateKeyPairSigner();
 
@@ -254,9 +258,11 @@ After opening a position, you can:
       param,
       lowerPrice,
       upperPrice,
-      100,
-      true,
-      wallet
+      {
+        slippageToleranceBps: 100,
+        funder: wallet,
+        whirlpoolDeployment: WhirlpoolDeployment.devnet,
+      },
     );
 
     console.log(`Initialization cost: ${initializationCost}`);

--- a/docs/whirlpool/docs/03-SDKs/04-Position Management/02-Adjust Liquidity.mdx
+++ b/docs/whirlpool/docs/03-SDKs/04-Position Management/02-Adjust Liquidity.mdx
@@ -69,8 +69,8 @@ By using the SDK to adjust liquidity, you gain flexibility in managing your posi
     ```rust
     use orca_whirlpools::{
         decrease_liquidity_instructions, increase_liquidity_instructions,
-        set_whirlpools_config_address, DecreaseLiquidityParam, IncreaseLiquidityParam,
-        WhirlpoolsConfigInput
+        DecreaseLiquidityConfig, DecreaseLiquidityParam, IncreaseLiquidityConfig,
+        IncreaseLiquidityParam, WhirlpoolDeployment,
     };
     use solana_client::nonblocking::rpc_client::RpcClient;
     use solana_sdk::pubkey::Pubkey;
@@ -83,7 +83,6 @@ By using the SDK to adjust liquidity, you gain flexibility in managing your posi
     #[tokio::main]
     async fn main() -> Result<(), Box<dyn std::error::Error>> {
         set_rpc("https://api.devnet.solana.com").await?;
-        set_whirlpools_config_address(WhirlpoolsConfigInput::SolanaDevnet).unwrap();
         let wallet = Keypair::new(); // Replace with your wallet loader
         let rpc = get_rpc_client()?;
         let position_mint_address = Pubkey::from_str("HqoV7Qv27REUtmd9UKSJGGmCRNx3531t33bDG1BUfo9K").unwrap();
@@ -94,8 +93,11 @@ By using the SDK to adjust liquidity, you gain flexibility in managing your posi
             &rpc,
             position_mint_address,
             increase_param,
-            Some(100),
-            Some(wallet.pubkey()),
+            IncreaseLiquidityConfig {
+                slippage_tolerance_bps: Some(100),
+                authority: Some(wallet.pubkey()),
+                whirlpool_deployment: Some(WhirlpoolDeployment::devnet()),
+            },
         )
         .await?;
 
@@ -115,8 +117,11 @@ By using the SDK to adjust liquidity, you gain flexibility in managing your posi
             &rpc,
             position_mint_address,
             decrease_param,
-            Some(100),
-            Some(wallet.pubkey()),
+            DecreaseLiquidityConfig {
+                slippage_tolerance_bps: Some(100),
+                authority: Some(wallet.pubkey()),
+                whirlpool_deployment: Some(WhirlpoolDeployment::devnet()),
+            },
         )
         .await?;
 
@@ -151,10 +156,9 @@ By using the SDK to adjust liquidity, you gain flexibility in managing your posi
     <ReactMarkdown>{startingGuideText}</ReactMarkdown>
 
     ```tsx
-    import { decreaseLiquidityInstructions, increaseLiquidityInstructions, setWhirlpoolsConfig } from '@orca-so/whirlpools';
+    import { decreaseLiquidityInstructions, increaseLiquidityInstructions, WhirlpoolDeployment } from '@orca-so/whirlpools';
     import { createSolanaRpc, devnet, address, generateKeyPairSigner } from '@solana/kit';
 
-    await setWhirlpoolsConfig('solanaDevnet');
     const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
     const wallet = await generateKeyPairSigner();
 
@@ -166,8 +170,11 @@ By using the SDK to adjust liquidity, you gain flexibility in managing your posi
         devnetRpc,
         positionMint,
         increaseParam,
-        100,
-        wallet
+        {
+            slippageToleranceBps: 100,
+            authority: wallet,
+            whirlpoolDeployment: WhirlpoolDeployment.devnet,
+        },
     );
 
     // Decrease: specify one of tokenA, tokenB, or liquidity
@@ -176,8 +183,11 @@ By using the SDK to adjust liquidity, you gain flexibility in managing your posi
         devnetRpc,
         positionMint,
         decreaseParam,
-        100,
-        wallet
+        {
+            slippageToleranceBps: 100,
+            authority: wallet,
+            whirlpoolDeployment: WhirlpoolDeployment.devnet,
+        },
     );
 
     console.log(`Decrease quote estimated token B: ${decreaseQuote.tokenEstB}`);

--- a/docs/whirlpool/docs/03-SDKs/04-Position Management/03-Harvest.mdx
+++ b/docs/whirlpool/docs/03-SDKs/04-Position Management/03-Harvest.mdx
@@ -141,6 +141,7 @@ By using the SDK, you can maximize the benefits of providing liquidity while kee
     );
 
     // Use the callback to submit the transaction
+    // Add a payer explicitly (e.g. `sendTx(payer)`) or default to the global payer from `setPayerFromBytes()`    
     const txId = await sendTx();
 
     console.log(`Fees owed token A: ${feesQuote.feeOwedA}`);

--- a/docs/whirlpool/docs/03-SDKs/04-Position Management/03-Harvest.mdx
+++ b/docs/whirlpool/docs/03-SDKs/04-Position Management/03-Harvest.mdx
@@ -58,7 +58,7 @@ By using the SDK, you can maximize the benefits of providing liquidity while kee
 
     ```rust
     use orca_whirlpools::{
-        harvest_position_instructions, set_whirlpools_config_address, WhirlpoolsConfigInput,
+        harvest_position_instructions, HarvestPositionConfig, WhirlpoolDeployment,
     };
     use solana_client::nonblocking::rpc_client::RpcClient;
     use solana_sdk::pubkey::Pubkey;
@@ -74,15 +74,21 @@ By using the SDK, you can maximize the benefits of providing liquidity while kee
     #[tokio::main]
     async fn main() -> Result<(), Box<dyn std::error::Error>> {
         set_rpc("https://api.devnet.solana.com").await?;
-        set_whirlpools_config_address(WhirlpoolsConfigInput::SolanaDevnet).unwrap();
         let wallet = load_wallet();
         let rpc = get_rpc_client()?;
 
         let position_mint_address =
             Pubkey::from_str("HqoV7Qv27REUtmd9UKSJGGmCRNx3531t33bDG1BUfo9K").unwrap();
 
-        let result = harvest_position_instructions(&rpc, position_mint_address, Some(wallet.pubkey()))
-            .await?;
+        let result = harvest_position_instructions(
+            &rpc,
+            position_mint_address,
+            HarvestPositionConfig {
+                authority: Some(wallet.pubkey()),
+                whirlpool_deployment: Some(WhirlpoolDeployment::devnet()),
+            },
+        )
+        .await?;
 
         // The instructions may include new token accounts that need to be created
         // and signed for with their corresponding Keypair.
@@ -121,19 +127,17 @@ By using the SDK, you can maximize the benefits of providing liquidity while kee
     <ReactMarkdown>{startingGuideText}</ReactMarkdown>
 
     ```tsx
-    import { harvestPosition, setWhirlpoolsConfig } from '@orca-so/whirlpools';
-    import { createSolanaRpc, devnet, address, setRpc, setPayerFromBytes } from '@solana/kit';
+    import { harvestPosition, setRpc, setPayerFromBytes, WhirlpoolDeployment } from '@orca-so/whirlpools';
+    import { address } from '@solana/kit';
     import secret from "wallet.json";
 
-    await setWhirlpoolsConfig('solanaDevnet');
     await setRpc('https://api.devnet.solana.com');
-    const signer = await setPayerFromBytes(new Uint8Array(secret));
+    await setPayerFromBytes(new Uint8Array(secret));
     const positionMint = address("HqoV7Qv27REUtmd9UKSJGGmCRNx3531t33bDG1BUfo9K");
 
     const { feesQuote, rewardsQuote, instructions, callback: sendTx } = await harvestPosition(
-      devnetRpc,
       positionMint,
-      signer
+      { whirlpoolDeployment: WhirlpoolDeployment.devnet },
     );
 
     // Use the callback to submit the transaction

--- a/docs/whirlpool/docs/03-SDKs/04-Position Management/04-Close Position.mdx
+++ b/docs/whirlpool/docs/03-SDKs/04-Position Management/04-Close Position.mdx
@@ -62,7 +62,7 @@ After closing a position, you can:
     ```rust
     use crate::utils::load_wallet;
     use orca_whirlpools::{
-        close_position_instructions, set_whirlpools_config_address, WhirlpoolsConfigInput,
+        close_position_instructions, ClosePositionConfig, WhirlpoolDeployment,
     };
     use solana_client::nonblocking::rpc_client::RpcClient;
     use solana_sdk::pubkey::Pubkey;
@@ -77,7 +77,6 @@ After closing a position, you can:
     #[tokio::main]
     async fn main() -> Result<(), Box<dyn std::error::Error>> {
         set_rpc("https://api.devnet.solana.com").await?;
-        set_whirlpools_config_address(WhirlpoolsConfigInput::SolanaDevnet).unwrap();
         let wallet = load_wallet();
         let rpc = get_rpc_client()?;
 
@@ -87,8 +86,11 @@ After closing a position, you can:
         let result = close_position_instructions(
             &rpc,
             position_mint_address,
-            Some(100),
-            Some(wallet.pubkey()),
+            ClosePositionConfig {
+                slippage_tolerance_bps: Some(100),
+                authority: Some(wallet.pubkey()),
+                whirlpool_deployment: Some(WhirlpoolDeployment::devnet()),
+            },
         )
         .await?;
 
@@ -131,20 +133,20 @@ After closing a position, you can:
     <ReactMarkdown>{startingGuideText}</ReactMarkdown>
 
     ```tsx
-    import { closePosition, setWhirlpoolsConfig } from '@orca-so/whirlpools';
-    import { createSolanaRpc, devnet, address, setRpc, setPayerFromBytes } from '@solana/kit';
+    import { closePosition, setRpc, setPayerFromBytes, WhirlpoolDeployment } from '@orca-so/whirlpools';
+    import { address } from '@solana/kit';
     import secret from "wallet.json";
 
-    await setWhirlpoolsConfig('solanaDevnet');
     await setRpc('https://api.devnet.solana.com');
-    const signer = await setPayerFromBytes(new Uint8Array(secret));
+    await setPayerFromBytes(new Uint8Array(secret));
     const positionMint = address("HqoV7Qv27REUtmd9UKSJGGmCRNx3531t33bDG1BUfo9K");
 
     const { instructions, quote, feesQuote, rewardsQuote, callback: sendTx } = await closePosition(
-      devnetRpc,
       positionMint,
-      100,
-      signer
+      {
+        slippageToleranceBps: 100,
+        whirlpoolDeployment: WhirlpoolDeployment.devnet,
+      },
     );
 
     // Use the callback to submit the transaction 

--- a/docs/whirlpool/docs/03-SDKs/04-Position Management/04-Close Position.mdx
+++ b/docs/whirlpool/docs/03-SDKs/04-Position Management/04-Close Position.mdx
@@ -150,6 +150,7 @@ After closing a position, you can:
     );
 
     // Use the callback to submit the transaction 
+    // Add a payer explicitly (e.g. `sendTx(payer)`) or default to the global payer from `setPayerFromBytes()`    
     const txId = await sendTx();
 
     console.log(`Quote token max B: ${quote.tokenEstB}`);

--- a/docs/whirlpool/docs/03-SDKs/04-Position Management/05-Monitor Positions.mdx
+++ b/docs/whirlpool/docs/03-SDKs/04-Position Management/05-Monitor Positions.mdx
@@ -93,23 +93,24 @@ By effectively monitoring positions, you gain the insights needed to optimize yo
     <ReactMarkdown>{walletPositionsSection}</ReactMarkdown>
     
     ```rust
-    use orca_whirlpools::{
-        fetch_positions_for_owner, set_whirlpools_config_address, WhirlpoolsConfigInput
-    };
+    use orca_whirlpools::{fetch_positions_for_owner, WhirlpoolDeployment};
     use solana_client::nonblocking::rpc_client::RpcClient;
     use solana_sdk::pubkey::Pubkey;
     use std::str::FromStr;
 
     #[tokio::main]
     async fn main() {
-        set_whirlpools_config_address(WhirlpoolsConfigInput::SolanaDevnet).unwrap();
         let rpc = RpcClient::new("https://api.devnet.solana.com".to_string());
         let owner_address =
             Pubkey::from_str("3KBZiL2g8C7tiJ32hTv5v3KM7aK9htpqTw4cTXz1HvPt").unwrap();
 
-        let positions = fetch_positions_for_owner(&rpc, owner_address)
-            .await
-            .unwrap();
+        let positions = fetch_positions_for_owner(
+            &rpc,
+            owner_address,
+            Some(WhirlpoolDeployment::devnet().id()),
+        )
+        .await
+        .unwrap();
 
         println!("Positions: {:?}", positions);
     }
@@ -118,23 +119,24 @@ By effectively monitoring positions, you gain the insights needed to optimize yo
     <ReactMarkdown>{whirlpoolPositionsSection}</ReactMarkdown>
     
     ```rust
-    use orca_whirlpools::{
-        fetch_positions_in_whirlpool, set_whirlpools_config_address, WhirlpoolsConfigInput,
-    };
+    use orca_whirlpools::{fetch_positions_in_whirlpool, WhirlpoolDeployment};
     use solana_client::nonblocking::rpc_client::RpcClient;
     use solana_sdk::pubkey::Pubkey;
     use std::str::FromStr;
 
     #[tokio::main]
     async fn main() {
-        set_whirlpools_config_address(WhirlpoolsConfigInput::SolanaDevnet).unwrap();
         let rpc = RpcClient::new("https://api.devnet.solana.com".to_string());
         let whirlpool_address =
             Pubkey::from_str("3KBZiL2g8C7tiJ32hTv5v3KM7aK9htpqTw4cTXz1HvPt").unwrap();
 
-        let positions = fetch_positions_in_whirlpool(&rpc, whirlpool_address)
-            .await
-            .unwrap();
+        let positions = fetch_positions_in_whirlpool(
+            &rpc,
+            whirlpool_address,
+            Some(WhirlpoolDeployment::devnet().id()),
+        )
+        .await
+        .unwrap();
 
         println!("Positions: {:?}", positions);
     }
@@ -157,14 +159,13 @@ By effectively monitoring positions, you gain the insights needed to optimize yo
     <ReactMarkdown>{walletPositionsSection}</ReactMarkdown>
 
     ```tsx
-    import { fetchPositionsForOwner, setWhirlpoolsConfig } from '@orca-so/whirlpools';
+    import { fetchPositionsForOwner, WhirlpoolDeployment } from '@orca-so/whirlpools';
     import { createSolanaRpc, devnet, address } from '@solana/kit';
 
-    await setWhirlpoolsConfig('solanaDevnet');
     const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
     const owner = address("3KBZiL2g8C7tiJ32hTv5v3KM7aK9htpqTw4cTXz1HvPt"); // set an owner address
 
-    const positions = await fetchPositionsForOwner(devnetRpc, owner);
+    const positions = await fetchPositionsForOwner(devnetRpc, owner, WhirlpoolDeployment.devnet);
 
     console.log(positions);
     ```
@@ -172,14 +173,13 @@ By effectively monitoring positions, you gain the insights needed to optimize yo
     <ReactMarkdown>{whirlpoolPositionsSection}</ReactMarkdown>
 
     ```tsx
-    import { fetchPositionsInWhirlpool, setWhirlpoolsConfig } from '@orca-so/whirlpools';
+    import { fetchPositionsInWhirlpool, WhirlpoolDeployment } from '@orca-so/whirlpools';
     import { createSolanaRpc, devnet, address } from '@solana/kit';
 
-    await setWhirlpoolsConfig('solanaDevnet');
     const devnetRpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
     const whirlpoolAddress = address("3KBZiL2g8C7tiJ32hTv5v3KM7aK9htpqTw4cTXz1HvPt");
 
-    const positions = await fetchPositionsInWhirlpool(devnetRpc, whirlpoolAddress);
+    const positions = await fetchPositionsInWhirlpool(devnetRpc, whirlpoolAddress, WhirlpoolDeployment.devnet);
 
     console.log(positions);
     ```

--- a/docs/whirlpool/docs/03-SDKs/05-Trade.mdx
+++ b/docs/whirlpool/docs/03-SDKs/05-Trade.mdx
@@ -161,6 +161,7 @@ This guide explains how to use the SDK to perform a token swap in an Orca Whirlp
     );
 
     // Use the callback to submit the transaction
+    // Add a payer explicitly (e.g. `sendTx(payer)`) or default to the global payer from `setPayerFromBytes()`
     const txId = await sendTx();
 
     console.log(`Quote estimated token out: ${quote.tokenEstOut}`);

--- a/docs/whirlpool/docs/03-SDKs/05-Trade.mdx
+++ b/docs/whirlpool/docs/03-SDKs/05-Trade.mdx
@@ -45,16 +45,13 @@ This guide explains how to use the SDK to perform a token swap in an Orca Whirlp
 
     ```rust
     use crate::utils::load_wallet;
-    use orca_whirlpools::{
-        set_whirlpools_config_address, swap_instructions, SwapType, WhirlpoolsConfigInput,
-    };
+    use orca_whirlpools::{swap_instructions, SwapConfig, SwapType, WhirlpoolDeployment};
     use solana_client::nonblocking::rpc_client::RpcClient;
     use solana_sdk::pubkey::Pubkey;
     use std::str::FromStr;
 
     #[tokio::main]
     async fn main() {
-        set_whirlpools_config_address(WhirlpoolsConfigInput::SolanaDevnet).unwrap();
         let rpc = RpcClient::new("https://api.devnet.solana.com".to_string());
         let wallet = load_wallet();
         let whirlpool_address =
@@ -68,8 +65,11 @@ This guide explains how to use the SDK to perform a token swap in an Orca Whirlp
             input_amount,
             mint_address,
             SwapType::ExactIn,
-            Some(100),
-            Some(wallet.pubkey()),
+            SwapConfig {
+                slippage_tolerance_bps: Some(100),
+                signer: Some(wallet.pubkey()),
+                whirlpool_deployment: Some(WhirlpoolDeployment::devnet()),
+            },
         )
         .await
         .unwrap();
@@ -140,11 +140,10 @@ This guide explains how to use the SDK to perform a token swap in an Orca Whirlp
     7. **Submit Transaction**: Use the callback to submit the transaction.
 
     ```tsx
-    import { setWhirlpoolsConfig, swap, setRpc, setPayerFromBytes } from '@orca-so/whirlpools';
-    import { createSolanaRpc, address } from '@solana/kit';
+    import { swap, setRpc, setPayerFromBytes, WhirlpoolDeployment } from '@orca-so/whirlpools';
+    import { address } from '@solana/kit';
     import secret from "wallet.json";
 
-    await setWhirlpoolsConfig('solanaDevnet');
     await setRpc('https://api.devnet.solana.com');
     await setPayerFromBytes(new Uint8Array(secret));
 
@@ -155,7 +154,10 @@ This guide explains how to use the SDK to perform a token swap in an Orca Whirlp
     const { instructions, quote, callback: sendTx } = await swap(
       { inputAmount, mint: mintAddress },
       whirlpoolAddress,
-      100
+      {
+        slippageToleranceBps: 100,
+        whirlpoolDeployment: WhirlpoolDeployment.devnet,
+      },
     );
 
     // Use the callback to submit the transaction


### PR DESCRIPTION
## Update SDK docs to reflect new WhirlpoolDeployment API

## Details
The Whirlpools SDK replaced the global setWhirlpoolsConfig / set_whirlpools_config_address pattern with a WhirlpoolDeployment value passed directly into each SDK function call. This PR updates all SDK documentation to reflect that change.

**Key updates:**
- Replace `setWhirlpoolsConfig` / `set_whirlpools_config_address` + `WhirlpoolsConfigInput` with the new `WhirlpoolDeployment` constructors (mainnet, devnet, mainnetImmutable, custom)
- Update all code samples to pass `whirlpool_deployment` (Rust) / `whirlpoolDeployment` (TypeScript) as part of the per-call config struct rather than as a global side effect
- Reframe the "Configure the SDK for Your Network" section as "Select a Whirlpool Deployment" to match the new mental model