### PR TITLE
fix(whirlpool): flush final batch in harvestAllPositionFees (#1298)

### DIFF
--- a/.changeset/harvest-all-position-fees-flush-fix.md
+++ b/.changeset/harvest-all-position-fees-flush-fix.md
@@ -1,0 +1,5 @@
+---
+"@orca-so/whirlpools": patch
+---
+
+Fix `harvestAllPositionFees` to flush the final instruction batch so all positions are harvested when instructions stay within or cross the transaction size limit.

--- a/ts-sdk/whirlpool/src/actionHelpers.ts
+++ b/ts-sdk/whirlpool/src/actionHelpers.ts
@@ -71,3 +71,8 @@ export async function wouldExceedTransactionSize(
 
   return encodedTransaction.length >= TX_BASE64_ENCODED_SIZE_LIMIT;
 }
+
+export {
+  packIntoTransactionSets,
+  type SizeExceedsPredicate,
+} from "./transactionBatching";

--- a/ts-sdk/whirlpool/src/harvest.ts
+++ b/ts-sdk/whirlpool/src/harvest.ts
@@ -42,10 +42,15 @@ import { MEMO_PROGRAM_ADDRESS } from "@solana-program/memo";
 import assert from "assert";
 import {
   executeWithCallback,
+  packIntoTransactionSets,
   wouldExceedTransactionSize,
 } from "./actionHelpers";
 import { rpcFromUrl, buildAndSendTransaction } from "@orca-so/tx-sender";
-import { fetchPositionsForOwner } from "./position";
+import {
+  fetchPositionsForOwner,
+  type HydratedPosition,
+  type PositionData,
+} from "./position";
 
 // TODO: Transfer hook
 
@@ -329,27 +334,25 @@ export async function harvestAllPositionFees(
     owner.address,
     whirlpoolDeployment,
   );
-  const instructionSets: Instruction[][] = [];
-  let currentInstructions: Instruction[] = [];
-  for (const position of positions) {
-    if ("positionMint" in position.data) {
+  const harvestablePositions = positions.filter(
+    (position): position is HydratedPosition & PositionData =>
+      !position.isPositionBundle,
+  );
+  const instructionSets = await packIntoTransactionSets(
+    harvestablePositions,
+    async (position) => {
       const { instructions } = await harvestPositionInstructions(
         rpc,
         position.data.positionMint,
         { authority: owner, whirlpoolDeployment },
       );
-      if (await wouldExceedTransactionSize(currentInstructions, instructions)) {
-        instructionSets.push(currentInstructions);
-        currentInstructions = [...instructions];
-      } else {
-        currentInstructions.push(...instructions);
-      }
-    }
-  }
+      return instructions;
+    },
+    wouldExceedTransactionSize,
+  );
   return Promise.all(
-    instructionSets.map(async (instructions) => {
-      const txHash = await buildAndSendTransaction(instructions, owner);
-      return txHash;
-    }),
+    instructionSets.map((instructions) =>
+      buildAndSendTransaction(instructions, owner),
+    ),
   );
 }

--- a/ts-sdk/whirlpool/src/transactionBatching.ts
+++ b/ts-sdk/whirlpool/src/transactionBatching.ts
@@ -1,0 +1,46 @@
+import type { Instruction } from "@solana/kit";
+
+/**
+ * Predicate used by {@link packIntoTransactionSets} to decide when to flush
+ * the current batch.
+ */
+export type SizeExceedsPredicate = (
+  current: Instruction[],
+  next: Instruction[],
+) => Promise<boolean>;
+
+/**
+ * Pack instructions for a sequence of items into transaction-sized batches.
+ *
+ * For each item, fetch its instructions and append them to the current batch.
+ * If appending would exceed the transaction size limit, the current batch is
+ * finalised and a new batch is started with that item's instructions. After
+ * the loop, the trailing batch is always flushed if non-empty.
+ *
+ * Items whose `buildInstructions` returns an empty list are skipped — they
+ * neither start a new batch nor trigger a flush.
+ */
+export async function packIntoTransactionSets<T>(
+  items: readonly T[],
+  buildInstructions: (item: T) => Promise<Instruction[]>,
+  sizeExceeds: SizeExceedsPredicate,
+): Promise<Instruction[][]> {
+  const sets: Instruction[][] = [];
+  let current: Instruction[] = [];
+  for (const item of items) {
+    const next = await buildInstructions(item);
+    if (next.length === 0) {
+      continue;
+    }
+    if (current.length > 0 && (await sizeExceeds(current, next))) {
+      sets.push(current);
+      current = [...next];
+    } else {
+      current.push(...next);
+    }
+  }
+  if (current.length > 0) {
+    sets.push(current);
+  }
+  return sets;
+}

