### PR TITLE
fix position_ratio overflow

### DIFF
--- a/.changeset/orange-buttons-shave.md
+++ b/.changeset/orange-buttons-shave.md
@@ -1,0 +1,10 @@
+---
+"@orca-so/whirlpools-rust-core": patch
+---
+
+fixes a panic in `position_ratio` caused by U256 overflow. the previous
+implementation computed `current_sqrt_price^2` as an independent term and
+then multiplied it into an already-large intermediate, which overflowed
+U256 at high tick indexes. the new form is algebraically equivalent but
+avoids ever materializing the squared term, so it stays within U256 range
+across the full whirlpool tick range.

--- a/.changeset/wasm-position-ratio.md
+++ b/.changeset/wasm-position-ratio.md
@@ -1,0 +1,5 @@
+---
+"@orca-so/whirlpools-core": patch
+---
+
+Rebuild WASM bindings to pick up the `positionRatio` (U256 overflow) fix from whirlpools-rust-core.

--- a/rust-sdk/core/src/math/position.rs
+++ b/rust-sdk/core/src/math/position.rs
@@ -98,15 +98,12 @@ pub fn position_ratio(
             let upper_sqrt_price: u128 =
                 tick_index_to_sqrt_price(tick_range.tick_upper_index).into();
 
-            let l: U256 = <U256>::from(1u16) << 128;
-            let p = <U256>::from(current_sqrt_price) * <U256>::from(current_sqrt_price);
+            let upper_minus_current = upper_sqrt_price - current_sqrt_price;
+            let deposit_a: U256 =
+                ((<U256>::from(current_sqrt_price) * <U256>::from(upper_minus_current)) << 64)
+                    / upper_sqrt_price;
 
-            let deposit_a_1: U256 = (l << 64) / current_sqrt_price;
-            let deposit_a_2: U256 = (l << 64) / upper_sqrt_price;
-            let deposit_a: U256 = ((deposit_a_1 - deposit_a_2) * p) >> 128;
-
-            let deposit_b_1 = current_sqrt_price - lower_sqrt_price;
-            let deposit_b = (l * deposit_b_1) >> 64;
+            let deposit_b: U256 = <U256>::from(current_sqrt_price - lower_sqrt_price) << 64;
 
             let total_deposit = deposit_a + deposit_b;
 
@@ -192,5 +189,9 @@ mod test {
         let ratio_5 = position_ratio(7267764841821948241, -21136, -17240);
         assert_eq!(ratio_5.ratio_a, 3630);
         assert_eq!(ratio_5.ratio_b, 6370);
+
+        let ratio_6 = position_ratio(228505006966548509531, 46976, 53696);
+        assert_eq!(ratio_6.ratio_a, 5000);
+        assert_eq!(ratio_6.ratio_b, 5000);
     }
 }


### PR DESCRIPTION
# Motivation

Large `sqrt_price` values caused a panic while testing position management on the [SPCX/USDC pool](https://www.orca.so/pools/FgjxPHeYsq1axH29fnGKZi6UyRWi4tMPHgu1gc3ezA9U). The update here algebraically re-arranges the math operations so that we never materialize p = sqrt_price^2 and then apply another multiply operation.

## Previous test behavior

```rust
// test case

// price = 153.4447367380454
// lower = 109.65785788756558
// upper = 214.71928801414012
println!(
    "price: {:?}",
    sqrt_price_to_price(228505006966548509531, 6, 6)
);
println!("lower: {:?}", tick_index_to_price(46976, 6, 6));
println!("upper: {:?}", tick_index_to_price(53696, 6, 6));

let ratio_6 = position_ratio(228505006966548509531, 46976, 53696);
assert_eq!(ratio_6.ratio_a, 5000);
assert_eq!(ratio_6.ratio_b, 5000);

// output

cargo test --lib math::position

warning: `orca_whirlpools_core` (lib test) generated 5 warnings
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.46s
     Running unittests src/lib.rs (target/debug/deps/orca_whirlpools_core-7665627fddbc1d33)

running 3 tests
test math::position::test::test_is_position_in_range ... ok
test math::position::test::test_position_status ... ok
test math::position::test::test_position_ratio ... FAILED

failures:

---- math::position::test::test_position_ratio stdout ----
price: 153.4447367380454
lower: 109.65785788756558
upper: 214.71928801414012

thread 'math::position::test::test_position_ratio' panicked at /Users/jacobshiohira/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ethnum-1.5.2/src/uint/ops.rs:17:1:
attempt to multiply with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```