### PR TITLE
add ability for caller to specificy idempotent create ata

### DIFF
--- a/.changeset/lucky-donkeys-wander.md
+++ b/.changeset/lucky-donkeys-wander.md
@@ -1,0 +1,5 @@
+---
+"@orca-so/whirlpools-sdk": minor
+---
+
+Add `createAtaMethod` to `AccountResolverOptions`, choosing between the ATA program's `Create` and `CreateIdempotent` for ATAs that don't exist yet. Existence is decided from a pre-flight fetch, so `Create` fails with `IllegalOwner` ("Provided owner is not allowed") when something else creates the ATA first — a preceding transaction in the same Jito bundle, for instance. Defaults to `create`, so existing behavior is unchanged; set `createIdempotent` when composing these instructions with anything that may create the same ATA. Honored by `openPosition`, `increaseLiquidity`, `decreaseLiquidity`, and `resolveAtaForMints`; `closePosition`, `collectRewards`, `collectAllForPositionsTxns`, and `swapAsync` already used `CreateIdempotent`. `AccountResolverOptions` is now merged over the defaults rather than replacing them.

--- a/legacy-sdk/whirlpool/src/context.ts
+++ b/legacy-sdk/whirlpool/src/context.ts
@@ -31,18 +31,54 @@ export type WhirlpoolContextOpts = {
 };
 
 /**
+ * Which Associated Token Account program instruction to use when creating a missing ATA.
+ * @category Core
+ */
+export type AtaCreationMethod = "create" | "createIdempotent";
+
+/**
  * Default settings used when resolving token accounts.
  * @category Core
  */
 export type AccountResolverOptions = {
   createWrappedSolAccountMethod: WrappedSolAccountCreateMethod;
   allowPDAOwnerAddress: boolean;
+  /**
+   * How to create ATAs that don't exist yet.
+   *
+   * Whether an ATA exists is decided from a pre-flight fetch, so `create` fails with
+   * `IllegalOwner` ("Provided owner is not allowed") if anything creates that ATA between
+   * the fetch and execution — another transaction in the same Jito bundle, a batched
+   * multisig transaction, or a concurrent send. `createIdempotent` tolerates that while
+   * still validating address derivation, the existing account's owner, and its mint.
+   *
+   * Optional, and defaults to `create` so existing behavior is unchanged. Set
+   * `createIdempotent` when composing these instructions with anything that may create
+   * the same ATA first.
+   */
+  createAtaMethod?: AtaCreationMethod;
 };
 
 const DEFAULT_ACCOUNT_RESOLVER_OPTS: AccountResolverOptions = {
   createWrappedSolAccountMethod: "keypair",
   allowPDAOwnerAddress: false,
+  createAtaMethod: "create",
 };
