### PR TITLE
remove hidden cu margin minimum in transaction builder

### DIFF
--- a/.changeset/three-cities-sing.md
+++ b/.changeset/three-cities-sing.md
@@ -1,0 +1,5 @@
+---
+"@orca-so/common-sdk": patch
+---
+
+Remove minimum CU margin when estimating compute units

--- a/legacy-sdk/common/src/web3/transactions/compute-budget.ts
+++ b/legacy-sdk/common/src/web3/transactions/compute-budget.ts
@@ -48,10 +48,7 @@ export async function estimateComputeBudgetLimit(
     if (!simulation.value.unitsConsumed) {
       return DEFAULT_MAX_COMPUTE_UNIT_LIMIT;
     }
-    const marginUnits = Math.max(
-      100_000,
-      margin * simulation.value.unitsConsumed,
-    );
+    const marginUnits = margin * simulation.value.unitsConsumed;
     const estimatedUnits = Math.ceil(
       simulation.value.unitsConsumed + marginUnits,
     );


### PR DESCRIPTION
## Motivation

We use TransactionBuilder in coralreef. In these transactions, it's often the case that we are grossly overestimating CU consumption due to this maximum. Maybe there's not as big of an impact on normal transactions, but I think there's a compounding effect when used with Jito bundles.

Unless there's a good reason to keep, I'd like to remove this in favor of only applying the requested margin. Without this, it's annoying for the caller to have to go back and manually manipulate the values in the CU budget instruction. 