### PR TITLE
Crnorthc/fix publish

### DIFF
--- a/.changeset/fix-docs-deploy-version-probe.md
+++ b/.changeset/fix-docs-deploy-version-probe.md
@@ -1,0 +1,5 @@
+---
+"@orca-so/whirlpools-docs": patch
+---
+
+Fix the docs deploy step failing in CI. The version probe in `scripts/deploy-docs` aborted under `set -eo pipefail` when grep found no match, and the `<meta itemprop="version">` tag was no longer reaching the served HTML. The tag is now emitted via `<Head>` and the probe tolerates a missing match.

--- a/docs/whirlpool/src/theme/Root.js
+++ b/docs/whirlpool/src/theme/Root.js
@@ -1,11 +1,14 @@
 import React from "react";
+import Head from "@docusaurus/Head";
 import packageJson from "../../package.json";
 
 export default function Root({ children }) {
   return (
     <>
       {children}
-      <meta itemProp="version" content={packageJson.version} />
+      <Head>
+        <meta itemProp="version" content={packageJson.version} />
+      </Head>
     </>
   );
 }

--- a/scripts/deploy-docs
+++ b/scripts/deploy-docs
@@ -4,8 +4,11 @@ set -eo pipefail
 # Get the local version from package.json
 local_version=$(jq -r ".version" package.json)
 
-# Get the published version from github
-published_version=$(curl -s https://orca-so.github.io/whirlpools/ | grep -o '<meta itemprop="version" content="[^"]*"' | cut -d'"' -f4)
+# Get the published version from github.
+# `|| true` keeps the pipeline from aborting the script (set -eo pipefail) when
+# grep finds no match (e.g. the meta tag is missing); an empty value is treated
+# as version 0 by the comparison below, so we fall through to publishing.
+published_version=$(curl -s https://orca-so.github.io/whirlpools/ | grep -o 'itemprop="version" content="[^"]*"' | cut -d'"' -f4 || true)
 
 function semver { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
 


### PR DESCRIPTION
**Title**
Fix docs deploy step failing in the Publish workflow

**Details**
The `deploy` step of the Publish workflow was failing in the
`@orca-so/whirlpools-docs` workspace with exit code 1, which in turn broke the
topological run for every workspace that depends on it
(`can't satisfy the dependency graph`).

Two issues, both surfaced by #1315 (the docs site moving to
`orca-so.github.io/whirlpools` and away from `dev.orca.so`):

1. **`scripts/deploy-docs` aborted silently.** The script scrapes the published
   site for a `<meta itemprop="version">` tag to decide whether to redeploy.
   When `grep` found no match it exited with status 1, and under
   `set -eo pipefail` that killed the whole script before it printed anything or
   compared versions — hence the bare `exit code 1`.

2. **The version meta tag wasn't in the served HTML.** It was rendered in the
   React body of `Root.js`, so it never reached the static `<head>`, and
   react-helmet renders it as `<meta data-rh="true" itemprop="version" ...>`,
   which the script's anchored `<meta itemprop=...` pattern would not match
   anyway.

Changes:
- `scripts/deploy-docs`: add `|| true` so a no-match no longer aborts the
  script (an empty value is treated as version 0, falling through to publish),
  and loosen the grep pattern to `itemprop="version" content="..."` so it
  matches regardless of attribute ordering.
- `docs/whirlpool/src/theme/Root.js`: emit the version meta tag via
  `@docusaurus/Head` so it lands in the static HTML `<head>`.