+
+/**
+ * Whether `opts` asks for `CreateIdempotent` when creating missing ATAs.
+ *
+ * Shaped as the `modeIdempotent` boolean that `resolveOrCreateATA(s)` takes. Anything but
+ * an explicit `createIdempotent` means `create` — including `undefined`, which is what an
+ * `AccountResolverOptions` built before this field existed carries.
+ *
+ * @category Core
+ */
+export function shouldCreateAtaIdempotent(
+  opts: AccountResolverOptions,
+): boolean {
+  return opts.createAtaMethod === "createIdempotent";
+}
 
 /**
  * Context for storing environment classes and objects for usage throughout the SDK
@@ -140,8 +176,12 @@ export class WhirlpoolContext {
     this.lookupTableFetcher = lookupTableFetcher;
     this.opts = opts;
     this.txBuilderOpts = contextOptionsToBuilderOptions(this.opts);
-    this.accountResolverOpts =
-      opts.accountResolverOptions ?? DEFAULT_ACCOUNT_RESOLVER_OPTS;
+    // Merged rather than replaced so options added to AccountResolverOptions over time keep
+    // their default for callers that built the object before the option existed.
+    this.accountResolverOpts = {
+      ...DEFAULT_ACCOUNT_RESOLVER_OPTS,
+      ...opts.accountResolverOptions,
+    };
   }
 
   // TODO: Add another factory method to build from on-chain IDL

--- a/legacy-sdk/whirlpool/src/context.ts
+++ b/legacy-sdk/whirlpool/src/context.ts
@@ -30,10 +30,6 @@ export type WhirlpoolContextOpts = {
   accountResolverOptions?: AccountResolverOptions;
 };
 
-/**
- * Which Associated Token Account program instruction to use when creating a missing ATA.
- * @category Core
- */
 export type AtaCreationMethod = "create" | "createIdempotent";
 
 /**
@@ -44,17 +40,10 @@ export type AccountResolverOptions = {
   createWrappedSolAccountMethod: WrappedSolAccountCreateMethod;
   allowPDAOwnerAddress: boolean;
   /**
-   * How to create ATAs that don't exist yet.
+   * The method to use when creating ATAs that don't exist.
    *
-   * Whether an ATA exists is decided from a pre-flight fetch, so `create` fails with
-   * `IllegalOwner` ("Provided owner is not allowed") if anything creates that ATA between
-   * the fetch and execution — another transaction in the same Jito bundle, a batched
-   * multisig transaction, or a concurrent send. `createIdempotent` tolerates that while
-   * still validating address derivation, the existing account's owner, and its mint.
-   *
-   * Optional, and defaults to `create` so existing behavior is unchanged. Set
-   * `createIdempotent` when composing these instructions with anything that may create
-   * the same ATA first.
+   * The historical default was the non-idempotent `create` method, so changing that
+   * introduces a breaking change for consumers.
    */
   createAtaMethod?: AtaCreationMethod;
 };
