### PR TITLE
docs(ts-sdk): fix JSDoc for calculateMinimumBalanceForRentExemption

### DIFF
--- a/ts-sdk/whirlpool/src/sysvar.ts
+++ b/ts-sdk/whirlpool/src/sysvar.ts
@@ -8,7 +8,7 @@ const ACCOUNT_STORAGE_OVERHEAD = 128;
 /**
  * Calculates the minimum balance required for rent exemption for a given account size.
  *
- * @param {Rpc} rpc - The Solana RPC client to fetch sysvar rent data.
+ * @param {SysvarRent} rent - The connected cluster's Rent sysvar, obtained via `fetchSysvarRent(rpc)`.
  * @param {number} dataSize - The size of the account data in bytes.
  * @returns {bigint} The minimum balance required for rent exemption in lamports.
  */

--- a/ts-sdk/whirlpool/src/sysvar.ts
+++ b/ts-sdk/whirlpool/src/sysvar.ts
@@ -8,7 +8,7 @@ const ACCOUNT_STORAGE_OVERHEAD = 128;
 /**
  * Calculates the minimum balance required for rent exemption for a given account size.
  *
- * @param {Rpc} rpc - The Solana RPC client to fetch sysvar rent data.
+ * @param {SysvarRent} rent - The sysvar rent data used to compute the minimum balance.
  * @param {number} dataSize - The size of the account data in bytes.
  * @returns {bigint} The minimum balance required for rent exemption in lamports.
  */


### PR DESCRIPTION
## Summary

This PR fixes the JSDoc for `calculateMinimumBalanceForRentExemption` so that it matches the actual function signature.

### Changes

- Updated the first parameter type from `Rpc` to `SysvarRent`
- Updated the parameter description accordingly

Closes #1319.