--- a/ts-sdk/whirlpool/tests/transactionBatching.test.ts
+++ b/ts-sdk/whirlpool/tests/transactionBatching.test.ts
@@ -1,0 +1,86 @@
+import type { Instruction } from "@solana/kit";
+import assert from "assert";
+import { describe, it } from "vitest";
+import { packIntoTransactionSets } from "../src/transactionBatching";
+
+const ix = (id: string): Instruction =>
+  ({ programAddress: id }) as unknown as Instruction;
+
+describe("packIntoTransactionSets", () => {
+  it("returns an empty array when there are no items", async () => {
+    const sets = await packIntoTransactionSets<string>(
+      [],
+      async () => [],
+      async () => false,
+    );
+    assert.deepStrictEqual(sets, []);
+  });
+
+  it("returns a single batch when nothing exceeds the limit", async () => {
+    const sets = await packIntoTransactionSets(
+      ["a", "b", "c"],
+      async (item) => [ix(item)],
+      async () => false,
+    );
+    assert.deepStrictEqual(sets, [[ix("a"), ix("b"), ix("c")]]);
+  });
+
+  it("flushes the trailing batch after a split (regression for #1298)", async () => {
+    // Predicate fires once between items 2 and 3, then never again.
+    let calls = 0;
+    const sets = await packIntoTransactionSets(
+      ["a", "b", "c", "d"],
+      async (item) => [ix(item)],
+      async () => {
+        calls += 1;
+        return calls === 2;
+      },
+    );
+    assert.deepStrictEqual(sets, [
+      [ix("a"), ix("b")],
+      [ix("c"), ix("d")],
+    ]);
+  });
+
+  it("never pushes an empty batch when the first item alone would overflow", async () => {
+    // A predicate that always returns true would, without the guard, push an
+    // empty `current` batch on the first iteration.
+    const sets = await packIntoTransactionSets(
+      ["a", "b"],
+      async (item) => [ix(item)],
+      async () => true,
+    );
+    assert.deepStrictEqual(sets, [[ix("a")], [ix("b")]]);
+    for (const set of sets) {
+      assert.ok(set.length > 0, "no empty batches should be emitted");
+    }
+  });
+
+  it("skips items whose buildInstructions returns an empty list", async () => {
+    const sets = await packIntoTransactionSets(
+      ["a", "skip", "b"],
+      async (item) => (item === "skip" ? [] : [ix(item)]),
+      async () => false,
+    );
+    assert.deepStrictEqual(sets, [[ix("a"), ix("b")]]);
+  });
+
+  it("splits into many batches and includes every item exactly once", async () => {
+    // Predicate returns true every other call to force frequent splits.
+    let calls = 0;
+    const items = ["a", "b", "c", "d", "e"];
+    const sets = await packIntoTransactionSets(
+      items,
+      async (item) => [ix(item)],
+      async () => {
+        calls += 1;
+        return calls % 2 === 0;
+      },
+    );
+    const flattened = sets.flat().map((i) => i.programAddress);
+    assert.deepStrictEqual(flattened, items);
+    for (const set of sets) {
+      assert.ok(set.length > 0);
+    }
+  });
+});


### PR DESCRIPTION
fix(whirlpool): flush final batch in harvestAllPositionFees (#1298)

`harvestAllPositionFees` accumulated instructions into a
`currentInstructions` buffer and only pushed it onto `instructionSets`
when the next position would overflow the transaction size limit.

The trailing buffer was never flushed after the loop, so:

- If the combined instructions stayed under the size limit, the function
  returned `[]` and sent zero transactions.
- If the limit was exceeded one or more times, earlier batches were
  emitted, but the final batch was silently dropped, leaving some
  positions unharvested.

Extract the batching loop into a small, dependency-free helper:
`packIntoTransactionSets`.

The helper now:

- Always flushes the trailing batch
- Never emits empty batches
- Skips items whose `buildInstructions` returns no instructions

Added unit tests covering:

- Empty input
- Single batch
- Trailing flush
- First-item overflow
- Skipped items
- Repeated splits

Fixes #1298