@@ -66,13 +55,10 @@ const DEFAULT_ACCOUNT_RESOLVER_OPTS: AccountResolverOptions = {
 };
 
 /**
- * Whether `opts` asks for `CreateIdempotent` when creating missing ATAs.
+ * Whether `opts` asks for `CreateIdempotent` when creating ATAs.
  *
- * Shaped as the `modeIdempotent` boolean that `resolveOrCreateATA(s)` takes. Anything but
- * an explicit `createIdempotent` means `create` — including `undefined`, which is what an
- * `AccountResolverOptions` built before this field existed carries.
- *
- * @category Core
+ * Only an explicit `createIdempotent` value gets idempotent behavior,
+ * anything else (including undefined) defaults to `create`
  */
 export function shouldCreateAtaIdempotent(
   opts: AccountResolverOptions,
@@ -176,8 +162,6 @@ export class WhirlpoolContext {
     this.lookupTableFetcher = lookupTableFetcher;
     this.opts = opts;
     this.txBuilderOpts = contextOptionsToBuilderOptions(this.opts);
-    // Merged rather than replaced so options added to AccountResolverOptions over time keep
-    // their default for callers that built the object before the option existed.
     this.accountResolverOpts = {
       ...DEFAULT_ACCOUNT_RESOLVER_OPTS,
       ...opts.accountResolverOptions,

--- a/legacy-sdk/whirlpool/src/impl/position-impl.ts
+++ b/legacy-sdk/whirlpool/src/impl/position-impl.ts
@@ -14,6 +14,7 @@ import { NATIVE_MINT, getAssociatedTokenAddressSync } from "@solana/spl-token";
 import { PublicKey } from "@solana/web3.js";
 import invariant from "tiny-invariant";
 import type { WhirlpoolContext } from "../context";
+import { shouldCreateAtaIdempotent } from "../context";
 import type {
   ByTokenAmountsParams,
   DecreaseLiquidityInput,
@@ -168,7 +169,7 @@ export class PositionImpl implements Position {
         ],
         () => this.ctx.fetcher.getAccountRentExempt(),
         ataPayerKey,
-        undefined, // use default
+        shouldCreateAtaIdempotent(this.ctx.accountResolverOpts),
         this.ctx.accountResolverOpts.allowPDAOwnerAddress,
         this.ctx.accountResolverOpts.createWrappedSolAccountMethod,
       );
@@ -298,7 +299,7 @@ export class PositionImpl implements Position {
         ],
         () => this.ctx.fetcher.getAccountRentExempt(),
         ataPayerKey,
-        undefined, // use default
+        shouldCreateAtaIdempotent(this.ctx.accountResolverOpts),
         this.ctx.accountResolverOpts.allowPDAOwnerAddress,
         this.ctx.accountResolverOpts.createWrappedSolAccountMethod,
       );

--- a/legacy-sdk/whirlpool/src/impl/whirlpool-impl.ts
+++ b/legacy-sdk/whirlpool/src/impl/whirlpool-impl.ts
@@ -18,6 +18,7 @@ import type { PublicKey } from "@solana/web3.js";
 import { Keypair } from "@solana/web3.js";
 import invariant from "tiny-invariant";
 import type { WhirlpoolContext } from "../context";
+import { shouldCreateAtaIdempotent } from "../context";
 import type {
   ByTokenAmountsParams,
   DevFeeSwapInput,
@@ -431,7 +432,7 @@ export class WhirlpoolImpl implements Whirlpool {
       ],
       () => this.ctx.fetcher.getAccountRentExempt(),
       funder,
-      undefined, // use default
+      shouldCreateAtaIdempotent(this.ctx.accountResolverOpts),
       this.ctx.accountResolverOpts.allowPDAOwnerAddress,
       this.ctx.accountResolverOpts.createWrappedSolAccountMethod,
     );

--- a/legacy-sdk/whirlpool/src/utils/whirlpool-ata-utils.ts
+++ b/legacy-sdk/whirlpool/src/utils/whirlpool-ata-utils.ts
@@ -8,6 +8,7 @@ import { NATIVE_MINT } from "@solana/spl-token";
 import { PublicKey } from "@solana/web3.js";
 import type { WhirlpoolContext } from "..";
 import { PoolUtil } from "..";
+import { shouldCreateAtaIdempotent } from "../context";
 import type { WhirlpoolData } from "../types/public";
 import { convertListToMap } from "./txn-utils";
 
@@ -134,7 +135,7 @@ export async function resolveAtaForMints(
     }),
     async () => accountExemption,
     payerKey,
-    undefined, // use default
+    shouldCreateAtaIdempotent(ctx.accountResolverOpts),
     ctx.accountResolverOpts.allowPDAOwnerAddress,
     ctx.accountResolverOpts.createWrappedSolAccountMethod,
   );

--- a/legacy-sdk/whirlpool/tests/sdk/whirlpools/utils/ata-creation-method.test.ts
+++ b/legacy-sdk/whirlpool/tests/sdk/whirlpools/utils/ata-creation-method.test.ts
@@ -3,9 +3,11 @@ import {
   ASSOCIATED_TOKEN_PROGRAM_ID,
   getAssociatedTokenAddressSync,
 } from "@solana/spl-token";
-import { PublicKey, Transaction } from "@solana/web3.js";
+import type { PublicKey } from "@solana/web3.js";
+import { Transaction } from "@solana/web3.js";
 import * as assert from "assert";
-import { AtaCreationMethod, WhirlpoolContext, WhirlpoolContextOpts } from "../../../../src";
+import type { AtaCreationMethod, WhirlpoolContextOpts } from "../../../../src";
+import { WhirlpoolContext } from "../../../../src";
 import { resolveAtaForMints } from "../../../../src/utils/whirlpool-ata-utils";
 import { createAssociatedTokenAccount, createMint } from "../../../utils";
 import { initializeLiteSVMEnvironment } from "../../../utils/litesvm";
@@ -48,7 +50,7 @@ describe("ata creation method", () => {
       program,
       undefined,
       undefined,
-      opts
+      opts,
     );
   }
 
@@ -127,7 +129,7 @@ describe("ata creation method", () => {
     });
 
     it("Create fails once the ATA exists", async () => {
-    // the Create instruction fails when another transaction creates the ATA
+      // the Create instruction fails when another transaction creates the ATA
       await assert.rejects(() => resolveThenSend("create", true));
     });
 

--- a/legacy-sdk/whirlpool/tests/sdk/whirlpools/utils/ata-creation-method.test.ts
+++ b/legacy-sdk/whirlpool/tests/sdk/whirlpools/utils/ata-creation-method.test.ts
@@ -5,23 +5,13 @@ import {
 } from "@solana/spl-token";
 import { PublicKey, Transaction } from "@solana/web3.js";
 import * as assert from "assert";
-import type { AtaCreationMethod, WhirlpoolContext } from "../../../../src";
-import { WhirlpoolContext } from "../../../../src";
+import { AtaCreationMethod, WhirlpoolContext, WhirlpoolContextOpts } from "../../../../src";
 import { resolveAtaForMints } from "../../../../src/utils/whirlpool-ata-utils";
 import { createAssociatedTokenAccount, createMint } from "../../../utils";
 import { initializeLiteSVMEnvironment } from "../../../utils/litesvm";
 
-/**
- * `AccountResolverOptions.createAtaMethod` selects which Associated Token Account program
- * instruction the SDK emits for ATAs that don't exist yet. `create` fails with
- * `IllegalOwner` if something else creates the ATA between the SDK's pre-flight fetch and
- * execution — a preceding transaction in the same Jito bundle, for instance — while
- * `createIdempotent` tolerates it.
- *
- * The default is `create`, which these tests pin: changing it would silently alter the
- * instructions every existing caller produces.
- */
 describe("ata creation method", () => {
+  // source: https://github.com/solana-program/associated-token-account/blob/5ef2d950ccdebb35a73c77e8008910cf15a87a5f/interface/src/instruction.rs#L19-L61
   const CREATE_DISCRIMINATOR: number[] = [];
   const CREATE_IDEMPOTENT_DISCRIMINATOR = [1];
 
@@ -40,26 +30,26 @@ describe("ata creation method", () => {
   });
 
   function ctxWithAtaCreationMethod(
-    createAtaMethod: AtaCreationMethod,
+    createAtaMethod?: AtaCreationMethod,
   ): WhirlpoolContext {
+    let opts: WhirlpoolContextOpts = {
+      accountResolverOptions: {
+        createWrappedSolAccountMethod: "keypair",
+        allowPDAOwnerAddress: false,
+      },
+    };
+
+    if (createAtaMethod) {
+      opts.accountResolverOptions!.createAtaMethod = createAtaMethod;
+    }
+
     return WhirlpoolContext.fromWorkspace(
       provider,
       program,
       undefined,
       undefined,
-      {
-        accountResolverOptions: {
-          createWrappedSolAccountMethod: "keypair",
-          allowPDAOwnerAddress: false,
-          createAtaMethod,
-        },
-      },
+      opts
     );
-  }
-
-  /** A mint the wallet holds no ATA for, so resolution has to emit a create instruction. */
-  async function mintWithoutAta(): Promise<PublicKey> {
-    return createMint(provider);
   }
 
   async function resolveCreateIx(ctx: WhirlpoolContext, mint: PublicKey) {
@@ -83,54 +73,36 @@ describe("ata creation method", () => {
   }
 
   it("emits Create by default", async () => {
-    const ix = await resolveCreateIx(defaultCtx, await mintWithoutAta());
+    const ix = await resolveCreateIx(defaultCtx, await createMint(provider));
     assert.deepEqual([...ix.data], CREATE_DISCRIMINATOR);
   });
 
   it("emits Create when explicitly configured", async () => {
     const ctx = ctxWithAtaCreationMethod("create");
-    const ix = await resolveCreateIx(ctx, await mintWithoutAta());
+    const ix = await resolveCreateIx(ctx, await createMint(provider));
     assert.deepEqual([...ix.data], CREATE_DISCRIMINATOR);
   });
 
   it("emits CreateIdempotent when configured", async () => {
     const ctx = ctxWithAtaCreationMethod("createIdempotent");
-    const ix = await resolveCreateIx(ctx, await mintWithoutAta());
+    const ix = await resolveCreateIx(ctx, await createMint(provider));
     assert.deepEqual([...ix.data], CREATE_IDEMPOTENT_DISCRIMINATOR);
   });
 
   it("keeps Create for an AccountResolverOptions built without the option", async () => {
-    // Callers that predate `createAtaMethod` pass an object without it. The context merges
-    // it over the defaults, so the field is absent from their literal but still resolves
-    // to `create`.
-    const ctx = WhirlpoolContext.fromWorkspace(
-      provider,
-      program,
-      undefined,
-      undefined,
-      {
-        accountResolverOptions: {
-          createWrappedSolAccountMethod: "keypair",
-          allowPDAOwnerAddress: false,
-        },
-      },
-    );
+    const ctx = ctxWithAtaCreationMethod();
     assert.equal(ctx.accountResolverOpts.createAtaMethod, "create");
-    const ix = await resolveCreateIx(ctx, await mintWithoutAta());
+    const ix = await resolveCreateIx(ctx, await createMint(provider));
     assert.deepEqual([...ix.data], CREATE_DISCRIMINATOR);
   });
 
   describe("when the ATA is created between resolution and execution", () => {
-    /**
-     * Resolve a create instruction and send it, optionally creating the ATA out of band
-     * first — the race a preceding transaction in the same bundle makes the SDK lose.
-     */
     async function resolveThenSend(
       createAtaMethod: AtaCreationMethod,
       frontRun: boolean,
     ) {
       const ctx = ctxWithAtaCreationMethod(createAtaMethod);
-      const mint = await mintWithoutAta();
+      const mint = await createMint(provider);
       const ix = await resolveCreateIx(ctx, mint);
 
       if (frontRun) {
@@ -149,21 +121,18 @@ describe("ata creation method", () => {
       });
     }
 
-    // Control: the same Create instruction lands when nothing front-runs it. Without this,
-    // the rejection below could pass for a malformed instruction rather than the race.
+    // the Create instruction lands when nothing front-runs it
     it("Create succeeds when nothing front-runs it", async () => {
       await resolveThenSend("create", false);
     });
 
     it("Create fails once the ATA exists", async () => {
-      // The failure is the point; the error is not portable. Mainnet's ATA program reports
-      // IllegalOwner ("Provided owner is not allowed") because it short-circuits before the
-      // system CPI, while the build bundled with LiteSVM reports NotEnoughAccountKeys for
-      // the same cause. Asserting either would pin the test to one program version.
+    // the Create instruction fails when another transaction creates the ATA
       await assert.rejects(() => resolveThenSend("create", true));
     });
 
     it("CreateIdempotent succeeds once the ATA exists", async () => {
+      // the CreateIdempotent instruction lands even when another transaction creates the ATA
       await resolveThenSend("createIdempotent", true);
     });
   });

--- a/legacy-sdk/whirlpool/tests/sdk/whirlpools/utils/ata-creation-method.test.ts
+++ b/legacy-sdk/whirlpool/tests/sdk/whirlpools/utils/ata-creation-method.test.ts
@@ -1,0 +1,170 @@
+import * as anchor from "@coral-xyz/anchor";
+import {
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  getAssociatedTokenAddressSync,
+} from "@solana/spl-token";
+import { PublicKey, Transaction } from "@solana/web3.js";
+import * as assert from "assert";
+import type { AtaCreationMethod, WhirlpoolContext } from "../../../../src";
+import { WhirlpoolContext } from "../../../../src";
+import { resolveAtaForMints } from "../../../../src/utils/whirlpool-ata-utils";
+import { createAssociatedTokenAccount, createMint } from "../../../utils";
+import { initializeLiteSVMEnvironment } from "../../../utils/litesvm";
+
+/**
+ * `AccountResolverOptions.createAtaMethod` selects which Associated Token Account program
+ * instruction the SDK emits for ATAs that don't exist yet. `create` fails with
+ * `IllegalOwner` if something else creates the ATA between the SDK's pre-flight fetch and
+ * execution — a preceding transaction in the same Jito bundle, for instance — while
+ * `createIdempotent` tolerates it.
+ *
+ * The default is `create`, which these tests pin: changing it would silently alter the
+ * instructions every existing caller produces.
+ */
+describe("ata creation method", () => {
+  const CREATE_DISCRIMINATOR: number[] = [];
+  const CREATE_IDEMPOTENT_DISCRIMINATOR = [1];
+
+  let provider: anchor.AnchorProvider;
+  let program: anchor.Program;
+  let defaultCtx: WhirlpoolContext;
+  let accountExemption: number;
+
+  beforeAll(async () => {
+    const env = await initializeLiteSVMEnvironment();
+    provider = env.provider;
+    program = env.program;
+    defaultCtx = env.ctx;
+    accountExemption = await env.fetcher.getAccountRentExempt();
+    anchor.setProvider(provider);
+  });
+
+  function ctxWithAtaCreationMethod(
+    createAtaMethod: AtaCreationMethod,
+  ): WhirlpoolContext {
+    return WhirlpoolContext.fromWorkspace(
+      provider,
+      program,
+      undefined,
+      undefined,
+      {
+        accountResolverOptions: {
+          createWrappedSolAccountMethod: "keypair",
+          allowPDAOwnerAddress: false,
+          createAtaMethod,
+        },
+      },
+    );
+  }
+
+  /** A mint the wallet holds no ATA for, so resolution has to emit a create instruction. */
+  async function mintWithoutAta(): Promise<PublicKey> {
+    return createMint(provider);
+  }
+
+  async function resolveCreateIx(ctx: WhirlpoolContext, mint: PublicKey) {
+    const { resolveAtaIxs } = await resolveAtaForMints(ctx, {
+      mints: [mint],
+      accountExemption,
+    });
+    assert.equal(
+      resolveAtaIxs.length,
+      1,
+      "expected one instruction set for an ATA that does not exist yet",
+    );
+    const instructions = resolveAtaIxs[0].instructions;
+    assert.equal(instructions.length, 1);
+    const ix = instructions[0];
+    assert.ok(
+      ix.programId.equals(ASSOCIATED_TOKEN_PROGRAM_ID),
+      "expected an Associated Token Account program instruction",
+    );
+    return ix;
+  }
+
+  it("emits Create by default", async () => {
+    const ix = await resolveCreateIx(defaultCtx, await mintWithoutAta());
+    assert.deepEqual([...ix.data], CREATE_DISCRIMINATOR);
+  });
+
+  it("emits Create when explicitly configured", async () => {
+    const ctx = ctxWithAtaCreationMethod("create");
+    const ix = await resolveCreateIx(ctx, await mintWithoutAta());
+    assert.deepEqual([...ix.data], CREATE_DISCRIMINATOR);
+  });
+
+  it("emits CreateIdempotent when configured", async () => {
+    const ctx = ctxWithAtaCreationMethod("createIdempotent");
+    const ix = await resolveCreateIx(ctx, await mintWithoutAta());
+    assert.deepEqual([...ix.data], CREATE_IDEMPOTENT_DISCRIMINATOR);
+  });
+
+  it("keeps Create for an AccountResolverOptions built without the option", async () => {
+    // Callers that predate `createAtaMethod` pass an object without it. The context merges
+    // it over the defaults, so the field is absent from their literal but still resolves
+    // to `create`.
+    const ctx = WhirlpoolContext.fromWorkspace(
+      provider,
+      program,
+      undefined,
+      undefined,
+      {
+        accountResolverOptions: {
+          createWrappedSolAccountMethod: "keypair",
+          allowPDAOwnerAddress: false,
+        },
+      },
+    );
+    assert.equal(ctx.accountResolverOpts.createAtaMethod, "create");
+    const ix = await resolveCreateIx(ctx, await mintWithoutAta());
+    assert.deepEqual([...ix.data], CREATE_DISCRIMINATOR);
+  });
+
+  describe("when the ATA is created between resolution and execution", () => {
+    /**
+     * Resolve a create instruction and send it, optionally creating the ATA out of band
+     * first — the race a preceding transaction in the same bundle makes the SDK lose.
+     */
+    async function resolveThenSend(
+      createAtaMethod: AtaCreationMethod,
+      frontRun: boolean,
+    ) {
+      const ctx = ctxWithAtaCreationMethod(createAtaMethod);
+      const mint = await mintWithoutAta();
+      const ix = await resolveCreateIx(ctx, mint);
+
+      if (frontRun) {
+        const owner = provider.wallet.publicKey;
+        const ata = await createAssociatedTokenAccount(
+          provider,
+          mint,
+          owner,
+          owner,
+        );
+        assert.ok(ata.equals(getAssociatedTokenAddressSync(mint, owner)));
+      }
+
+      return provider.sendAndConfirm(new Transaction().add(ix), [], {
+        commitment: "confirmed",
+      });
+    }
+
+    // Control: the same Create instruction lands when nothing front-runs it. Without this,
+    // the rejection below could pass for a malformed instruction rather than the race.
+    it("Create succeeds when nothing front-runs it", async () => {
+      await resolveThenSend("create", false);
+    });
+
+    it("Create fails once the ATA exists", async () => {
+      // The failure is the point; the error is not portable. Mainnet's ATA program reports
+      // IllegalOwner ("Provided owner is not allowed") because it short-circuits before the
+      // system CPI, while the build bundled with LiteSVM reports NotEnoughAccountKeys for
+      // the same cause. Asserting either would pin the test to one program version.
+      await assert.rejects(() => resolveThenSend("create", true));
+    });
+
+    it("CreateIdempotent succeeds once the ATA exists", async () => {
+      await resolveThenSend("createIdempotent", true);
+    });
+  });
+});


### PR DESCRIPTION
## Add `createAtaMethod` to `AccountResolverOptions`

Let callers pick b/w ATA `Create` or `CreateIdempotent` instructions to create a missing ATA.

### Why

The current implementation of `resolveOrCreateATAs` decides whether or not to create an ATA from a pre-flight fetch, so `Create` fails with `IllegalOwner` ("Provided owner is not allowed") if anything later creates that ATA.  This becomes important in a world where separate transactions can land atomically.

### Next step

If this change is adopted, we can pull into coralreef to reduce issues related to this behavior in aggregator autoswap.

### Change

- `createAtaMethod?: "create" | "createIdempotent"` plus a `shouldCreateAtaIdempotent(opts)` helper. Defaults to `create`, so existing behavior is unchanged.
- Optional field, and `AccountResolverOptions` is now merged over the defaults instead of replacing them, so callers constructing the literal keep compiling.
- New change pulled in by `openPosition`, `increaseLiquidity`, `decreaseLiquidity`, `resolveAtaForMints`.
- `closePosition`, `collectRewards`, `collectAllForPositionsTxns`, and `swapAsync` already hardcoded `CreateIdempotent`, so those are untouched

### Test plan

New `ata-creation-method.test.ts` (7 tests): pins `create` as the default three ways, asserts `createIdempotent` emits `[1]`, and covers the race — `Create` lands normally, fails once the ATA exists, `CreateIdempotent` succeeds (with a control so the rejection can't pass for a malformed instruction).