### PR TITLE
Prepare for rent reduction starting with Agave 4.2

### DIFF
--- a/.changeset/seven-dragons-begin.md
+++ b/.changeset/seven-dragons-begin.md
@@ -1,0 +1,5 @@
+---
+"@orca-so/whirlpools-program": patch
+---
+
+Prepare for rent reduction starting agave 4.2 (Anchor the amount of lamports reserved for rent)

--- a/legacy-sdk/whirlpool/package.json
+++ b/legacy-sdk/whirlpool/package.json
@@ -22,7 +22,7 @@
     "@solana/web3.js": "^1.98.4",
     "@types/bn.js": "~5.1.6",
     "@types/jest": "^30.0.0",
-    "litesvm": "^0.4.0",
+    "litesvm": "^1.3.0",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"
   },

--- a/legacy-sdk/whirlpool/tests/integration/multi-ix/agave42_rent_reduction_and_fallback.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/multi-ix/agave42_rent_reduction_and_fallback.test.ts
@@ -1,0 +1,582 @@
+import * as anchor from "@coral-xyz/anchor";
+import {
+  ACCOUNT_SIZE,
+  createSyncNativeInstruction,
+  getAssociatedTokenAddressSync,
+  MINT_SIZE,
+  TOKEN_PROGRAM_ID,
+} from "@solana/spl-token";
+import type {
+  PublicKey} from "@solana/web3.js";
+import {
+  Keypair,
+  LAMPORTS_PER_SOL,
+  SYSVAR_RENT_PUBKEY,
+} from "@solana/web3.js";
+import * as assert from "assert";
+import BN from "bn.js";
+import type { WhirlpoolClient } from "../../../src";
+import {
+  PDAUtil,
+  PriceMath,
+  WhirlpoolIx,
+  buildWhirlpoolClient,
+  toTx,
+} from "../../../src";
+import { WhirlpoolContext } from "../../../src/context";
+import {
+  createMint,
+  createTokenAccount,
+  systemTransferTx,
+  ZERO_BN,
+} from "../../utils";
+import {
+  getLiteSVM,
+  initializeLiteSVMEnvironment,
+  requestAirdropLiteSVM,
+  resetLiteSVM,
+} from "../../utils/litesvm";
+import { WhirlpoolTestFixture } from "../../utils/fixture";
+import type { initializePositionBundle } from "../../utils/init-utils";
+
+describe("SIMD-0437 rent reduction and SIMD-0438 fallback tests", () => {
+  let provider: anchor.AnchorProvider;
+  let program: anchor.Program;
+  let ctx: WhirlpoolContext;
+  let client: WhirlpoolClient;
+
+  beforeAll(async () => {
+    const env = await initializeLiteSVMEnvironment();
+    provider = env.provider;
+    program = env.program;
+
+    anchor.setProvider(provider);
+    ctx = WhirlpoolContext.fromWorkspace(provider, program);
+    client = buildWhirlpoolClient(ctx);
+  });
+
+  const LEGACY_LAMPORTS_PER_BYTE = 6960;
+  const REDUCTED_LAMPORTS_PER_BYTE = 696;
+
+  beforeEach(async () => {
+    await resetLiteSVM();
+    requestAirdropLiteSVM(provider.wallet.publicKey, BigInt(100e9));
+  });
+
+  it("precondition: simulate rent reduction (mint)", async () => {
+    setLamportsPerByte(LEGACY_LAMPORTS_PER_BYTE);
+    assertLamportsPerByte(LEGACY_LAMPORTS_PER_BYTE);
+    const mintLegacyRent = await createMint(provider);
+    const mintLegacyRentExpectedLamports = calcMinimumBalanceForRentExemption(
+      MINT_SIZE,
+      LEGACY_LAMPORTS_PER_BYTE,
+    );
+    assert.equal(mintLegacyRentExpectedLamports, 1_461_600);
+    assertLamportsBalance(mintLegacyRent, mintLegacyRentExpectedLamports);
+
+    setLamportsPerByte(REDUCTED_LAMPORTS_PER_BYTE);
+    assertLamportsPerByte(REDUCTED_LAMPORTS_PER_BYTE);
+    const mintReductedRent = await createMint(provider);
+    const mintReductedRentExpectedLamports = calcMinimumBalanceForRentExemption(
+      MINT_SIZE,
+      REDUCTED_LAMPORTS_PER_BYTE,
+    );
+    assert.equal(mintReductedRentExpectedLamports, 146_160);
+    assertLamportsBalance(mintReductedRent, mintReductedRentExpectedLamports);
+  });
+
+  it("precondition: simulate rent reduction (token account)", async () => {
+    const mint = await createMint(provider);
+
+    setLamportsPerByte(LEGACY_LAMPORTS_PER_BYTE);
+    assertLamportsPerByte(LEGACY_LAMPORTS_PER_BYTE);
+    const tokenLegacyRent = await createTokenAccount(
+      provider,
+      mint,
+      ctx.wallet.publicKey,
+    );
+    const tokenLegacyRentExpectedLamports = calcMinimumBalanceForRentExemption(
+      ACCOUNT_SIZE,
+      LEGACY_LAMPORTS_PER_BYTE,
+    );
+    assert.equal(tokenLegacyRentExpectedLamports, 2_039_280);
+    assertLamportsBalance(tokenLegacyRent, tokenLegacyRentExpectedLamports);
+
+    setLamportsPerByte(REDUCTED_LAMPORTS_PER_BYTE);
+    assertLamportsPerByte(REDUCTED_LAMPORTS_PER_BYTE);
+    const tokenReductedRent = await createTokenAccount(
+      provider,
+      mint,
+      ctx.wallet.publicKey,
+    );
+    const tokenReductedRentExpectedLamports =
+      calcMinimumBalanceForRentExemption(
+        ACCOUNT_SIZE,
+        REDUCTED_LAMPORTS_PER_BYTE,
+      );
+    assert.equal(tokenReductedRentExpectedLamports, 203_928);
+    assertLamportsBalance(tokenReductedRent, tokenReductedRentExpectedLamports);
+  });
+
+  it("lamports_per_byte=6960 (legacy)", async () => {
+    await testWhirlpoolOps(6960);
+  });
+
+  it("lamports_per_byte=6333 (reduction step 1)", async () => {
+    await testWhirlpoolOps(6333);
+  });
+
+  it("lamports_per_byte=2575 (reduction step 3)", async () => {
+    await testWhirlpoolOps(2575);
+  });
+
+  it("lamports_per_byte=696 (goal)", async () => {
+    await testWhirlpoolOps(696);
+  });
+
+  async function testWhirlpoolOps(lamportsPerByte: number) {
+    setLamportsPerByte(lamportsPerByte);
+    assertLamportsPerByte(lamportsPerByte);
+
+    const tickSpacing = 64;
+    const fixture = await new WhirlpoolTestFixture(ctx).init({
+      tickSpacing,
+      initialSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(32),
+      positions: [],
+      rewards: [],
+      tokenAIsNative: true,
+    });
+
+    const whirlpoolPubkey =
+      fixture.getInfos().poolInitInfo.whirlpoolPda.publicKey;
+    const whirlpool = await client.getPool(whirlpoolPubkey);
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Check rent on the Whirlpool account
+    ////////////////////////////////////////////////////////////////////////////////
+    // lamports of Whirlpool is calculated based on the effective lamports per byte config.
+    assertDataSizeAndLamportsBalance(
+      whirlpoolPubkey,
+      653,
+      calcMinimumBalanceForRentExemption(653, lamportsPerByte),
+    );
+
+    const rewardAuthorityKeypair =
+      fixture.getInfos().configKeypairs.rewardEmissionsSuperAuthorityKeypair;
+    const rewardVaultKeypair0 = Keypair.generate();
+    await toTx(
+      ctx,
+      WhirlpoolIx.initializeRewardIx(ctx.program, {
+        funder: ctx.wallet.publicKey,
+        whirlpool: whirlpoolPubkey,
+        rewardAuthority: rewardAuthorityKeypair.publicKey,
+        rewardIndex: 0,
+        rewardMint: whirlpool.getData().tokenMintA, // SOL
+        rewardVaultKeypair: rewardVaultKeypair0,
+      }),
+    )
+      .addSigner(rewardVaultKeypair0)
+      .addSigner(rewardAuthorityKeypair)
+      .buildAndExecute();
+
+    const rewardVaultKeypair1 = Keypair.generate();
+    await toTx(
+      ctx,
+      WhirlpoolIx.initializeRewardIx(ctx.program, {
+        funder: ctx.wallet.publicKey,
+        whirlpool: whirlpoolPubkey,
+        rewardAuthority: rewardAuthorityKeypair.publicKey,
+        rewardIndex: 1,
+        rewardMint: whirlpool.getData().tokenMintB,
+        rewardVaultKeypair: rewardVaultKeypair1,
+      }),
+    )
+      .addSigner(rewardVaultKeypair1)
+      .addSigner(rewardAuthorityKeypair)
+      .buildAndExecute();
+
+    await whirlpool.refreshData();
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Check rent on the vault token accounts
+    ////////////////////////////////////////////////////////////////////////////////
+    // lamports of WSOL token vault is ALWAYS calculated based on LEGACY_LAMPORTS_PER_BYTE.
+    assertDataSizeAndLamportsBalance(
+      whirlpool.getData().tokenVaultA,
+      165,
+      calcMinimumBalanceForRentExemption(165, LEGACY_LAMPORTS_PER_BYTE),
+    );
+
+    // lamports of non WSOL token vault is calculated based on the effective lamports per byte config.
+    assertDataSizeAndLamportsBalance(
+      whirlpool.getData().tokenVaultB,
+      165,
+      calcMinimumBalanceForRentExemption(165, lamportsPerByte),
+    );
+
+    // lamports of WSOL token vault is ALWAYS calculated based on LEGACY_LAMPORTS_PER_BYTE.
+    assertDataSizeAndLamportsBalance(
+      whirlpool.getData().rewardInfos[0].vault,
+      165,
+      calcMinimumBalanceForRentExemption(165, LEGACY_LAMPORTS_PER_BYTE),
+    );
+
+    // lamports of non WSOL token vault is calculated based on the effective lamports per byte config.
+    assertDataSizeAndLamportsBalance(
+      whirlpool.getData().rewardInfos[1].vault,
+      165,
+      calcMinimumBalanceForRentExemption(165, lamportsPerByte),
+    );
+
+    const tickArrayLowerPubkey = PDAUtil.getTickArray(
+      ctx.program.programId,
+      whirlpoolPubkey,
+      -5632,
+    ).publicKey;
+    const tickArrayUpperPubkey = PDAUtil.getTickArray(
+      ctx.program.programId,
+      whirlpoolPubkey,
+      0,
+    ).publicKey;
+
+    await (
+      await whirlpool.initTickArrayForTicks(
+        [-1, 1],
+        undefined,
+        undefined,
+        "dynamic",
+      )
+    )?.buildAndExecute();
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Check rent on the DynamicTickArray accounts
+    ////////////////////////////////////////////////////////////////////////////////
+    // lamports of DynamicTickArray is ALWAYS calculated based on LEGACY_LAMPORTS_PER_BYTE.
+    assertDataSizeAndLamportsBalance(
+      tickArrayLowerPubkey,
+      148,
+      calcMinimumBalanceForRentExemption(148, LEGACY_LAMPORTS_PER_BYTE),
+    );
+
+    // lamports of DynamicTickArray is ALWAYS calculated based on LEGACY_LAMPORTS_PER_BYTE.
+    assertDataSizeAndLamportsBalance(
+      tickArrayUpperPubkey,
+      148,
+      calcMinimumBalanceForRentExemption(148, LEGACY_LAMPORTS_PER_BYTE),
+    );
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Check rent on the Position account
+    ////////////////////////////////////////////////////////////////////////////////
+    const rentForTick = calcMinimumBalanceForRentExemptionForSlice(
+      112,
+      LEGACY_LAMPORTS_PER_BYTE,
+    );
+    const tokenBasedPositionMintKeypair = Keypair.generate();
+    const tokenBasedPositionPda = PDAUtil.getPosition(
+      ctx.program.programId,
+      tokenBasedPositionMintKeypair.publicKey,
+    );
+    const tokenBasedPositionATA = getAssociatedTokenAddressSync(
+      tokenBasedPositionMintKeypair.publicKey,
+      ctx.wallet.publicKey,
+      true,
+      TOKEN_PROGRAM_ID,
+    );
+    await toTx(
+      ctx,
+      WhirlpoolIx.openPositionIx(ctx.program, {
+        funder: ctx.wallet.publicKey,
+        owner: ctx.wallet.publicKey,
+        positionMintAddress: tokenBasedPositionMintKeypair.publicKey,
+        positionPda: tokenBasedPositionPda,
+        positionTokenAccount: tokenBasedPositionATA,
+        tickLowerIndex: -64,
+        tickUpperIndex: 64,
+        whirlpool: whirlpoolPubkey,
+      }),
+    )
+      .addSigner(tokenBasedPositionMintKeypair)
+      .buildAndExecute();
+    await assertDataSizeAndLamportsBalance(
+      tokenBasedPositionPda.publicKey,
+      216,
+      calcMinimumBalanceForRentExemption(216, LEGACY_LAMPORTS_PER_BYTE) +
+        rentForTick * 2,
+    );
+
+    const liquidityAmount = new BN(100_000_000);
+    const liquidityIxParams = {
+      position: tokenBasedPositionPda.publicKey,
+      positionAuthority: ctx.wallet.publicKey,
+      positionTokenAccount: tokenBasedPositionATA,
+      tickArrayLower: tickArrayLowerPubkey,
+      tickArrayUpper: tickArrayUpperPubkey,
+      tokenMaxA: new BN(1_000_000_000),
+      tokenMaxB: new BN(1_000_000_000),
+      tokenMinA: new BN(0),
+      tokenMinB: new BN(0),
+      tokenMintA: whirlpool.getData().tokenMintA,
+      tokenMintB: whirlpool.getData().tokenMintB,
+      tokenOwnerAccountA: fixture.getInfos().tokenAccountA,
+      tokenOwnerAccountB: fixture.getInfos().tokenAccountB,
+      tokenProgramA: TOKEN_PROGRAM_ID,
+      tokenProgramB: TOKEN_PROGRAM_ID,
+      tokenVaultA: whirlpool.getData().tokenVaultA,
+      tokenVaultB: whirlpool.getData().tokenVaultB,
+      whirlpool: whirlpoolPubkey,
+      liquidityAmount,
+    };
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Check rent changes on increase_liquidity (V1)
+    ////////////////////////////////////////////////////////////////////////////////
+    await toTx(
+      ctx,
+      WhirlpoolIx.increaseLiquidityIx(ctx.program, liquidityIxParams),
+    ).buildAndExecute();
+
+    assertDataSizeAndLamportsBalance(
+      tokenBasedPositionPda.publicKey,
+      216,
+      calcMinimumBalanceForRentExemption(216, LEGACY_LAMPORTS_PER_BYTE),
+    );
+    assertDataSizeAndLamportsBalance(
+      tickArrayLowerPubkey,
+      148 + 112,
+      calcMinimumBalanceForRentExemption(148, LEGACY_LAMPORTS_PER_BYTE) +
+        rentForTick,
+    );
+    assertDataSizeAndLamportsBalance(
+      tickArrayUpperPubkey,
+      148 + 112,
+      calcMinimumBalanceForRentExemption(148, LEGACY_LAMPORTS_PER_BYTE) +
+        rentForTick,
+    );
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Check rent changes on decrease_liquidity (V1)
+    ////////////////////////////////////////////////////////////////////////////////
+    await toTx(
+      ctx,
+      WhirlpoolIx.decreaseLiquidityIx(ctx.program, liquidityIxParams),
+    ).buildAndExecute();
+
+    assertDataSizeAndLamportsBalance(
+      tokenBasedPositionPda.publicKey,
+      216,
+      calcMinimumBalanceForRentExemption(216, LEGACY_LAMPORTS_PER_BYTE) +
+        rentForTick * 2,
+    );
+    assertDataSizeAndLamportsBalance(
+      tickArrayLowerPubkey,
+      148,
+      calcMinimumBalanceForRentExemption(148, LEGACY_LAMPORTS_PER_BYTE),
+    );
+    assertDataSizeAndLamportsBalance(
+      tickArrayUpperPubkey,
+      148,
+      calcMinimumBalanceForRentExemption(148, LEGACY_LAMPORTS_PER_BYTE),
+    );
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Check rent changes on increase_liquidity (V2)
+    ////////////////////////////////////////////////////////////////////////////////
+    await toTx(
+      ctx,
+      WhirlpoolIx.increaseLiquidityV2Ix(ctx.program, liquidityIxParams),
+    ).buildAndExecute();
+
+    assertDataSizeAndLamportsBalance(
+      tokenBasedPositionPda.publicKey,
+      216,
+      calcMinimumBalanceForRentExemption(216, LEGACY_LAMPORTS_PER_BYTE),
+    );
+    assertDataSizeAndLamportsBalance(
+      tickArrayLowerPubkey,
+      148 + 112,
+      calcMinimumBalanceForRentExemption(148, LEGACY_LAMPORTS_PER_BYTE) +
+        rentForTick,
+    );
+    assertDataSizeAndLamportsBalance(
+      tickArrayUpperPubkey,
+      148 + 112,
+      calcMinimumBalanceForRentExemption(148, LEGACY_LAMPORTS_PER_BYTE) +
+        rentForTick,
+    );
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Check rent changes on decrease_liquidity (V2)
+    ////////////////////////////////////////////////////////////////////////////////
+    await toTx(
+      ctx,
+      WhirlpoolIx.decreaseLiquidityV2Ix(ctx.program, liquidityIxParams),
+    ).buildAndExecute();
+
+    assertDataSizeAndLamportsBalance(
+      tokenBasedPositionPda.publicKey,
+      216,
+      calcMinimumBalanceForRentExemption(216, LEGACY_LAMPORTS_PER_BYTE) +
+        rentForTick * 2,
+    );
+    assertDataSizeAndLamportsBalance(
+      tickArrayLowerPubkey,
+      148,
+      calcMinimumBalanceForRentExemption(148, LEGACY_LAMPORTS_PER_BYTE),
+    );
+    assertDataSizeAndLamportsBalance(
+      tickArrayUpperPubkey,
+      148,
+      calcMinimumBalanceForRentExemption(148, LEGACY_LAMPORTS_PER_BYTE),
+    );
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Check rent changes on increase_liquidity_by_token_amounts
+    ////////////////////////////////////////////////////////////////////////////////
+    await toTx(
+      ctx,
+      WhirlpoolIx.increaseLiquidityByTokenAmountsV2Ix(ctx.program, {
+        ...liquidityIxParams,
+        maxSqrtPrice: whirlpool.getData().sqrtPrice,
+        minSqrtPrice: whirlpool.getData().sqrtPrice,
+      }),
+    ).buildAndExecute();
+
+    assertDataSizeAndLamportsBalance(
+      tokenBasedPositionPda.publicKey,
+      216,
+      calcMinimumBalanceForRentExemption(216, LEGACY_LAMPORTS_PER_BYTE),
+    );
+    assertDataSizeAndLamportsBalance(
+      tickArrayLowerPubkey,
+      148 + 112,
+      calcMinimumBalanceForRentExemption(148, LEGACY_LAMPORTS_PER_BYTE) +
+        rentForTick,
+    );
+    assertDataSizeAndLamportsBalance(
+      tickArrayUpperPubkey,
+      148 + 112,
+      calcMinimumBalanceForRentExemption(148, LEGACY_LAMPORTS_PER_BYTE) +
+        rentForTick,
+    );
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Check rent changes on reposition_liquidity
+    ////////////////////////////////////////////////////////////////////////////////
+    await toTx(
+      ctx,
+      WhirlpoolIx.repositionLiquidityV2Ix(ctx.program, {
+        ...liquidityIxParams,
+        funder: ctx.wallet.publicKey,
+        existingRangeTokenMinA: ZERO_BN,
+        existingRangeTokenMinB: ZERO_BN,
+        existingTickArrayLower: tickArrayLowerPubkey,
+        existingTickArrayUpper: tickArrayUpperPubkey,
+        newLiquidityAmount: liquidityAmount,
+        newRangeTokenMaxA: new BN(1_000_000_000),
+        newRangeTokenMaxB: new BN(1_000_000_000),
+        newTickArrayLower: tickArrayUpperPubkey,
+        newTickArrayUpper: tickArrayUpperPubkey,
+        newTickLowerIndex: 64,
+        newTickUpperIndex: 128,
+      }),
+    ).buildAndExecute();
+
+    assertDataSizeAndLamportsBalance(
+      tokenBasedPositionPda.publicKey,
+      216,
+      calcMinimumBalanceForRentExemption(216, LEGACY_LAMPORTS_PER_BYTE),
+    );
+    assertDataSizeAndLamportsBalance(
+      tickArrayLowerPubkey,
+      148,
+      calcMinimumBalanceForRentExemption(148, LEGACY_LAMPORTS_PER_BYTE),
+    );
+    assertDataSizeAndLamportsBalance(
+      tickArrayUpperPubkey,
+      148 + 112 * 2,
+      calcMinimumBalanceForRentExemption(148, LEGACY_LAMPORTS_PER_BYTE) +
+        rentForTick * 2,
+    );
+  }
+
+  async function assertLamportsPerByte(expected: number) {
+    const rent = await provider.connection.getAccountInfo(SYSVAR_RENT_PUBKEY);
+    assert.ok(rent);
+
+    const lamportsPerByte = new BN(rent.data.subarray(0, 8), undefined, "le");
+    const rentExemptThreshold = new BN(
+      rent.data.subarray(8, 16),
+      undefined,
+      "le",
+    );
+
+    assert.ok(lamportsPerByte.toNumber() == expected);
+    assert.ok(rentExemptThreshold.eq(new BN(0x3ff00000_00000000n.toString()))); // 1.0f64
+  }
+
+  async function setLamportsPerByte(newLamportsPerByte: number) {
+    const svm = getLiteSVM();
+    const rent = svm.getRent();
+    rent.lamportsPerByteYear = BigInt(newLamportsPerByte);
+    svm.setRent(rent);
+  }
+
+  async function assertLamportsBalance(
+    accountPubkey: PublicKey,
+    expectedLamports: number,
+  ) {
+    const accountInfo = await provider.connection.getAccountInfo(accountPubkey);
+    assert.equal(accountInfo?.lamports, expectedLamports);
+  }
+
+  async function assertDataSizeAndLamportsBalance(
+    accountPubkey: PublicKey,
+    expectedDataSize: number,
+    expectedLamports: number,
+  ) {
+    const accountInfo = await provider.connection.getAccountInfo(accountPubkey);
+    assert.ok(accountInfo);
+    assert.equal(accountInfo.data.length, expectedDataSize);
+    assert.equal(accountInfo.lamports, expectedLamports);
+  }
+
+  function calcMinimumBalanceForRentExemption(
+    dataSize: number,
+    lamportsPerByte: number,
+  ): number {
+    // https://github.com/anza-xyz/solana-sdk/blob/5190ff456079d17b64669bcb5eeac48dd595b91e/rent/src/lib.rs#L86
+    const ACCOUNT_STORAGE_OVERHEAD = 128;
+    return (ACCOUNT_STORAGE_OVERHEAD + dataSize) * lamportsPerByte;
+  }
+
+  function calcMinimumBalanceForRentExemptionForSlice(
+    sliceSize: number,
+    lamportsPerByte: number,
+  ): number {
+    return sliceSize * lamportsPerByte;
+  }
+
+  async function sendLamports(accountPubkey: PublicKey, lamports: number) {
+    await systemTransferTx(provider, accountPubkey, lamports).buildAndExecute();
+  }
+
+  async function addLamportsAndEnsureRentExemption(accountPubkey: PublicKey) {
+    await sendLamports(accountPubkey, LAMPORTS_PER_SOL);
+  }
+
+  async function syncNative(accountPubkey: PublicKey) {
+    const ix = createSyncNativeInstruction(accountPubkey);
+    ix.keys.push({
+      pubkey: SYSVAR_RENT_PUBKEY,
+      isSigner: false,
+      isWritable: false,
+    });
+
+    await toTx(ctx, {
+      instructions: [ix],
+      cleanupInstructions: [],
+      signers: [],
+    }).buildAndExecute();
+  }
+});

--- a/legacy-sdk/whirlpool/tests/integration/multi-ix/agave42_rent_reduction_and_fallback.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/multi-ix/agave42_rent_reduction_and_fallback.test.ts
@@ -1,18 +1,12 @@
 import * as anchor from "@coral-xyz/anchor";
 import {
   ACCOUNT_SIZE,
-  createSyncNativeInstruction,
   getAssociatedTokenAddressSync,
   MINT_SIZE,
   TOKEN_PROGRAM_ID,
 } from "@solana/spl-token";
-import type {
-  PublicKey} from "@solana/web3.js";
-import {
-  Keypair,
-  LAMPORTS_PER_SOL,
-  SYSVAR_RENT_PUBKEY,
-} from "@solana/web3.js";
+import type { PublicKey } from "@solana/web3.js";
+import { Keypair, SYSVAR_RENT_PUBKEY } from "@solana/web3.js";
 import * as assert from "assert";
 import BN from "bn.js";
 import type { WhirlpoolClient } from "../../../src";
@@ -27,7 +21,6 @@ import { WhirlpoolContext } from "../../../src/context";
 import {
   createMint,
   createTokenAccount,
-  systemTransferTx,
   ZERO_BN,
 } from "../../utils";
 import {
@@ -37,7 +30,6 @@ import {
   resetLiteSVM,
 } from "../../utils/litesvm";
 import { WhirlpoolTestFixture } from "../../utils/fixture";
-import type { initializePositionBundle } from "../../utils/init-utils";
 
 describe("SIMD-0437 rent reduction and SIMD-0438 fallback tests", () => {
   let provider: anchor.AnchorProvider;
@@ -500,6 +492,260 @@ describe("SIMD-0437 rent reduction and SIMD-0438 fallback tests", () => {
     );
   }
 
+  it("fallback: lamports_per_byte=696 -> 6960", async () => {
+    let lamportsPerByte = REDUCTED_LAMPORTS_PER_BYTE;
+    setLamportsPerByte(lamportsPerByte);
+    assertLamportsPerByte(lamportsPerByte);
+
+    const tickSpacing = 64;
+    const fixture = await new WhirlpoolTestFixture(ctx).init({
+      tickSpacing,
+      initialSqrtPrice: PriceMath.tickIndexToSqrtPriceX64(32),
+      positions: [],
+      rewards: [],
+      tokenAIsNative: true,
+    });
+
+    const whirlpoolPubkey =
+      fixture.getInfos().poolInitInfo.whirlpoolPda.publicKey;
+    const whirlpool = await client.getPool(whirlpoolPubkey);
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Check rent on the Whirlpool account
+    ////////////////////////////////////////////////////////////////////////////////
+    // lamports of Whirlpool is calculated based on the effective lamports per byte config.
+    assertDataSizeAndLamportsBalance(
+      whirlpoolPubkey,
+      653,
+      calcMinimumBalanceForRentExemption(653, lamportsPerByte),
+    );
+
+    const rewardAuthorityKeypair =
+      fixture.getInfos().configKeypairs.rewardEmissionsSuperAuthorityKeypair;
+    const rewardVaultKeypair0 = Keypair.generate();
+    await toTx(
+      ctx,
+      WhirlpoolIx.initializeRewardIx(ctx.program, {
+        funder: ctx.wallet.publicKey,
+        whirlpool: whirlpoolPubkey,
+        rewardAuthority: rewardAuthorityKeypair.publicKey,
+        rewardIndex: 0,
+        rewardMint: whirlpool.getData().tokenMintA, // SOL
+        rewardVaultKeypair: rewardVaultKeypair0,
+      }),
+    )
+      .addSigner(rewardVaultKeypair0)
+      .addSigner(rewardAuthorityKeypair)
+      .buildAndExecute();
+
+    const rewardVaultKeypair1 = Keypair.generate();
+    await toTx(
+      ctx,
+      WhirlpoolIx.initializeRewardIx(ctx.program, {
+        funder: ctx.wallet.publicKey,
+        whirlpool: whirlpoolPubkey,
+        rewardAuthority: rewardAuthorityKeypair.publicKey,
+        rewardIndex: 1,
+        rewardMint: whirlpool.getData().tokenMintB,
+        rewardVaultKeypair: rewardVaultKeypair1,
+      }),
+    )
+      .addSigner(rewardVaultKeypair1)
+      .addSigner(rewardAuthorityKeypair)
+      .buildAndExecute();
+
+    await whirlpool.refreshData();
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Check rent on the vault token accounts
+    ////////////////////////////////////////////////////////////////////////////////
+    // lamports of WSOL token vault is ALWAYS calculated based on LEGACY_LAMPORTS_PER_BYTE.
+    assertDataSizeAndLamportsBalance(
+      whirlpool.getData().tokenVaultA,
+      165,
+      calcMinimumBalanceForRentExemption(165, LEGACY_LAMPORTS_PER_BYTE),
+    );
+
+    // lamports of non WSOL token vault is calculated based on the effective lamports per byte config.
+    assertDataSizeAndLamportsBalance(
+      whirlpool.getData().tokenVaultB,
+      165,
+      calcMinimumBalanceForRentExemption(165, lamportsPerByte),
+    );
+
+    // lamports of WSOL token vault is ALWAYS calculated based on LEGACY_LAMPORTS_PER_BYTE.
+    assertDataSizeAndLamportsBalance(
+      whirlpool.getData().rewardInfos[0].vault,
+      165,
+      calcMinimumBalanceForRentExemption(165, LEGACY_LAMPORTS_PER_BYTE),
+    );
+
+    // lamports of non WSOL token vault is calculated based on the effective lamports per byte config.
+    assertDataSizeAndLamportsBalance(
+      whirlpool.getData().rewardInfos[1].vault,
+      165,
+      calcMinimumBalanceForRentExemption(165, lamportsPerByte),
+    );
+
+    const tickArrayLowerPubkey = PDAUtil.getTickArray(
+      ctx.program.programId,
+      whirlpoolPubkey,
+      -5632,
+    ).publicKey;
+    const tickArrayUpperPubkey = PDAUtil.getTickArray(
+      ctx.program.programId,
+      whirlpoolPubkey,
+      0,
+    ).publicKey;
+
+    await (
+      await whirlpool.initTickArrayForTicks(
+        [-1, 1],
+        undefined,
+        undefined,
+        "dynamic",
+      )
+    )?.buildAndExecute();
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Check rent on the DynamicTickArray accounts
+    ////////////////////////////////////////////////////////////////////////////////
+    // lamports of DynamicTickArray is ALWAYS calculated based on LEGACY_LAMPORTS_PER_BYTE.
+    assertDataSizeAndLamportsBalance(
+      tickArrayLowerPubkey,
+      148,
+      calcMinimumBalanceForRentExemption(148, LEGACY_LAMPORTS_PER_BYTE),
+    );
+
+    // lamports of DynamicTickArray is ALWAYS calculated based on LEGACY_LAMPORTS_PER_BYTE.
+    assertDataSizeAndLamportsBalance(
+      tickArrayUpperPubkey,
+      148,
+      calcMinimumBalanceForRentExemption(148, LEGACY_LAMPORTS_PER_BYTE),
+    );
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Check rent on the Position account
+    ////////////////////////////////////////////////////////////////////////////////
+    const rentForTick = calcMinimumBalanceForRentExemptionForSlice(
+      112,
+      LEGACY_LAMPORTS_PER_BYTE,
+    );
+    const tokenBasedPositionMintKeypair = Keypair.generate();
+    const tokenBasedPositionPda = PDAUtil.getPosition(
+      ctx.program.programId,
+      tokenBasedPositionMintKeypair.publicKey,
+    );
+    const tokenBasedPositionATA = getAssociatedTokenAddressSync(
+      tokenBasedPositionMintKeypair.publicKey,
+      ctx.wallet.publicKey,
+      true,
+      TOKEN_PROGRAM_ID,
+    );
+    await toTx(
+      ctx,
+      WhirlpoolIx.openPositionIx(ctx.program, {
+        funder: ctx.wallet.publicKey,
+        owner: ctx.wallet.publicKey,
+        positionMintAddress: tokenBasedPositionMintKeypair.publicKey,
+        positionPda: tokenBasedPositionPda,
+        positionTokenAccount: tokenBasedPositionATA,
+        tickLowerIndex: -64,
+        tickUpperIndex: 64,
+        whirlpool: whirlpoolPubkey,
+      }),
+    )
+      .addSigner(tokenBasedPositionMintKeypair)
+      .buildAndExecute();
+    await assertDataSizeAndLamportsBalance(
+      tokenBasedPositionPda.publicKey,
+      216,
+      calcMinimumBalanceForRentExemption(216, LEGACY_LAMPORTS_PER_BYTE) +
+        rentForTick * 2,
+    );
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Fallback
+    ////////////////////////////////////////////////////////////////////////////////
+    lamportsPerByte = LEGACY_LAMPORTS_PER_BYTE;
+    setLamportsPerByte(lamportsPerByte);
+    assertLamportsPerByte(lamportsPerByte);
+
+    const liquidityAmount = new BN(100_000_000);
+    const liquidityIxParams = {
+      position: tokenBasedPositionPda.publicKey,
+      positionAuthority: ctx.wallet.publicKey,
+      positionTokenAccount: tokenBasedPositionATA,
+      tickArrayLower: tickArrayLowerPubkey,
+      tickArrayUpper: tickArrayUpperPubkey,
+      tokenMaxA: new BN(1_000_000_000),
+      tokenMaxB: new BN(1_000_000_000),
+      tokenMinA: new BN(0),
+      tokenMinB: new BN(0),
+      tokenMintA: whirlpool.getData().tokenMintA,
+      tokenMintB: whirlpool.getData().tokenMintB,
+      tokenOwnerAccountA: fixture.getInfos().tokenAccountA,
+      tokenOwnerAccountB: fixture.getInfos().tokenAccountB,
+      tokenProgramA: TOKEN_PROGRAM_ID,
+      tokenProgramB: TOKEN_PROGRAM_ID,
+      tokenVaultA: whirlpool.getData().tokenVaultA,
+      tokenVaultB: whirlpool.getData().tokenVaultB,
+      whirlpool: whirlpoolPubkey,
+      liquidityAmount,
+    };
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Check rent changes on increase_liquidity (V1)
+    ////////////////////////////////////////////////////////////////////////////////
+    await toTx(
+      ctx,
+      WhirlpoolIx.increaseLiquidityIx(ctx.program, liquidityIxParams),
+    ).buildAndExecute();
+
+    assertDataSizeAndLamportsBalance(
+      tokenBasedPositionPda.publicKey,
+      216,
+      calcMinimumBalanceForRentExemption(216, LEGACY_LAMPORTS_PER_BYTE),
+    );
+    assertDataSizeAndLamportsBalance(
+      tickArrayLowerPubkey,
+      148 + 112,
+      calcMinimumBalanceForRentExemption(148, LEGACY_LAMPORTS_PER_BYTE) +
+        rentForTick,
+    );
+    assertDataSizeAndLamportsBalance(
+      tickArrayUpperPubkey,
+      148 + 112,
+      calcMinimumBalanceForRentExemption(148, LEGACY_LAMPORTS_PER_BYTE) +
+        rentForTick,
+    );
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Check rent changes on decrease_liquidity (V1)
+    ////////////////////////////////////////////////////////////////////////////////
+    await toTx(
+      ctx,
+      WhirlpoolIx.decreaseLiquidityIx(ctx.program, liquidityIxParams),
+    ).buildAndExecute();
+
+    assertDataSizeAndLamportsBalance(
+      tokenBasedPositionPda.publicKey,
+      216,
+      calcMinimumBalanceForRentExemption(216, LEGACY_LAMPORTS_PER_BYTE) +
+        rentForTick * 2,
+    );
+    assertDataSizeAndLamportsBalance(
+      tickArrayLowerPubkey,
+      148,
+      calcMinimumBalanceForRentExemption(148, LEGACY_LAMPORTS_PER_BYTE),
+    );
+    assertDataSizeAndLamportsBalance(
+      tickArrayUpperPubkey,
+      148,
+      calcMinimumBalanceForRentExemption(148, LEGACY_LAMPORTS_PER_BYTE),
+    );
+  });
+
   async function assertLamportsPerByte(expected: number) {
     const rent = await provider.connection.getAccountInfo(SYSVAR_RENT_PUBKEY);
     assert.ok(rent);
@@ -555,28 +801,5 @@ describe("SIMD-0437 rent reduction and SIMD-0438 fallback tests", () => {
     lamportsPerByte: number,
   ): number {
     return sliceSize * lamportsPerByte;
-  }
-
-  async function sendLamports(accountPubkey: PublicKey, lamports: number) {
-    await systemTransferTx(provider, accountPubkey, lamports).buildAndExecute();
-  }
-
-  async function addLamportsAndEnsureRentExemption(accountPubkey: PublicKey) {
-    await sendLamports(accountPubkey, LAMPORTS_PER_SOL);
-  }
-
-  async function syncNative(accountPubkey: PublicKey) {
-    const ix = createSyncNativeInstruction(accountPubkey);
-    ix.keys.push({
-      pubkey: SYSVAR_RENT_PUBKEY,
-      isSigner: false,
-      isWritable: false,
-    });
-
-    await toTx(ctx, {
-      instructions: [ix],
-      cleanupInstructions: [],
-      signers: [],
-    }).buildAndExecute();
   }
 });

--- a/legacy-sdk/whirlpool/tests/integration/multi-ix/agave42_rent_reduction_and_fallback.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/multi-ix/agave42_rent_reduction_and_fallback.test.ts
@@ -18,11 +18,7 @@ import {
   toTx,
 } from "../../../src";
 import { WhirlpoolContext } from "../../../src/context";
-import {
-  createMint,
-  createTokenAccount,
-  ZERO_BN,
-} from "../../utils";
+import { createMint, createTokenAccount, ZERO_BN } from "../../utils";
 import {
   getLiteSVM,
   initializeLiteSVMEnvironment,

--- a/legacy-sdk/whirlpool/tests/integration/multi-ix/sparse_swap.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/multi-ix/sparse_swap.test.ts
@@ -31,9 +31,9 @@ import { WhirlpoolContext } from "../../../src/context";
 import { IGNORE_CACHE } from "../../../src/network/public/fetcher";
 import {
   resetLiteSVM,
-  getLiteSVM,
   pollForCondition,
   initializeLiteSVMEnvironment,
+  requestAirdropLiteSVM,
 } from "../../utils/litesvm";
 import {
   buildTestAquariums,
@@ -776,7 +776,7 @@ describe("sparse swap tests", () => {
     describe("failures", () => {
       beforeEach(async () => {
         await resetLiteSVM();
-        getLiteSVM().airdrop(testCtx.provider.wallet.publicKey, BigInt(100e9));
+        requestAirdropLiteSVM(testCtx.provider.wallet.publicKey, BigInt(100e9));
       });
 
       async function buildTestEnvironment() {
@@ -1206,7 +1206,7 @@ describe("sparse swap tests", () => {
     describe("swap, b to a: 2816 --> 2816 + (64 * 88) * 2", () => {
       beforeEach(async () => {
         await resetLiteSVM();
-        getLiteSVM().airdrop(testCtx.provider.wallet.publicKey, BigInt(100e9));
+        requestAirdropLiteSVM(testCtx.provider.wallet.publicKey, BigInt(100e9));
       });
 
       const aToB = false;
@@ -1382,7 +1382,7 @@ describe("sparse swap tests", () => {
     describe("swap, a to b: 2816 - (64 * 88) * 2 <-- 2816", () => {
       beforeEach(async () => {
         await resetLiteSVM();
-        getLiteSVM().airdrop(testCtx.provider.wallet.publicKey, BigInt(100e9));
+        requestAirdropLiteSVM(testCtx.provider.wallet.publicKey, BigInt(100e9));
       });
 
       const aToB = true;
@@ -1556,7 +1556,7 @@ describe("sparse swap tests", () => {
     describe("twoHopSwap, b to a: 2816 --> 2816 + (64 * 88) * 2", () => {
       beforeEach(async () => {
         await resetLiteSVM();
-        getLiteSVM().airdrop(testCtx.provider.wallet.publicKey, BigInt(100e9));
+        requestAirdropLiteSVM(testCtx.provider.wallet.publicKey, BigInt(100e9));
       });
 
       const aToB = false;
@@ -1903,7 +1903,7 @@ describe("sparse swap tests", () => {
     describe("twoHopSwap, a to b: 2816 + (64 * 88) * 2 <-- 2816", () => {
       beforeEach(async () => {
         await resetLiteSVM();
-        getLiteSVM().airdrop(testCtx.provider.wallet.publicKey, BigInt(100e9));
+        requestAirdropLiteSVM(testCtx.provider.wallet.publicKey, BigInt(100e9));
       });
 
       const aToB = true;
@@ -2252,7 +2252,7 @@ describe("sparse swap tests", () => {
     describe("swapV2", () => {
       beforeEach(async () => {
         await resetLiteSVM();
-        getLiteSVM().airdrop(testCtx.provider.wallet.publicKey, BigInt(100e9));
+        requestAirdropLiteSVM(testCtx.provider.wallet.publicKey, BigInt(100e9));
       });
 
       async function buildTestEnvironment() {
@@ -2620,7 +2620,7 @@ describe("sparse swap tests", () => {
     describe("twoHopSwapV2", () => {
       beforeEach(async () => {
         await resetLiteSVM();
-        getLiteSVM().airdrop(testCtx.provider.wallet.publicKey, BigInt(100e9));
+        requestAirdropLiteSVM(testCtx.provider.wallet.publicKey, BigInt(100e9));
       });
 
       it("using 3 supplemental tick arrays", async () => {

--- a/legacy-sdk/whirlpool/tests/integration/multi-ix/splash_pool.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/multi-ix/splash_pool.test.ts
@@ -28,6 +28,7 @@ import {
   resetLiteSVM,
   getLiteSVM,
   initializeLiteSVMEnvironment,
+  requestAirdropLiteSVM,
 } from "../../utils/litesvm";
 import { initTestPoolWithTokens } from "../../utils/init-utils";
 import { NO_TOKEN_EXTENSION_CONTEXT } from "../../../src/utils/public/token-extension-util";
@@ -65,7 +66,7 @@ describe("splash pool tests", () => {
   describe("trades on splash pool", () => {
     beforeEach(async () => {
       await resetLiteSVM();
-      getLiteSVM().airdrop(testCtx.provider.wallet.publicKey, BigInt(100e9));
+      requestAirdropLiteSVM(testCtx.provider.wallet.publicKey, BigInt(100e9));
     });
 
     type TestVariation = {
@@ -499,7 +500,7 @@ describe("splash pool tests", () => {
   describe("ExactOut overflow (required input token is over u64 max)", () => {
     beforeEach(async () => {
       await resetLiteSVM();
-      getLiteSVM().airdrop(testCtx.provider.wallet.publicKey, BigInt(100e9));
+      requestAirdropLiteSVM(testCtx.provider.wallet.publicKey, BigInt(100e9));
     });
 
     // Since trade mode is ExactOut, the outputt amount must be within u64 max, but the input token may over u64 max.
@@ -761,7 +762,7 @@ describe("splash pool tests", () => {
   describe("Sandwitch attack scenario", () => {
     beforeEach(async () => {
       await resetLiteSVM();
-      getLiteSVM().airdrop(testCtx.provider.wallet.publicKey, BigInt(100e9));
+      requestAirdropLiteSVM(testCtx.provider.wallet.publicKey, BigInt(100e9));
     });
 
     it("ExactOut Sandwitch attack senario", async () => {

--- a/legacy-sdk/whirlpool/tests/integration/multi-ix/splash_pool.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/multi-ix/splash_pool.test.ts
@@ -26,7 +26,6 @@ import { WhirlpoolContext } from "../../../src/context";
 import { IGNORE_CACHE } from "../../../src/network/public/fetcher";
 import {
   resetLiteSVM,
-  getLiteSVM,
   initializeLiteSVMEnvironment,
   requestAirdropLiteSVM,
 } from "../../utils/litesvm";

--- a/legacy-sdk/whirlpool/tests/integration/multi-ix/swap_cu.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/multi-ix/swap_cu.test.ts
@@ -16,7 +16,6 @@ import { IGNORE_CACHE } from "../../../src/network/public/fetcher";
 import { initTestPoolWithTokens, useMaxCU } from "../../utils/init-utils";
 import {
   resetLiteSVM,
-  getLiteSVM,
   initializeLiteSVMEnvironment,
   requestAirdropLiteSVM,
 } from "../../utils/litesvm";

--- a/legacy-sdk/whirlpool/tests/integration/multi-ix/swap_cu.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/multi-ix/swap_cu.test.ts
@@ -18,6 +18,7 @@ import {
   resetLiteSVM,
   getLiteSVM,
   initializeLiteSVMEnvironment,
+  requestAirdropLiteSVM,
 } from "../../utils/litesvm";
 import type { ByTokenAmountsParams } from "../../../src/instructions";
 
@@ -186,7 +187,7 @@ describe("Swap CUs", () => {
   describe("Fixed TA", () => {
     beforeEach(async () => {
       await resetLiteSVM();
-      getLiteSVM().airdrop(provider.wallet.publicKey, BigInt(100e9));
+      requestAirdropLiteSVM(provider.wallet.publicKey, BigInt(100e9));
     });
 
     it("No ticks initialized", async () => {
@@ -205,7 +206,7 @@ describe("Swap CUs", () => {
   describe("Dynamic TA", () => {
     beforeEach(async () => {
       await resetLiteSVM();
-      getLiteSVM().airdrop(provider.wallet.publicKey, BigInt(100e9));
+      requestAirdropLiteSVM(provider.wallet.publicKey, BigInt(100e9));
     });
 
     it("No ticks initialized", async () => {

--- a/legacy-sdk/whirlpool/tests/integration/token-extensions/memo-transfer.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/token-extensions/memo-transfer.test.ts
@@ -1554,7 +1554,6 @@ async function countMemoLog(
   signature: string,
   logMessage: string,
 ): Promise<number> {
-  const logLen = logMessage.length;
   // old format(1 line) : Program log: Memo (len N): "MSG"
   // new format(2 lines): Program log: Memo (len N)
   //                      Program log: MSG

--- a/legacy-sdk/whirlpool/tests/integration/token-extensions/memo-transfer.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/token-extensions/memo-transfer.test.ts
@@ -1555,7 +1555,10 @@ async function countMemoLog(
   logMessage: string,
 ): Promise<number> {
   const logLen = logMessage.length;
-  const logFormat = `Program log: Memo (len ${logLen}): "${logMessage}"`;
+  // old format(1 line) : Program log: Memo (len N): "MSG"
+  // new format(2 lines): Program log: Memo (len N)
+  //                      Program log: MSG
+  const logFormat = `Program log: ${logMessage}`;
 
   const tx = await provider.connection.getParsedTransaction(signature, {
     maxSupportedTransactionVersion: 0,

--- a/legacy-sdk/whirlpool/tests/integration/token-extensions/transfer-fee.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/token-extensions/transfer-fee.test.ts
@@ -13051,13 +13051,12 @@ describe("TokenExtension/TransferFee", () => {
             .publicKey,
         }),
       ).buildAndExecute();
-
       const parsedTx = await provider.connection.getParsedTransaction(sig, {
         maxSupportedTransactionVersion: 0,
       });
 
       assert.ok(parsedTx?.meta?.innerInstructions);
-      assert.ok(parsedTx!.meta!.innerInstructions.length === 1); // twoHopSwap only (top-level ix)
+      assert.ok(parsedTx!.meta!.innerInstructions.length === 1); // swapV2 only (top-level ix)
       const memoLogs = parsedTx!.meta!.innerInstructions[0].instructions.filter(
         (ix) => ix.programId.equals(MEMO_PROGRAM_ADDRESS),
       );

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/close_position.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/close_position.test.ts
@@ -7,6 +7,7 @@ import {
   approveToken,
   createAndMintToTokenAccount,
   createTokenAccount,
+  REGEX_FOR_MISSING_SIGNATURE_ERROR,
   setAuthority,
   TickSpacing,
   transferToken,
@@ -236,7 +237,7 @@ describe("close_position", () => {
           positionTokenAccount: params.positionTokenAccount,
         }),
       ).buildAndExecute(),
-      /.*signature verification fail.*/i,
+      REGEX_FOR_MISSING_SIGNATURE_ERROR,
     );
   });
 
@@ -280,7 +281,7 @@ describe("close_position", () => {
           positionTokenAccount: params.positionTokenAccount,
         }),
       ).buildAndExecute(),
-      /.*signature verification fail.*/i,
+      REGEX_FOR_MISSING_SIGNATURE_ERROR,
     );
   });
 

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/collect_fees.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/collect_fees.test.ts
@@ -21,6 +21,7 @@ import {
   approveToken,
   createTokenAccount,
   getTokenBalance,
+  REGEX_FOR_MISSING_SIGNATURE_ERROR,
   TickSpacing,
   transferToken,
   ZERO_BN,
@@ -618,7 +619,7 @@ describe("collect_fees", () => {
           tokenVaultB: tokenVaultBKeypair.publicKey,
         }),
       ).buildAndExecute(),
-      /.*signature verification fail.*/i,
+      REGEX_FOR_MISSING_SIGNATURE_ERROR,
     );
   });
 

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/collect_protocol_fees.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/collect_protocol_fees.test.ts
@@ -10,6 +10,7 @@ import {
   createTokenAccount,
   getTokenBalance,
   initializeLiteSVMEnvironment,
+  REGEX_FOR_MISSING_SIGNATURE_ERROR,
   TickSpacing,
   ZERO_BN,
 } from "../../utils";
@@ -208,7 +209,7 @@ describe("collect_protocol_fees", () => {
           tokenOwnerAccountB: tokenAccountB,
         }),
       ).buildAndExecute(),
-      /.*signature verification fail.*/i,
+      REGEX_FOR_MISSING_SIGNATURE_ERROR,
     );
   });
 

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/collect_reward.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/collect_reward.test.ts
@@ -18,6 +18,7 @@ import {
   createMint,
   createTokenAccount,
   getTokenBalance,
+  REGEX_FOR_MISSING_SIGNATURE_ERROR,
   TickSpacing,
   transferToken,
   ZERO_BN,
@@ -733,7 +734,7 @@ describe("collect_reward", () => {
           rewardIndex: 0,
         }),
       ).buildAndExecute(),
-      /.*signature verification fail.*/i,
+      REGEX_FOR_MISSING_SIGNATURE_ERROR,
     );
   });
 

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/decrease_liquidity.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/decrease_liquidity.test.ts
@@ -13,6 +13,7 @@ import { WhirlpoolIx, toTx } from "../../../src";
 import { IGNORE_CACHE } from "../../../src/network/public/fetcher";
 import { decreaseLiquidityQuoteByLiquidityWithParams } from "../../../src/quotes/public/decrease-liquidity-quote";
 import {
+  REGEX_FOR_MISSING_SIGNATURE_ERROR,
   TickSpacing,
   ZERO_BN,
   approveToken,
@@ -1474,7 +1475,7 @@ describe("decrease_liquidity", () => {
           tickArrayUpper: position.tickArrayUpper,
         }),
       ).buildAndExecute(),
-      /.*signature verification fail.*/i,
+      REGEX_FOR_MISSING_SIGNATURE_ERROR,
     );
   });
 

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/increase_liquidity.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/increase_liquidity.test.ts
@@ -14,6 +14,7 @@ import { IGNORE_CACHE } from "../../../src/network/public/fetcher";
 import { PoolUtil, toTokenAmount } from "../../../src/utils/public/pool-utils";
 import {
   MAX_U64,
+  REGEX_FOR_MISSING_SIGNATURE_ERROR,
   TickSpacing,
   ZERO_BN,
   approveToken,
@@ -1570,7 +1571,7 @@ describe("increase_liquidity", () => {
           tickArrayUpper: positionInitInfo.tickArrayUpper,
         }),
       ).buildAndExecute(),
-      /.*signature verification fail.*/i,
+      REGEX_FOR_MISSING_SIGNATURE_ERROR,
     );
   });
 

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/initialize_fee_tier.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/initialize_fee_tier.test.ts
@@ -2,7 +2,12 @@ import * as anchor from "@coral-xyz/anchor";
 import * as assert from "assert";
 import type { FeeTierData, WhirlpoolContext } from "../../../src";
 import { PDAUtil, toTx, WhirlpoolIx } from "../../../src";
-import { ONE_SOL, REGEX_FOR_MISSING_SIGNATURE_ERROR, systemTransferTx, TickSpacing } from "../../utils";
+import {
+  ONE_SOL,
+  REGEX_FOR_MISSING_SIGNATURE_ERROR,
+  systemTransferTx,
+  TickSpacing,
+} from "../../utils";
 import { initializeLiteSVMEnvironment } from "../../utils/litesvm";
 import {
   initFeeTier,

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/initialize_fee_tier.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/initialize_fee_tier.test.ts
@@ -2,7 +2,7 @@ import * as anchor from "@coral-xyz/anchor";
 import * as assert from "assert";
 import type { FeeTierData, WhirlpoolContext } from "../../../src";
 import { PDAUtil, toTx, WhirlpoolIx } from "../../../src";
-import { ONE_SOL, systemTransferTx, TickSpacing } from "../../utils";
+import { ONE_SOL, REGEX_FOR_MISSING_SIGNATURE_ERROR, systemTransferTx, TickSpacing } from "../../utils";
 import { initializeLiteSVMEnvironment } from "../../utils/litesvm";
 import {
   initFeeTier,
@@ -166,7 +166,7 @@ describe("initialize_fee_tier", () => {
           ),
         ),
       ).buildAndExecute(),
-      /.*signature verification fail.*/i,
+      REGEX_FOR_MISSING_SIGNATURE_ERROR,
     );
   });
 

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/set_collect_protocol_fee_authority.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/set_collect_protocol_fee_authority.test.ts
@@ -4,7 +4,10 @@ import type { WhirlpoolsConfigData, WhirlpoolContext } from "../../../src";
 import { toTx, WhirlpoolIx } from "../../../src";
 import { initializeLiteSVMEnvironment } from "../../utils/litesvm";
 import { generateDefaultConfigParams } from "../../utils/test-builders";
-import { getLocalnetAdminKeypair0, REGEX_FOR_MISSING_SIGNATURE_ERROR } from "../../utils";
+import {
+  getLocalnetAdminKeypair0,
+  REGEX_FOR_MISSING_SIGNATURE_ERROR,
+} from "../../utils";
 
 describe("set_collect_protocol_fee_authority", () => {
   let provider: anchor.AnchorProvider;

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/set_collect_protocol_fee_authority.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/set_collect_protocol_fee_authority.test.ts
@@ -4,7 +4,7 @@ import type { WhirlpoolsConfigData, WhirlpoolContext } from "../../../src";
 import { toTx, WhirlpoolIx } from "../../../src";
 import { initializeLiteSVMEnvironment } from "../../utils/litesvm";
 import { generateDefaultConfigParams } from "../../utils/test-builders";
-import { getLocalnetAdminKeypair0 } from "../../utils";
+import { getLocalnetAdminKeypair0, REGEX_FOR_MISSING_SIGNATURE_ERROR } from "../../utils";
 
 describe("set_collect_protocol_fee_authority", () => {
   let provider: anchor.AnchorProvider;
@@ -67,7 +67,7 @@ describe("set_collect_protocol_fee_authority", () => {
           newCollectProtocolFeesAuthority: provider.wallet.publicKey,
         }),
       ).buildAndExecute(),
-      /.*signature verification fail.*/i,
+      REGEX_FOR_MISSING_SIGNATURE_ERROR,
     );
   });
 

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/set_default_fee_rate.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/set_default_fee_rate.test.ts
@@ -6,7 +6,7 @@ import type {
   WhirlpoolContext,
 } from "../../../src";
 import { PDAUtil, toTx, WhirlpoolIx } from "../../../src";
-import { getLocalnetAdminKeypair0, TickSpacing } from "../../utils";
+import { getLocalnetAdminKeypair0, REGEX_FOR_MISSING_SIGNATURE_ERROR, TickSpacing } from "../../utils";
 import { initializeLiteSVMEnvironment } from "../../utils/litesvm";
 import { initTestPool } from "../../utils/init-utils";
 import {
@@ -221,7 +221,7 @@ describe("set_default_fee_rate", () => {
           feeAuthority: feeAuthorityKeypair.publicKey,
         },
       }),
-      /.*signature verification fail.*/i,
+      REGEX_FOR_MISSING_SIGNATURE_ERROR,
     );
   });
 

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/set_default_fee_rate.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/set_default_fee_rate.test.ts
@@ -214,13 +214,15 @@ describe("set_default_fee_rate", () => {
 
     const newDefaultFeeRate = 1000;
     await assert.rejects(
-      program.rpc.setDefaultFeeRate(newDefaultFeeRate, {
-        accounts: {
+      toTx(
+        ctx,
+        WhirlpoolIx.setDefaultFeeRateIx(ctx.program, {
           whirlpoolsConfig: whirlpoolsConfigKey,
-          feeTier: feeTierPda.publicKey,
+          tickSpacing: TickSpacing.Standard,
           feeAuthority: feeAuthorityKeypair.publicKey,
-        },
-      }),
+          defaultFeeRate: newDefaultFeeRate,
+        }),
+      ).buildAndExecute(),
       REGEX_FOR_MISSING_SIGNATURE_ERROR,
     );
   });

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/set_default_fee_rate.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/set_default_fee_rate.test.ts
@@ -6,7 +6,11 @@ import type {
   WhirlpoolContext,
 } from "../../../src";
 import { PDAUtil, toTx, WhirlpoolIx } from "../../../src";
-import { getLocalnetAdminKeypair0, REGEX_FOR_MISSING_SIGNATURE_ERROR, TickSpacing } from "../../utils";
+import {
+  getLocalnetAdminKeypair0,
+  REGEX_FOR_MISSING_SIGNATURE_ERROR,
+  TickSpacing,
+} from "../../utils";
 import { initializeLiteSVMEnvironment } from "../../utils/litesvm";
 import { initTestPool } from "../../utils/init-utils";
 import {
@@ -206,11 +210,6 @@ describe("set_default_fee_rate", () => {
     const whirlpoolsConfigKey =
       configInitInfo.whirlpoolsConfigKeypair.publicKey;
     const feeAuthorityKeypair = configKeypairs.feeAuthorityKeypair;
-    const feeTierPda = PDAUtil.getFeeTier(
-      ctx.program.programId,
-      configInitInfo.whirlpoolsConfigKeypair.publicKey,
-      TickSpacing.Standard,
-    );
 
     const newDefaultFeeRate = 1000;
     await assert.rejects(

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/set_default_protocol_fee_rate.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/set_default_protocol_fee_rate.test.ts
@@ -6,7 +6,7 @@ import type {
   WhirlpoolContext,
 } from "../../../src";
 import { PDAUtil, toTx, WhirlpoolIx } from "../../../src";
-import { TickSpacing } from "../../utils";
+import { REGEX_FOR_MISSING_SIGNATURE_ERROR, TickSpacing } from "../../utils";
 import { initializeLiteSVMEnvironment } from "../../utils/litesvm";
 import { initTestPool } from "../../utils/init-utils";
 import { createInOrderMints } from "../../utils/test-builders";
@@ -133,7 +133,7 @@ describe("set_default_protocol_fee_rate", () => {
           feeAuthority: feeAuthorityKeypair.publicKey,
         },
       }),
-      /.*signature verification fail.*/i,
+      REGEX_FOR_MISSING_SIGNATURE_ERROR,
     );
   });
 

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/set_default_protocol_fee_rate.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/set_default_protocol_fee_rate.test.ts
@@ -133,7 +133,7 @@ describe("set_default_protocol_fee_rate", () => {
           whirlpoolsConfig: whirlpoolsConfigKey,
           feeAuthority: feeAuthorityKeypair.publicKey,
           defaultProtocolFeeRate: newDefaultProtocolFeeRate,
-        })
+        }),
       ).buildAndExecute(),
       REGEX_FOR_MISSING_SIGNATURE_ERROR,
     );

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/set_default_protocol_fee_rate.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/set_default_protocol_fee_rate.test.ts
@@ -127,12 +127,14 @@ describe("set_default_protocol_fee_rate", () => {
 
     const newDefaultProtocolFeeRate = 1000;
     await assert.rejects(
-      program.rpc.setDefaultProtocolFeeRate(newDefaultProtocolFeeRate, {
-        accounts: {
+      toTx(
+        ctx,
+        WhirlpoolIx.setDefaultProtocolFeeRateIx(ctx.program, {
           whirlpoolsConfig: whirlpoolsConfigKey,
           feeAuthority: feeAuthorityKeypair.publicKey,
-        },
-      }),
+          defaultProtocolFeeRate: newDefaultProtocolFeeRate,
+        })
+      ).buildAndExecute(),
       REGEX_FOR_MISSING_SIGNATURE_ERROR,
     );
   });

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/set_fee_authority.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/set_fee_authority.test.ts
@@ -4,7 +4,10 @@ import type { WhirlpoolsConfigData, WhirlpoolContext } from "../../../src";
 import { toTx, WhirlpoolIx } from "../../../src";
 import { initializeLiteSVMEnvironment } from "../../utils/litesvm";
 import { generateDefaultConfigParams } from "../../utils/test-builders";
-import { getLocalnetAdminKeypair0, REGEX_FOR_MISSING_SIGNATURE_ERROR } from "../../utils";
+import {
+  getLocalnetAdminKeypair0,
+  REGEX_FOR_MISSING_SIGNATURE_ERROR,
+} from "../../utils";
 
 describe("set_fee_authority", () => {
   let provider: anchor.AnchorProvider;

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/set_fee_authority.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/set_fee_authority.test.ts
@@ -4,7 +4,7 @@ import type { WhirlpoolsConfigData, WhirlpoolContext } from "../../../src";
 import { toTx, WhirlpoolIx } from "../../../src";
 import { initializeLiteSVMEnvironment } from "../../utils/litesvm";
 import { generateDefaultConfigParams } from "../../utils/test-builders";
-import { getLocalnetAdminKeypair0 } from "../../utils";
+import { getLocalnetAdminKeypair0, REGEX_FOR_MISSING_SIGNATURE_ERROR } from "../../utils";
 
 describe("set_fee_authority", () => {
   let provider: anchor.AnchorProvider;
@@ -63,7 +63,7 @@ describe("set_fee_authority", () => {
           newFeeAuthority: provider.wallet.publicKey,
         }),
       ).buildAndExecute(),
-      /.*signature verification fail.*/i,
+      REGEX_FOR_MISSING_SIGNATURE_ERROR,
     );
   });
 

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/set_fee_rate.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/set_fee_rate.test.ts
@@ -3,7 +3,7 @@ import * as assert from "assert";
 import type { WhirlpoolData, WhirlpoolContext } from "../../../src";
 import { toTx, WhirlpoolIx } from "../../../src";
 import { IGNORE_CACHE } from "../../../src/network/public/fetcher";
-import { getLocalnetAdminKeypair0, TickSpacing } from "../../utils";
+import { getLocalnetAdminKeypair0, REGEX_FOR_MISSING_SIGNATURE_ERROR, TickSpacing } from "../../utils";
 import {
   initializeLiteSVMEnvironment,
   pollForCondition,
@@ -152,7 +152,7 @@ describe("set_fee_rate", () => {
           feeRate: newFeeRate,
         }),
       ).buildAndExecute(),
-      /.*signature verification fail.*/i,
+      REGEX_FOR_MISSING_SIGNATURE_ERROR,
     );
   });
 

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/set_fee_rate.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/set_fee_rate.test.ts
@@ -3,7 +3,11 @@ import * as assert from "assert";
 import type { WhirlpoolData, WhirlpoolContext } from "../../../src";
 import { toTx, WhirlpoolIx } from "../../../src";
 import { IGNORE_CACHE } from "../../../src/network/public/fetcher";
-import { getLocalnetAdminKeypair0, REGEX_FOR_MISSING_SIGNATURE_ERROR, TickSpacing } from "../../utils";
+import {
+  getLocalnetAdminKeypair0,
+  REGEX_FOR_MISSING_SIGNATURE_ERROR,
+  TickSpacing,
+} from "../../utils";
 import {
   initializeLiteSVMEnvironment,
   pollForCondition,

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/set_protocol_fee_rate.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/set_protocol_fee_rate.test.ts
@@ -3,7 +3,11 @@ import * as assert from "assert";
 import type { WhirlpoolData, WhirlpoolContext } from "../../../src";
 import { toTx, WhirlpoolIx } from "../../../src";
 import { IGNORE_CACHE } from "../../../src/network/public/fetcher";
-import { getLocalnetAdminKeypair0, REGEX_FOR_MISSING_SIGNATURE_ERROR, TickSpacing } from "../../utils";
+import {
+  getLocalnetAdminKeypair0,
+  REGEX_FOR_MISSING_SIGNATURE_ERROR,
+  TickSpacing,
+} from "../../utils";
 import {
   initializeLiteSVMEnvironment,
   pollForCondition,

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/set_protocol_fee_rate.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/set_protocol_fee_rate.test.ts
@@ -3,7 +3,7 @@ import * as assert from "assert";
 import type { WhirlpoolData, WhirlpoolContext } from "../../../src";
 import { toTx, WhirlpoolIx } from "../../../src";
 import { IGNORE_CACHE } from "../../../src/network/public/fetcher";
-import { getLocalnetAdminKeypair0, TickSpacing } from "../../utils";
+import { getLocalnetAdminKeypair0, REGEX_FOR_MISSING_SIGNATURE_ERROR, TickSpacing } from "../../utils";
 import {
   initializeLiteSVMEnvironment,
   pollForCondition,
@@ -117,7 +117,7 @@ describe("set_protocol_fee_rate", () => {
           protocolFeeRate: newProtocolFeeRate,
         }),
       ).buildAndExecute(),
-      /.*signature verification fail.*/i,
+      REGEX_FOR_MISSING_SIGNATURE_ERROR,
     );
   });
 

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/set_reward_authority.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/set_reward_authority.test.ts
@@ -3,7 +3,7 @@ import { TransactionBuilder } from "@orca-so/common-sdk";
 import * as assert from "assert";
 import type { WhirlpoolData, WhirlpoolContext } from "../../../src";
 import { PoolUtil, toTx, WhirlpoolIx } from "../../../src";
-import { TickSpacing } from "../../utils";
+import { REGEX_FOR_MISSING_SIGNATURE_ERROR, TickSpacing } from "../../utils";
 import { initializeLiteSVMEnvironment } from "../../utils/litesvm";
 import { initTestPool } from "../../utils/init-utils";
 
@@ -127,7 +127,7 @@ describe("set_reward_authority", () => {
           rewardIndex: 0,
         }),
       ).buildAndExecute(),
-      /.*signature verification fail.*/i,
+      REGEX_FOR_MISSING_SIGNATURE_ERROR,
     );
   });
 });

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/set_reward_authority_by_super_authority.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/set_reward_authority_by_super_authority.test.ts
@@ -2,7 +2,7 @@ import * as anchor from "@coral-xyz/anchor";
 import * as assert from "assert";
 import type { WhirlpoolData, WhirlpoolContext } from "../../../src";
 import { PoolUtil, toTx, WhirlpoolIx } from "../../../src";
-import { TickSpacing } from "../../utils";
+import { REGEX_FOR_MISSING_SIGNATURE_ERROR, TickSpacing } from "../../utils";
 import { initializeLiteSVMEnvironment } from "../../utils/litesvm";
 import { initTestPool } from "../../utils/init-utils";
 
@@ -114,7 +114,7 @@ describe("set_reward_authority_by_super_authority", () => {
           rewardIndex: 0,
         }),
       ).buildAndExecute(),
-      /.*signature verification fail.*/i,
+      REGEX_FOR_MISSING_SIGNATURE_ERROR,
     );
   });
 

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/set_reward_emissions.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/set_reward_emissions.test.ts
@@ -6,6 +6,7 @@ import { IGNORE_CACHE } from "../../../src/network/public/fetcher";
 import {
   createAndMintToTokenAccount,
   mintToDestination,
+  REGEX_FOR_MISSING_SIGNATURE_ERROR,
   TickSpacing,
   ZERO_BN,
 } from "../../utils";
@@ -226,7 +227,7 @@ describe("set_reward_emissions", () => {
           emissionsPerSecondX64,
         }),
       ).buildAndExecute(),
-      /.*signature verification fail.*/i,
+      REGEX_FOR_MISSING_SIGNATURE_ERROR,
     );
   });
 });

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/set_reward_emissions_super_authority.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/set_reward_emissions_super_authority.test.ts
@@ -63,14 +63,15 @@ describe("set_reward_emissions_super_authority", () => {
       .buildAndExecute();
 
     await assert.rejects(
-      ctx.program.rpc.setRewardEmissionsSuperAuthority({
-        accounts: {
+      toTx(
+        ctx,
+        WhirlpoolIx.setRewardEmissionsSuperAuthorityIx(ctx.program, {
           whirlpoolsConfig: configInitInfo.whirlpoolsConfigKeypair.publicKey,
           rewardEmissionsSuperAuthority:
             rewardEmissionsSuperAuthorityKeypair.publicKey,
           newRewardEmissionsSuperAuthority: provider.wallet.publicKey,
-        },
-      }),
+        }),
+      ).buildAndExecute(),
       REGEX_FOR_MISSING_SIGNATURE_ERROR,
     );
   });

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/set_reward_emissions_super_authority.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/set_reward_emissions_super_authority.test.ts
@@ -4,7 +4,10 @@ import type { WhirlpoolsConfigData, WhirlpoolContext } from "../../../src";
 import { toTx, WhirlpoolIx } from "../../../src";
 import { initializeLiteSVMEnvironment } from "../../utils/litesvm";
 import { generateDefaultConfigParams } from "../../utils/test-builders";
-import { getLocalnetAdminKeypair0, REGEX_FOR_MISSING_SIGNATURE_ERROR } from "../../utils";
+import {
+  getLocalnetAdminKeypair0,
+  REGEX_FOR_MISSING_SIGNATURE_ERROR,
+} from "../../utils";
 
 describe("set_reward_emissions_super_authority", () => {
   let provider: anchor.AnchorProvider;

--- a/legacy-sdk/whirlpool/tests/integration/v1-ix/set_reward_emissions_super_authority.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v1-ix/set_reward_emissions_super_authority.test.ts
@@ -4,7 +4,7 @@ import type { WhirlpoolsConfigData, WhirlpoolContext } from "../../../src";
 import { toTx, WhirlpoolIx } from "../../../src";
 import { initializeLiteSVMEnvironment } from "../../utils/litesvm";
 import { generateDefaultConfigParams } from "../../utils/test-builders";
-import { getLocalnetAdminKeypair0 } from "../../utils";
+import { getLocalnetAdminKeypair0, REGEX_FOR_MISSING_SIGNATURE_ERROR } from "../../utils";
 
 describe("set_reward_emissions_super_authority", () => {
   let provider: anchor.AnchorProvider;
@@ -71,7 +71,7 @@ describe("set_reward_emissions_super_authority", () => {
           newRewardEmissionsSuperAuthority: provider.wallet.publicKey,
         },
       }),
-      /.*signature verification fail.*/i,
+      REGEX_FOR_MISSING_SIGNATURE_ERROR,
     );
   });
 

--- a/legacy-sdk/whirlpool/tests/integration/v2-ix/collect/collect_fees_v2.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v2-ix/collect/collect_fees_v2.test.ts
@@ -29,6 +29,7 @@ import {
   transferToken,
   ZERO_BN,
   initializeLiteSVMEnvironment,
+  REGEX_FOR_MISSING_SIGNATURE_ERROR,
 } from "../../../utils";
 import { WhirlpoolTestFixtureV2 } from "../../../utils/v2/fixture-v2";
 import type { TokenTrait } from "../../../utils/v2/init-utils-v2";
@@ -1002,7 +1003,7 @@ describe("collect_fees_v2", () => {
                 tokenVaultB: tokenVaultBKeypair.publicKey,
               }),
             ).buildAndExecute(),
-            /.*signature verification fail.*/i,
+            REGEX_FOR_MISSING_SIGNATURE_ERROR,
           );
         });
 

--- a/legacy-sdk/whirlpool/tests/integration/v2-ix/collect/collect_protocol_fees_v2.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v2-ix/collect/collect_protocol_fees_v2.test.ts
@@ -18,6 +18,7 @@ import {
   TickSpacing,
   ZERO_BN,
   initializeLiteSVMEnvironment,
+  REGEX_FOR_MISSING_SIGNATURE_ERROR,
 } from "../../../utils";
 import { WhirlpoolTestFixtureV2 } from "../../../utils/v2/fixture-v2";
 import type { TokenTrait } from "../../../utils/v2/init-utils-v2";
@@ -276,7 +277,7 @@ describe("collect_protocol_fees_v2", () => {
                 tokenOwnerAccountB: tokenAccountB,
               }),
             ).buildAndExecute(),
-            /.*signature verification fail.*/i,
+            REGEX_FOR_MISSING_SIGNATURE_ERROR,
           );
         });
 

--- a/legacy-sdk/whirlpool/tests/integration/v2-ix/collect/collect_reward_v2.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v2-ix/collect/collect_reward_v2.test.ts
@@ -28,6 +28,7 @@ import {
   ZERO_BN,
   warpClock,
   initializeLiteSVMEnvironment,
+  REGEX_FOR_MISSING_SIGNATURE_ERROR,
 } from "../../../utils";
 import { WhirlpoolTestFixtureV2 } from "../../../utils/v2/fixture-v2";
 import type { TokenTrait } from "../../../utils/v2/init-utils-v2";
@@ -980,7 +981,7 @@ describe("collect_reward_v2", () => {
                 rewardIndex: 0,
               }),
             ).buildAndExecute(),
-            /.*signature verification fail.*/i,
+            REGEX_FOR_MISSING_SIGNATURE_ERROR,
           );
         });
 

--- a/legacy-sdk/whirlpool/tests/integration/v2-ix/initialize/set_reward_emissions_v2.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v2-ix/initialize/set_reward_emissions_v2.test.ts
@@ -4,6 +4,7 @@ import type { WhirlpoolData, WhirlpoolContext } from "../../../../src";
 import { toTx, WhirlpoolIx } from "../../../../src";
 import { IGNORE_CACHE } from "../../../../src/network/public/fetcher";
 import {
+  REGEX_FOR_MISSING_SIGNATURE_ERROR,
   TickSpacing,
   ZERO_BN,
   initializeLiteSVMEnvironment,
@@ -321,7 +322,7 @@ describe("set_reward_emissions_v2", () => {
                 emissionsPerSecondX64,
               }),
             ).buildAndExecute(),
-            /.*signature verification fail.*/i,
+            REGEX_FOR_MISSING_SIGNATURE_ERROR,
           );
         });
       });

--- a/legacy-sdk/whirlpool/tests/integration/v2-ix/liquidity/decrease_liquidity_v2.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v2-ix/liquidity/decrease_liquidity_v2.test.ts
@@ -22,6 +22,7 @@ import {
   transferToken,
   warpClock,
   initializeLiteSVMEnvironment,
+  REGEX_FOR_MISSING_SIGNATURE_ERROR,
 } from "../../../utils";
 import { TICK_INIT_SIZE, TICK_RENT_AMOUNT } from "../../../utils/const";
 import { WhirlpoolTestFixtureV2 } from "../../../utils/v2/fixture-v2";
@@ -1702,7 +1703,7 @@ describe("decrease_liquidity_v2", () => {
                 tickArrayUpper: position.tickArrayUpper,
               }),
             ).buildAndExecute(),
-            /.*signature verification fail.*/i,
+            REGEX_FOR_MISSING_SIGNATURE_ERROR,
           );
         });
 

--- a/legacy-sdk/whirlpool/tests/integration/v2-ix/liquidity/increase_liquidity_by_token_amounts_v2.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v2-ix/liquidity/increase_liquidity_by_token_amounts_v2.test.ts
@@ -35,6 +35,7 @@ import {
   transferToken,
   warpClock,
   initializeLiteSVMEnvironment,
+  REGEX_FOR_MISSING_SIGNATURE_ERROR,
 } from "../../../utils";
 import { TICK_INIT_SIZE, TICK_RENT_AMOUNT } from "../../../utils/const";
 import { WhirlpoolTestFixtureV2 } from "../../../utils/v2/fixture-v2";
@@ -1783,7 +1784,7 @@ describe("increase_liquidity_v2", () => {
                 tickArrayUpper: positionInitInfo.tickArrayUpper,
               }),
             ).buildAndExecute(),
-            /.*signature verification fail.*/i,
+            REGEX_FOR_MISSING_SIGNATURE_ERROR,
           );
         });
 

--- a/legacy-sdk/whirlpool/tests/integration/v2-ix/liquidity/increase_liquidity_v2.test.ts
+++ b/legacy-sdk/whirlpool/tests/integration/v2-ix/liquidity/increase_liquidity_v2.test.ts
@@ -34,6 +34,7 @@ import {
   transferToken,
   warpClock,
   initializeLiteSVMEnvironment,
+  REGEX_FOR_MISSING_SIGNATURE_ERROR,
 } from "../../../utils";
 import { TICK_INIT_SIZE, TICK_RENT_AMOUNT } from "../../../utils/const";
 import { WhirlpoolTestFixtureV2 } from "../../../utils/v2/fixture-v2";
@@ -1778,7 +1779,7 @@ describe("increase_liquidity_v2", () => {
                 tickArrayUpper: positionInitInfo.tickArrayUpper,
               }),
             ).buildAndExecute(),
-            /.*signature verification fail.*/i,
+            REGEX_FOR_MISSING_SIGNATURE_ERROR,
           );
         });
 

--- a/legacy-sdk/whirlpool/tests/utils/assert.ts
+++ b/legacy-sdk/whirlpool/tests/utils/assert.ts
@@ -192,4 +192,5 @@ export function assertTick(
   assert.ok(tick.liquidityGross.eq(liquidityGross));
 }
 
-export const REGEX_FOR_MISSING_SIGNATURE_ERROR: RegExp = /Transaction is missing signatures/;
+export const REGEX_FOR_MISSING_SIGNATURE_ERROR: RegExp =
+  /Transaction is missing signatures/;

--- a/legacy-sdk/whirlpool/tests/utils/assert.ts
+++ b/legacy-sdk/whirlpool/tests/utils/assert.ts
@@ -191,3 +191,5 @@ export function assertTick(
   assert.ok(tick.liquidityNet.eq(liquidityNet));
   assert.ok(tick.liquidityGross.eq(liquidityGross));
 }
+
+export const REGEX_FOR_MISSING_SIGNATURE_ERROR: RegExp = /Transaction is missing signatures/;

--- a/legacy-sdk/whirlpool/tests/utils/litesvm.ts
+++ b/legacy-sdk/whirlpool/tests/utils/litesvm.ts
@@ -3,7 +3,8 @@
  */
 import type { AnchorProvider } from "@coral-xyz/anchor";
 import * as anchor from "@coral-xyz/anchor";
-import { PublicKey, Keypair, Transaction, VersionedTransaction } from "@solana/web3.js";
+import type { VersionedTransaction } from "@solana/web3.js";
+import { PublicKey, Keypair, Transaction } from "@solana/web3.js";
 import { LiteSVM, Clock, FeatureSet } from "litesvm";
 import bs58 from "bs58";
 import * as fs from "fs";
@@ -19,7 +20,13 @@ import { TEST_TOKEN_PROGRAM_ID } from "./test-consts";
 import whirlpoolIdl from "../../src/artifacts/whirlpool.json";
 import { WhirlpoolContext } from "../../src";
 import { TEST_TOKEN_2022_PROGRAM_ID } from "../utils";
-import { Address, EncodedAccount, lamports, address, MaybeEncodedAccount, TransactionMessageBytes, SignaturesMap, Transaction as KitTransaction, getTransactionDecoder } from "@solana/kit";
+import type {
+  Address,
+  EncodedAccount,
+  MaybeEncodedAccount,
+  Transaction as KitTransaction,
+} from "@solana/kit";
+import { lamports, address, getTransactionDecoder } from "@solana/kit";
 
 let _litesvm: LiteSVM | null = null;
 
@@ -58,13 +65,15 @@ function ensureNativeMintAccounts(litesvm: LiteSVM) {
       data.writeUInt8(9, 44);
       // isInitialized at offset 45 (bool)
       data.writeUInt8(1, 45);
-      litesvm.setAccount(toEncodedAccount(mint, {
-        lamports: 1_000_000, // non-zero rent to look realistic
-        data: new Uint8Array(data),
-        owner,
-        executable: false,
-        rentEpoch: 0,
-      }));
+      litesvm.setAccount(
+        toEncodedAccount(mint, {
+          lamports: 1_000_000, // non-zero rent to look realistic
+          data: new Uint8Array(data),
+          owner,
+          executable: false,
+          rentEpoch: 0,
+        }),
+      );
     }
   };
   ensure(NATIVE_MINT, TOKEN_PROGRAM_ID);
@@ -431,7 +440,9 @@ function createLiteSVMConnection(litesvm: LiteSVM) {
   return {
     getAccountInfo: async (pubkey: PublicKey) => {
       const litesvm = getLiteSVM();
-      const account = fromMaybeEncodedAccount(litesvm.getAccount(toAddress(pubkey)));
+      const account = fromMaybeEncodedAccount(
+        litesvm.getAccount(toAddress(pubkey)),
+      );
       if (!account) {
         // Synthesize native mint accounts if missing so tests can read owner
         if (pubkey.equals(NATIVE_MINT)) {
@@ -465,7 +476,9 @@ function createLiteSVMConnection(litesvm: LiteSVM) {
     getMultipleAccountsInfo: async (pubkeys: PublicKey[]) => {
       const litesvm = getLiteSVM();
       return pubkeys.map((pk) => {
-        const account = fromMaybeEncodedAccount(litesvm.getAccount(toAddress(pk)));
+        const account = fromMaybeEncodedAccount(
+          litesvm.getAccount(toAddress(pk)),
+        );
         if (!account) {
           if (pk.equals(NATIVE_MINT)) {
             return {
@@ -756,7 +769,10 @@ function createLiteSVMConnection(litesvm: LiteSVM) {
     requestAirdrop: async (pubkey: PublicKey, airdropLamports: number) => {
       const litesvm = getLiteSVM();
       try {
-        const result = litesvm.airdrop(toAddress(pubkey), lamports(BigInt(airdropLamports)));
+        const result = litesvm.airdrop(
+          toAddress(pubkey),
+          lamports(BigInt(airdropLamports)),
+        );
         // LiteSVM airdrop returns null on success or an error object on failure
         // If result is null or undefined, it's a success
         if (!result) {
@@ -783,7 +799,9 @@ function createLiteSVMConnection(litesvm: LiteSVM) {
     },
     getTokenSupply: async (mint: PublicKey) => {
       const litesvm = getLiteSVM();
-      const mintAccount = fromMaybeEncodedAccount(litesvm.getAccount(toAddress(mint)));
+      const mintAccount = fromMaybeEncodedAccount(
+        litesvm.getAccount(toAddress(mint)),
+      );
       if (!mintAccount || mintAccount.data.length < 45) {
         throw new Error("Invalid mint account");
       }
@@ -834,7 +852,9 @@ function createLiteSVMConnection(litesvm: LiteSVM) {
     getTokenAccountBalance: async (pubkey: PublicKey) => {
       const litesvm = getLiteSVM();
       // Get the token account data
-      const account = fromMaybeEncodedAccount(litesvm.getAccount(toAddress(pubkey)));
+      const account = fromMaybeEncodedAccount(
+        litesvm.getAccount(toAddress(pubkey)),
+      );
       if (!account || account.data.length < 72) {
         throw new Error("Invalid token account");
       }
@@ -844,7 +864,9 @@ function createLiteSVMConnection(litesvm: LiteSVM) {
       const amount = data.readBigUInt64LE(64);
       // Get the mint to determine decimals
       const mintPubkey = new PublicKey(data.slice(0, 32));
-      const mintAccount = fromMaybeEncodedAccount(litesvm.getAccount(toAddress(mintPubkey)));
+      const mintAccount = fromMaybeEncodedAccount(
+        litesvm.getAccount(toAddress(mintPubkey)),
+      );
       let decimals = 0;
       if (mintAccount && mintAccount.data.length >= 45) {
         const mintData = Buffer.from(mintAccount.data);
@@ -1122,7 +1144,10 @@ export async function createFundedKeypair(
 ): Promise<Keypair> {
   const litesvm = getLiteSVM();
   const keypair = Keypair.generate();
-  litesvm.airdrop(toAddress(keypair.publicKey), lamports(BigInt(airdropLamports)));
+  litesvm.airdrop(
+    toAddress(keypair.publicKey),
+    lamports(BigInt(airdropLamports)),
+  );
   return keypair;
 }
 
@@ -1152,13 +1177,15 @@ export function loadPreloadAccount(relativePath: string): void {
     typeof rentEpochRaw === "number" && rentEpochRaw > Number.MAX_SAFE_INTEGER
       ? 0
       : Number(rentEpochRaw);
-  litesvm.setAccount(toEncodedAccount(pubkey, {
-    lamports: lamportsNumber,
-    data: new Uint8Array(data),
-    owner: new PublicKey(account.owner),
-    executable: account.executable,
-    rentEpoch: rentEpochNumber,
-  }));
+  litesvm.setAccount(
+    toEncodedAccount(pubkey, {
+      lamports: lamportsNumber,
+      data: new Uint8Array(data),
+      owner: new PublicKey(account.owner),
+      executable: account.executable,
+      rentEpoch: rentEpochNumber,
+    }),
+  );
   console.info(`✅ Loaded preload account: ${pubkey.toBase58()}`);
 }
 
@@ -1397,13 +1424,15 @@ export async function initializeNativeMintIdempotent(provider: AnchorProvider) {
   const rentExemptLamports =
     await provider.connection.getMinimumBalanceForRentExemption(82);
   const litesvm = getLiteSVM();
-  litesvm.setAccount(toEncodedAccount(NATIVE_MINT, {
-    lamports: Number(rentExemptLamports),
-    data: new Uint8Array(mintData),
-    owner: TEST_TOKEN_PROGRAM_ID,
-    executable: false,
-    rentEpoch: 0,
-  }));
+  litesvm.setAccount(
+    toEncodedAccount(NATIVE_MINT, {
+      lamports: Number(rentExemptLamports),
+      data: new Uint8Array(mintData),
+      owner: TEST_TOKEN_PROGRAM_ID,
+      executable: false,
+      rentEpoch: 0,
+    }),
+  );
 }
 
 export async function initializeLiteSVMEnvironment(programId?: PublicKey) {
@@ -1438,7 +1467,10 @@ export async function resetAndInitializeLiteSVMEnvironment(
   return await initializeLiteSVMEnvironment(programId);
 }
 
-export function requestAirdropLiteSVM(pubkey: PublicKey, airdropLamports: bigint) {
+export function requestAirdropLiteSVM(
+  pubkey: PublicKey,
+  airdropLamports: bigint,
+) {
   getLiteSVM().airdrop(toAddress(pubkey), lamports(airdropLamports));
 }
 
@@ -1460,29 +1492,32 @@ function toAddress(pubkey: PublicKey): Address {
   return address(pubkey.toBase58());
 }
 
-function toEncodedAccount(pubkey: PublicKey, accountInfo: {
-    lamports: number,
-    data: Uint8Array,
-    owner: PublicKey,
-    executable: boolean,
-    rentEpoch: number,
-  }): EncodedAccount {
-    return {
-      address: toAddress(pubkey),
-      executable: accountInfo.executable,
-      programAddress: toAddress(accountInfo.owner),
-      lamports: lamports(BigInt(accountInfo.lamports)),
-      space: BigInt(accountInfo.data.length),
-      data: accountInfo.data,
-    };
+function toEncodedAccount(
+  pubkey: PublicKey,
+  accountInfo: {
+    lamports: number;
+    data: Uint8Array;
+    owner: PublicKey;
+    executable: boolean;
+    rentEpoch: number;
+  },
+): EncodedAccount {
+  return {
+    address: toAddress(pubkey),
+    executable: accountInfo.executable,
+    programAddress: toAddress(accountInfo.owner),
+    lamports: lamports(BigInt(accountInfo.lamports)),
+    space: BigInt(accountInfo.data.length),
+    data: accountInfo.data,
+  };
 }
 
 function fromMaybeEncodedAccount(account: MaybeEncodedAccount): {
-    lamports: bigint,
-    data: Uint8Array,
-    owner: PublicKey,
-    executable: boolean,
-    rentEpoch: number,
+  lamports: bigint;
+  data: Uint8Array;
+  owner: PublicKey;
+  executable: boolean;
+  rentEpoch: number;
 } | null {
   if (!account.exists) {
     return null;
@@ -1494,7 +1529,7 @@ function fromMaybeEncodedAccount(account: MaybeEncodedAccount): {
     executable: account.executable,
     owner: new PublicKey(account.programAddress.toString()),
     rentEpoch: 0,
-  };  
+  };
 }
 
 function toKitTransaction(

--- a/legacy-sdk/whirlpool/tests/utils/litesvm.ts
+++ b/legacy-sdk/whirlpool/tests/utils/litesvm.ts
@@ -3,8 +3,7 @@
  */
 import type { AnchorProvider } from "@coral-xyz/anchor";
 import * as anchor from "@coral-xyz/anchor";
-import type { VersionedTransaction } from "@solana/web3.js";
-import { PublicKey, Keypair, Transaction } from "@solana/web3.js";
+import { PublicKey, Keypair, Transaction, VersionedTransaction } from "@solana/web3.js";
 import { LiteSVM, Clock, FeatureSet } from "litesvm";
 import bs58 from "bs58";
 import * as fs from "fs";
@@ -19,6 +18,7 @@ import { TEST_TOKEN_PROGRAM_ID } from "./test-consts";
 import whirlpoolIdl from "../../src/artifacts/whirlpool.json";
 import { WhirlpoolContext } from "../../src";
 import { TEST_TOKEN_2022_PROGRAM_ID } from "../utils";
+import { Address, EncodedAccount, lamports, address, MaybeEncodedAccount, TransactionMessageBytes, SignaturesMap, Transaction as KitTransaction, getTransactionDecoder } from "@solana/kit";
 
 let _litesvm: LiteSVM | null = null;
 
@@ -49,7 +49,7 @@ let _transactionHistory: Map<string, TransactionRecord> = new Map();
 function ensureNativeMintAccounts(litesvm: LiteSVM) {
   // Minimal mint layout: set owner and 82-byte data buffer
   const ensure = (mint: PublicKey, owner: PublicKey) => {
-    const acc = litesvm.getAccount(mint);
+    const acc = fromMaybeEncodedAccount(litesvm.getAccount(toAddress(mint)));
     if (!acc) {
       const data = Buffer.alloc(82, 0);
       // supply at offset 36 (u64) -> 0
@@ -57,13 +57,13 @@ function ensureNativeMintAccounts(litesvm: LiteSVM) {
       data.writeUInt8(9, 44);
       // isInitialized at offset 45 (bool)
       data.writeUInt8(1, 45);
-      litesvm.setAccount(mint, {
+      litesvm.setAccount(toEncodedAccount(mint, {
         lamports: 1_000_000, // non-zero rent to look realistic
         data: new Uint8Array(data),
         owner,
         executable: false,
         rentEpoch: 0,
-      });
+      }));
     }
   };
   ensure(NATIVE_MINT, TOKEN_PROGRAM_ID);
@@ -169,7 +169,7 @@ function loadProgramFromPath(
   onError?: (message: string) => void,
 ): void {
   if (fs.existsSync(programPath)) {
-    _litesvm!.addProgramFromFile(programId, programPath);
+    _litesvm!.addProgramFromFile(toAddress(programId), programPath);
     onSuccess?.();
   } else {
     onError?.(`Program not found at ${programPath}`);
@@ -401,7 +401,7 @@ export async function createLiteSVMProvider(): Promise<anchor.AnchorProvider> {
   // Create wallet
   const wallet = Keypair.generate();
   // Fund the wallet using airdrop (500 SOL for tests that need large transfers)
-  litesvm.airdrop(wallet.publicKey, BigInt(500e9));
+  litesvm.airdrop(toAddress(wallet.publicKey), lamports(BigInt(500e9)));
   // Create connection wrapper
   const connection = createLiteSVMConnection(litesvm);
   // Create provider
@@ -422,7 +422,7 @@ function createLiteSVMConnection(litesvm: LiteSVM) {
   return {
     getAccountInfo: async (pubkey: PublicKey) => {
       const litesvm = getLiteSVM();
-      const account = litesvm.getAccount(pubkey);
+      const account = fromMaybeEncodedAccount(litesvm.getAccount(toAddress(pubkey)));
       if (!account) {
         // Synthesize native mint accounts if missing so tests can read owner
         if (pubkey.equals(NATIVE_MINT)) {
@@ -456,7 +456,7 @@ function createLiteSVMConnection(litesvm: LiteSVM) {
     getMultipleAccountsInfo: async (pubkeys: PublicKey[]) => {
       const litesvm = getLiteSVM();
       return pubkeys.map((pk) => {
-        const account = litesvm.getAccount(pk);
+        const account = fromMaybeEncodedAccount(litesvm.getAccount(toAddress(pk)));
         if (!account) {
           if (pk.equals(NATIVE_MINT)) {
             return {
@@ -502,7 +502,7 @@ function createLiteSVMConnection(litesvm: LiteSVM) {
       // Send the raw transaction bytes directly to avoid type conflicts
       // TypeScript sees incompatibility between workspace and litesvm's bundled @solana/web3.js
       // but at runtime they're compatible
-      const result = vm.sendTransaction(tx);
+      const result = vm.sendTransaction(toKitTransaction(tx));
       patchEnvironmentAfterSendTransaction();
       // Check if transaction failed
       if ("err" in result) {
@@ -560,7 +560,7 @@ function createLiteSVMConnection(litesvm: LiteSVM) {
           tx.sign(...signers);
         }
       }
-      const result = vm.sendTransaction(tx);
+      const result = vm.sendTransaction(toKitTransaction(tx));
       patchEnvironmentAfterSendTransaction();
       // Check if transaction failed
       if ("err" in result) {
@@ -660,7 +660,7 @@ function createLiteSVMConnection(litesvm: LiteSVM) {
         // LiteSVM handles serialization internally, just pass the transaction
         // TypeScript sees incompatibility between workspace and litesvm's bundled @solana/web3.js
         // but at runtime they're compatible
-        const result = vm.sendTransaction(tx);
+        const result = vm.sendTransaction(toKitTransaction(tx));
         patchEnvironmentAfterSendTransaction();
         // Check if transaction failed
         if ("err" in result) {
@@ -736,7 +736,7 @@ function createLiteSVMConnection(litesvm: LiteSVM) {
     },
     getBalance: async (pubkey: PublicKey) => {
       const litesvm = getLiteSVM();
-      const balance = litesvm.getBalance(pubkey);
+      const balance = litesvm.getBalance(toAddress(pubkey));
       return balance ? Number(balance) : 0;
     },
     getMinimumBalanceForRentExemption: async (dataLength: number) => {
@@ -744,10 +744,10 @@ function createLiteSVMConnection(litesvm: LiteSVM) {
         getLiteSVM().minimumBalanceForRentExemption(BigInt(dataLength)),
       );
     },
-    requestAirdrop: async (pubkey: PublicKey, lamports: number) => {
+    requestAirdrop: async (pubkey: PublicKey, airdropLamports: number) => {
       const litesvm = getLiteSVM();
       try {
-        const result = litesvm.airdrop(pubkey, BigInt(lamports));
+        const result = litesvm.airdrop(toAddress(pubkey), lamports(BigInt(airdropLamports)));
         // LiteSVM airdrop returns null on success or an error object on failure
         // If result is null or undefined, it's a success
         if (!result) {
@@ -774,7 +774,7 @@ function createLiteSVMConnection(litesvm: LiteSVM) {
     },
     getTokenSupply: async (mint: PublicKey) => {
       const litesvm = getLiteSVM();
-      const mintAccount = litesvm.getAccount(mint);
+      const mintAccount = fromMaybeEncodedAccount(litesvm.getAccount(toAddress(mint)));
       if (!mintAccount || mintAccount.data.length < 45) {
         throw new Error("Invalid mint account");
       }
@@ -825,7 +825,7 @@ function createLiteSVMConnection(litesvm: LiteSVM) {
     getTokenAccountBalance: async (pubkey: PublicKey) => {
       const litesvm = getLiteSVM();
       // Get the token account data
-      const account = litesvm.getAccount(pubkey);
+      const account = fromMaybeEncodedAccount(litesvm.getAccount(toAddress(pubkey)));
       if (!account || account.data.length < 72) {
         throw new Error("Invalid token account");
       }
@@ -835,7 +835,7 @@ function createLiteSVMConnection(litesvm: LiteSVM) {
       const amount = data.readBigUInt64LE(64);
       // Get the mint to determine decimals
       const mintPubkey = new PublicKey(data.slice(0, 32));
-      const mintAccount = litesvm.getAccount(mintPubkey);
+      const mintAccount = fromMaybeEncodedAccount(litesvm.getAccount(toAddress(mintPubkey)));
       let decimals = 0;
       if (mintAccount && mintAccount.data.length >= 45) {
         const mintData = Buffer.from(mintAccount.data);
@@ -1101,11 +1101,11 @@ function createLiteSVMConnection(litesvm: LiteSVM) {
  * Create funded keypair for testing
  */
 export async function createFundedKeypair(
-  lamports: number = 100e9,
+  airdropLamports: number = 100e9,
 ): Promise<Keypair> {
   const litesvm = getLiteSVM();
   const keypair = Keypair.generate();
-  litesvm.airdrop(keypair.publicKey, BigInt(lamports));
+  litesvm.airdrop(toAddress(keypair.publicKey), lamports(BigInt(airdropLamports)));
   return keypair;
 }
 
@@ -1135,13 +1135,13 @@ export function loadPreloadAccount(relativePath: string): void {
     typeof rentEpochRaw === "number" && rentEpochRaw > Number.MAX_SAFE_INTEGER
       ? 0
       : Number(rentEpochRaw);
-  litesvm.setAccount(pubkey, {
+  litesvm.setAccount(toEncodedAccount(pubkey, {
     lamports: lamportsNumber,
     data: new Uint8Array(data),
     owner: new PublicKey(account.owner),
     executable: account.executable,
     rentEpoch: rentEpochNumber,
-  });
+  }));
   console.info(`✅ Loaded preload account: ${pubkey.toBase58()}`);
 }
 
@@ -1380,13 +1380,13 @@ export async function initializeNativeMintIdempotent(provider: AnchorProvider) {
   const rentExemptLamports =
     await provider.connection.getMinimumBalanceForRentExemption(82);
   const litesvm = getLiteSVM();
-  litesvm.setAccount(NATIVE_MINT, {
+  litesvm.setAccount(toEncodedAccount(NATIVE_MINT, {
     lamports: Number(rentExemptLamports),
     data: new Uint8Array(mintData),
     owner: TEST_TOKEN_PROGRAM_ID,
     executable: false,
     rentEpoch: 0,
-  });
+  }));
 }
 
 export async function initializeLiteSVMEnvironment(programId?: PublicKey) {
@@ -1433,4 +1433,52 @@ export async function resetAndInitializeLiteSVMEnvironment(
 // This behavior is observed when Number or BN calls toString(), since toString() internally uses the remainder operator - resulting in NaN appearing in the string output.
 function patchEnvironmentAfterSendTransaction() {
   void (Number.MAX_SAFE_INTEGER % 10000000);
+}
+
+function toAddress(pubkey: PublicKey): Address {
+  return address(pubkey.toBase58());
+}
+
+function toEncodedAccount(pubkey: PublicKey, accountInfo: {
+    lamports: number,
+    data: Uint8Array,
+    owner: PublicKey,
+    executable: boolean,
+    rentEpoch: number,
+  }): EncodedAccount {
+    return {
+      address: toAddress(pubkey),
+      executable: accountInfo.executable,
+      programAddress: toAddress(accountInfo.owner),
+      lamports: lamports(BigInt(accountInfo.lamports)),
+      space: BigInt(accountInfo.data.length),
+      data: accountInfo.data,
+    };
+}
+
+function fromMaybeEncodedAccount(account: MaybeEncodedAccount): {
+    lamports: bigint,
+    data: Uint8Array,
+    owner: PublicKey,
+    executable: boolean,
+    rentEpoch: number,
+} | null {
+  if (!account.exists) {
+    return null;
+  }
+
+  return {
+    data: account.data,
+    lamports: account.lamports,
+    executable: account.executable,
+    owner: new PublicKey(account.programAddress.toString()),
+    rentEpoch: 0,
+  };  
+}
+
+function toKitTransaction(
+  tx: Transaction | VersionedTransaction,
+): KitTransaction {
+  const decoder = getTransactionDecoder();
+  return decoder.decode(tx.serialize());
 }

--- a/legacy-sdk/whirlpool/tests/utils/litesvm.ts
+++ b/legacy-sdk/whirlpool/tests/utils/litesvm.ts
@@ -8,6 +8,7 @@ import { LiteSVM, Clock, FeatureSet } from "litesvm";
 import bs58 from "bs58";
 import * as fs from "fs";
 import * as path from "path";
+import * as assert from "assert";
 import {
   NATIVE_MINT,
   NATIVE_MINT_2022,
@@ -100,11 +101,19 @@ function convertPayloadToBase64(payload: string): string | null {
 
 function normalizeLogsForAnchor(logs: string[]): string[] {
   const PROGRAM_DATA_PREFIX = "Program data:";
+  const MEMO_FIRST_LINE_PREFIX = "Program log: Memo (len";
+  let memoBodyLine = false;
   return logs.map((line) => {
     if (typeof line !== "string") return line as unknown as string;
     const trimmed = line.trim();
     // Preserve memo lines as-is
-    if (trimmed.startsWith("Program log: Memo (len")) {
+    // new Memo program generates 2 lines, the first line prints the length only.
+    // The second line contains the memo string.
+    if (trimmed.startsWith(MEMO_FIRST_LINE_PREFIX)) {
+      memoBodyLine = true;
+      return line;
+    } else if (memoBodyLine) {
+      memoBodyLine = false;
       return line;
     }
     // Helper: emit canonical Program data form understood by Anchor
@@ -1016,14 +1025,22 @@ function createLiteSVMConnection(litesvm: LiteSVM) {
       const MEMO_PROGRAM_ADDRESS = new PublicKey(
         "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr",
       );
+      let memoBodyLine = false;
       for (const log of logs) {
-        const memoMatch = log.match(/Program log: Memo \(len \d+\): "(.+)"/);
-        if (memoMatch) {
+        if (memoBodyLine) {
+          const memoBodyLineMatch = log.match(/Program log: (.+)/);
+          assert.ok(memoBodyLineMatch);
           instructions.push({
             programId: MEMO_PROGRAM_ADDRESS,
-            parsed: memoMatch[1],
+            parsed: memoBodyLineMatch[1],
           });
+
+          memoBodyLine = false;
+          continue;
         }
+
+        const memoLengthLineMatch = log.match(/Program log: Memo \(len \d+\)/); //log.match(/Program log: Memo \(len \d+\): "(.+)"/);
+        memoBodyLine = !!memoLengthLineMatch;
       }
       // If we found any memo instructions, add them as inner instructions
       if (instructions.length > 0) {

--- a/legacy-sdk/whirlpool/tests/utils/litesvm.ts
+++ b/legacy-sdk/whirlpool/tests/utils/litesvm.ts
@@ -1421,6 +1421,10 @@ export async function resetAndInitializeLiteSVMEnvironment(
   return await initializeLiteSVMEnvironment(programId);
 }
 
+export function requestAirdropLiteSVM(pubkey: PublicKey, airdropLamports: bigint) {
+  getLiteSVM().airdrop(toAddress(pubkey), lamports(airdropLamports));
+}
+
 // After calling sendTransaction, performing a remainder operation results in NaN.
 // When taking the remainder of an integer greater than or equal to 2^31, NaN occurs once - but it does not occur afterward.
 //

--- a/programs/whirlpool/src/instructions/adaptive_fee/initialize_pool_with_adaptive_fee.rs
+++ b/programs/whirlpool/src/instructions/adaptive_fee/initialize_pool_with_adaptive_fee.rs
@@ -117,7 +117,7 @@ pub fn handler(
     initialize_vault_token_account(
         whirlpool,
         &ctx.accounts.token_vault_a,
-        &ctx.accounts.token_mint_a,
+        &ctx.accounts.token_mint_a.to_account_info(),
         &ctx.accounts.funder,
         &ctx.accounts.token_program_a,
         &ctx.accounts.system_program,
@@ -125,7 +125,7 @@ pub fn handler(
     initialize_vault_token_account(
         whirlpool,
         &ctx.accounts.token_vault_b,
-        &ctx.accounts.token_mint_b,
+        &ctx.accounts.token_mint_b.to_account_info(),
         &ctx.accounts.funder,
         &ctx.accounts.token_program_b,
         &ctx.accounts.system_program,

--- a/programs/whirlpool/src/instructions/initialize_dynamic_tick_array.rs
+++ b/programs/whirlpool/src/instructions/initialize_dynamic_tick_array.rs
@@ -1,6 +1,10 @@
 use anchor_lang::{prelude::*, system_program};
 
-use crate::{state::*, util::safe_create_account, ID};
+use crate::{
+    state::*,
+    util::{get_dynamic_tick_array_minimum_rent_amount, safe_create_account},
+    ID,
+};
 
 #[derive(Accounts)]
 #[instruction(start_tick_index: i32)]
@@ -29,13 +33,13 @@ pub fn handler(
     idempotent: bool,
 ) -> Result<()> {
     if ctx.accounts.tick_array.owner == &system_program::ID {
-        let rent_exempt = Rent::get()?.minimum_balance(DynamicTickArray::MIN_LEN);
+        let rent_with_reduction_fallback_margin = get_dynamic_tick_array_minimum_rent_amount()?;
         safe_create_account(
             ctx.accounts.system_program.to_account_info(),
             ctx.accounts.funder.to_account_info(),
             ctx.accounts.tick_array.to_account_info(),
             &ID,
-            rent_exempt,
+            rent_with_reduction_fallback_margin,
             DynamicTickArray::MIN_LEN as u64,
             &[&[
                 b"tick_array",

--- a/programs/whirlpool/src/instructions/initialize_pool.rs
+++ b/programs/whirlpool/src/instructions/initialize_pool.rs
@@ -1,6 +1,6 @@
-use crate::{events::*, state::*};
+use crate::{events::*, state::*, util::initialize_vault_token_account};
 use anchor_lang::prelude::*;
-use anchor_spl::token::{self, Mint, Token, TokenAccount};
+use anchor_spl::token::{self, Mint, Token};
 
 #[derive(Accounts)]
 // now we don't use bumps, but we must list args in the same order to use tick_spacing arg.
@@ -27,17 +27,13 @@ pub struct InitializePool<'info> {
       space = Whirlpool::LEN)]
     pub whirlpool: Box<Account<'info, Whirlpool>>,
 
-    #[account(init,
-      payer = funder,
-      token::mint = token_mint_a,
-      token::authority = whirlpool)]
-    pub token_vault_a: Box<Account<'info, TokenAccount>>,
+    /// CHECK: initialized in the handler
+    #[account(mut)]
+    pub token_vault_a: Signer<'info>,
 
-    #[account(init,
-      payer = funder,
-      token::mint = token_mint_b,
-      token::authority = whirlpool)]
-    pub token_vault_b: Box<Account<'info, TokenAccount>>,
+    /// CHECK: initialized in the handler
+    #[account(mut)]
+    pub token_vault_b: Signer<'info>,
 
     #[account(has_one = whirlpools_config, constraint = fee_tier.tick_spacing == tick_spacing)]
     pub fee_tier: Account<'info, FeeTier>,
@@ -66,6 +62,23 @@ pub fn handler(
 
     // ignore the bump passed and use one Anchor derived
     let bump = ctx.bumps.whirlpool;
+
+    initialize_vault_token_account(
+        whirlpool,
+        &ctx.accounts.token_vault_a,
+        &ctx.accounts.token_mint_a.to_account_info(),
+        &ctx.accounts.funder,
+        &ctx.accounts.token_program,
+        &ctx.accounts.system_program,
+    )?;
+    initialize_vault_token_account(
+        whirlpool,
+        &ctx.accounts.token_vault_b,
+        &ctx.accounts.token_mint_b.to_account_info(),
+        &ctx.accounts.funder,
+        &ctx.accounts.token_program,
+        &ctx.accounts.system_program,
+    )?;
 
     whirlpool.initialize(
         whirlpools_config,

--- a/programs/whirlpool/src/instructions/initialize_reward.rs
+++ b/programs/whirlpool/src/instructions/initialize_reward.rs
@@ -1,7 +1,7 @@
 use anchor_lang::prelude::*;
-use anchor_spl::token::{self, Mint, Token, TokenAccount};
+use anchor_spl::token::{self, Mint, Token};
 
-use crate::state::Whirlpool;
+use crate::{state::Whirlpool, util::initialize_vault_token_account};
 
 #[derive(Accounts)]
 pub struct InitializeReward<'info> {
@@ -16,13 +16,9 @@ pub struct InitializeReward<'info> {
 
     pub reward_mint: Box<Account<'info, Mint>>,
 
-    #[account(
-        init,
-        payer = funder,
-        token::mint = reward_mint,
-        token::authority = whirlpool
-    )]
-    pub reward_vault: Box<Account<'info, TokenAccount>>,
+    /// CHECK: initialized in the handler
+    #[account(mut)]
+    pub reward_vault: Signer<'info>,
 
     #[account(address = token::ID)]
     pub token_program: Program<'info, Token>,
@@ -32,6 +28,15 @@ pub struct InitializeReward<'info> {
 
 pub fn handler(ctx: Context<InitializeReward>, reward_index: u8) -> Result<()> {
     let whirlpool = &mut ctx.accounts.whirlpool;
+
+    initialize_vault_token_account(
+        whirlpool,
+        &ctx.accounts.reward_vault,
+        &ctx.accounts.reward_mint.to_account_info(),
+        &ctx.accounts.funder,
+        &ctx.accounts.token_program,
+        &ctx.accounts.system_program,
+    )?;
 
     whirlpool.initialize_reward(
         reward_index as usize,

--- a/programs/whirlpool/src/instructions/open_bundled_position.rs
+++ b/programs/whirlpool/src/instructions/open_bundled_position.rs
@@ -4,7 +4,7 @@ use anchor_spl::token::TokenAccount;
 use crate::{
     errors::ErrorCode,
     events::*,
-    manager::tick_array_manager::collect_rent_for_ticks_in_position,
+    manager::tick_array_manager::collect_rent_for_ticks_in_position_and_reduction_fallback_margin,
     state::*,
     util::{resolve_one_sided_position_ticks, verify_position_bundle_authority},
 };
@@ -64,7 +64,7 @@ pub fn handler(
         &ctx.accounts.position_bundle_authority,
     )?;
 
-    collect_rent_for_ticks_in_position(
+    collect_rent_for_ticks_in_position_and_reduction_fallback_margin(
         &ctx.accounts.funder,
         position,
         &ctx.accounts.system_program,

--- a/programs/whirlpool/src/instructions/open_position.rs
+++ b/programs/whirlpool/src/instructions/open_position.rs
@@ -4,7 +4,7 @@ use anchor_spl::token::{self, Mint, Token, TokenAccount};
 
 use crate::errors::ErrorCode;
 use crate::events::*;
-use crate::manager::tick_array_manager::collect_rent_for_ticks_in_position;
+use crate::manager::tick_array_manager::collect_rent_for_ticks_in_position_and_reduction_fallback_margin;
 use crate::state;
 use crate::{
     state::*,
@@ -68,7 +68,7 @@ pub fn handler(
         return Err(ErrorCode::PositionWithTokenExtensionsRequired.into());
     }
 
-    collect_rent_for_ticks_in_position(
+    collect_rent_for_ticks_in_position_and_reduction_fallback_margin(
         &ctx.accounts.funder,
         position,
         &ctx.accounts.system_program,

--- a/programs/whirlpool/src/instructions/open_position_with_metadata.rs
+++ b/programs/whirlpool/src/instructions/open_position_with_metadata.rs
@@ -5,7 +5,7 @@ use anchor_spl::token::{self, Mint, Token, TokenAccount};
 
 use crate::errors::ErrorCode;
 use crate::events::*;
-use crate::manager::tick_array_manager::collect_rent_for_ticks_in_position;
+use crate::manager::tick_array_manager::collect_rent_for_ticks_in_position_and_reduction_fallback_margin;
 use crate::state;
 use crate::{
     state::*,
@@ -84,7 +84,7 @@ pub fn handler(
         return Err(ErrorCode::PositionWithTokenExtensionsRequired.into());
     }
 
-    collect_rent_for_ticks_in_position(
+    collect_rent_for_ticks_in_position_and_reduction_fallback_margin(
         &ctx.accounts.funder,
         position,
         &ctx.accounts.system_program,

--- a/programs/whirlpool/src/instructions/open_position_with_token_extensions.rs
+++ b/programs/whirlpool/src/instructions/open_position_with_token_extensions.rs
@@ -1,4 +1,4 @@
-use crate::manager::tick_array_manager::collect_rent_for_ticks_in_position;
+use crate::manager::tick_array_manager::collect_rent_for_ticks_in_position_and_reduction_fallback_margin;
 use crate::state::*;
 use crate::util::build_position_token_metadata;
 use anchor_lang::prelude::*;
@@ -69,7 +69,7 @@ pub fn handler(
         &[ctx.bumps.position],
     ];
 
-    collect_rent_for_ticks_in_position(
+    collect_rent_for_ticks_in_position_and_reduction_fallback_margin(
         &ctx.accounts.funder,
         position,
         &ctx.accounts.system_program,

--- a/programs/whirlpool/src/instructions/reset_position_range.rs
+++ b/programs/whirlpool/src/instructions/reset_position_range.rs
@@ -3,9 +3,10 @@ use anchor_spl::token_interface::TokenAccount as TokenAccountInterface;
 use solana_program::program::invoke;
 use solana_program::system_instruction;
 
-use crate::manager::tick_array_manager::get_tick_rent_amount;
 use crate::state::*;
-use crate::util::verify_position_authority_interface;
+use crate::util::{
+    get_position_minimum_rent_amount, get_tick_rent_amount, verify_position_authority_interface,
+};
 
 #[derive(Accounts)]
 pub struct ResetPositionRange<'info> {
@@ -58,11 +59,9 @@ fn ensure_position_has_enough_rent_for_ticks<'info>(
     position: &Account<'info, Position>,
     system_program: &Program<'info, System>,
 ) -> Result<()> {
-    let rent = Rent::get()?;
-
-    let position_rent_required = rent.minimum_balance(Position::LEN);
+    let position_rent_with_reduction_fallback_margin = get_position_minimum_rent_amount()?;
     let tick_required_rent = get_tick_rent_amount()? * 2;
-    let all_required_rent = position_rent_required
+    let all_required_rent = position_rent_with_reduction_fallback_margin
         .checked_add(tick_required_rent)
         .ok_or(crate::errors::ErrorCode::RentCalculationError)?;
 

--- a/programs/whirlpool/src/instructions/v2/initialize_pool.rs
+++ b/programs/whirlpool/src/instructions/v2/initialize_pool.rs
@@ -93,7 +93,7 @@ pub fn handler(
     initialize_vault_token_account(
         whirlpool,
         &ctx.accounts.token_vault_a,
-        &ctx.accounts.token_mint_a,
+        &ctx.accounts.token_mint_a.to_account_info(),
         &ctx.accounts.funder,
         &ctx.accounts.token_program_a,
         &ctx.accounts.system_program,
@@ -101,7 +101,7 @@ pub fn handler(
     initialize_vault_token_account(
         whirlpool,
         &ctx.accounts.token_vault_b,
-        &ctx.accounts.token_mint_b,
+        &ctx.accounts.token_mint_b.to_account_info(),
         &ctx.accounts.funder,
         &ctx.accounts.token_program_b,
         &ctx.accounts.system_program,

--- a/programs/whirlpool/src/instructions/v2/initialize_reward.rs
+++ b/programs/whirlpool/src/instructions/v2/initialize_reward.rs
@@ -46,7 +46,7 @@ pub fn handler(ctx: Context<InitializeRewardV2>, reward_index: u8) -> Result<()>
     initialize_vault_token_account(
         whirlpool,
         &ctx.accounts.reward_vault,
-        &ctx.accounts.reward_mint,
+        &ctx.accounts.reward_mint.to_account_info(),
         &ctx.accounts.funder,
         &ctx.accounts.reward_token_program,
         &ctx.accounts.system_program,

--- a/programs/whirlpool/src/manager/tick_array_manager.rs
+++ b/programs/whirlpool/src/manager/tick_array_manager.rs
@@ -3,7 +3,9 @@ use solana_program::{program::invoke, system_instruction};
 
 use crate::errors::ErrorCode;
 use crate::state::{DynamicTick, Position, PositionUpdate, Tick, TickUpdate};
-const TICK_INITIALIZATION_SIZE: usize =
+use crate::util::{get_position_minimum_rent_amount, get_tick_rent_amount};
+
+pub const TICK_INITIALIZATION_SIZE: usize =
     DynamicTick::INITIALIZED_LEN - DynamicTick::UNINITIALIZED_LEN;
 
 #[derive(Default, Debug, PartialEq)]
@@ -57,44 +59,6 @@ pub struct TickArrayUpdate {
     pub size_update: TickArraySizeUpdate,
 }
 
-pub fn get_tick_rent_amount() -> Result<u64> {
-    let rent = Rent::get()?;
-    match (
-        TICK_INITIALIZATION_SIZE,
-        rent.lamports_per_byte_year,
-        rent.exemption_threshold.to_bits(),
-    ) {
-        // floating point number operation is high cost, so we hardcode a precalculated value here
-        // see also: https://github.com/anza-xyz/solana-sdk/blob/5390fa973897e969c5adea858079c7de1fa67d07/rent/src/lib.rs#L55-L59
-        //           https://github.com/anza-xyz/agave/pull/7373  (SIMD-0194)
-        //           https://github.com/anza-xyz/agave/pull/10126 (SIMD-0437 Rent reduction)
-        //           https://github.com/anza-xyz/agave/pull/10127 (SIMD-0438 Rent reduction fallback)
-        //
-        // New params (after SIMD-0194 and Rent reduction (Agave 4.2))
-        // - 6960u64 = 1_000_000_000 / 100 * 365 / (1024 * 1024) * 2
-        // - 0x3f_f0_00_00_00_00_00_00u64 = 1.0f64 in u64 bits representation
-        //
-        // Why we use ..=6960u64 here:
-        // To ensure that accounts remain rent-exempt even if the rent reduction fallback to 6960 occurs, any value below 6960 is treated as 6960.
-        // This also keeps the amount of lamports transferred between Position and DynamicTickArray accounts constant,
-        // even if the fallback never occurs.
-        // If the amount is not kept constant, it may become possible to withdraw more/less lamports from a DynamicTickArray
-        // than were transferred to it during increase liquidity, or the Position account may not have enough lamports to cover the required transfer.
-        (112, ..=6960u64, 0x3f_f0_00_00_00_00_00_00u64) |
-        // Old params (before SIMD-0194)
-        // - 3480u64 = 1_000_000_000 / 100 * 365 / (1024 * 1024)
-        // - 0x40_00_00_00_00_00_00_00u64 = 2.0f64 in u64 bits representation
-        (112, 3480u64, 0x40_00_00_00_00_00_00_00u64) => Ok(779520u64),
-        _ => {
-            unreachable!(
-                "unexpected Rent configuration on the Solana network: lamports_per_byte_year={}, exemption_threshold_bits={:#018x}",
-                rent.lamports_per_byte_year,
-                rent.exemption_threshold.to_bits(),
-            );
-        }
-    }
-}
-
 pub fn calculate_modify_tick_array(
     position: &Position,
     position_update: &PositionUpdate,
@@ -146,12 +110,21 @@ pub fn calculate_modify_tick_array(
 //
 // If the TAs are not variable size, the rent for the ticks will just remain in
 // the position account, and will be refunded when the position is closed.
-pub fn collect_rent_for_ticks_in_position<'info>(
+//
+// Ensure the Position account has a sufficient amount of lamports to prevent issues caused by changes in rent.
+pub fn collect_rent_for_ticks_in_position_and_reduction_fallback_margin<'info>(
     funder: &Signer<'info>,
     position: &Account<'info, Position>,
     system_program: &Program<'info, System>,
 ) -> Result<()> {
-    let rent_amount = get_tick_rent_amount()? * 2;
+    let rent_with_reduction_fallback_margin = get_position_minimum_rent_amount()?;
+    let reduction_fallback_margin =
+        rent_with_reduction_fallback_margin.saturating_sub(position.get_lamports());
+
+    let rent_for_ticks = get_tick_rent_amount()? * 2;
+    let rent_amount = rent_for_ticks
+        .checked_add(reduction_fallback_margin)
+        .ok_or(ErrorCode::RentCalculationError)?;
 
     let position_account = position.to_account_info();
     let instruction = system_instruction::transfer(funder.key, position_account.key, rent_amount);

--- a/programs/whirlpool/src/manager/tick_array_manager.rs
+++ b/programs/whirlpool/src/manager/tick_array_manager.rs
@@ -66,14 +66,31 @@ pub fn get_tick_rent_amount() -> Result<u64> {
     ) {
         // floating point number operation is high cost, so we hardcode a precalculated value here
         // see also: https://github.com/anza-xyz/solana-sdk/blob/5390fa973897e969c5adea858079c7de1fa67d07/rent/src/lib.rs#L55-L59
+        //           https://github.com/anza-xyz/agave/pull/7373  (SIMD-0194)
+        //           https://github.com/anza-xyz/agave/pull/10126 (SIMD-0437 Rent reduction)
+        //           https://github.com/anza-xyz/agave/pull/10127 (SIMD-0438 Rent reduction fallback)
+        //
+        // New params (after SIMD-0194 and Rent reduction (Agave 4.2))
+        // - 6960u64 = 1_000_000_000 / 100 * 365 / (1024 * 1024) * 2
+        // - 0x3f_f0_00_00_00_00_00_00u64 = 1.0f64 in u64 bits representation
+        //
+        // Why we use ..=6960u64 here:
+        // To ensure that accounts remain rent-exempt even if the rent reduction fallback to 6960 occurs, any value below 6960 is treated as 6960.
+        // This also keeps the amount of lamports transferred between Position and DynamicTickArray accounts constant,
+        // even if the fallback never occurs.
+        // If the amount is not kept constant, it may become possible to withdraw more/less lamports from a DynamicTickArray
+        // than were transferred to it during increase liquidity, or the Position account may not have enough lamports to cover the required transfer.
+        (112, ..=6960u64, 0x3f_f0_00_00_00_00_00_00u64) |
+        // Old params (before SIMD-0194)
         // - 3480u64 = 1_000_000_000 / 100 * 365 / (1024 * 1024)
         // - 0x40_00_00_00_00_00_00_00u64 = 2.0f64 in u64 bits representation
-        (112, 3480u64, 0x40_00_00_00_00_00_00_00u64) => Ok(779520u64), // Solana
+        (112, 3480u64, 0x40_00_00_00_00_00_00_00u64) => Ok(779520u64),
         _ => {
-            let amount = ((TICK_INITIALIZATION_SIZE as u64 * rent.lamports_per_byte_year) as f64
-                * rent.exemption_threshold)
-                .ceil() as u64;
-            Ok(amount)
+            unreachable!(
+                "unexpected Rent configuration on the Solana network: lamports_per_byte_year={}, exemption_threshold_bits={:#018x}",
+                rent.lamports_per_byte_year,
+                rent.exemption_threshold.to_bits(),
+            );
         }
     }
 }

--- a/programs/whirlpool/src/pinocchio/ported/manager_tick_array_manager.rs
+++ b/programs/whirlpool/src/pinocchio/ported/manager_tick_array_manager.rs
@@ -1,7 +1,8 @@
 use crate::manager::tick_array_manager::{
-    get_tick_rent_amount, TickArrayRentTransfer, TickArraySizeUpdate, TickArrayUpdate,
+    TickArrayRentTransfer, TickArraySizeUpdate, TickArrayUpdate,
 };
 use crate::pinocchio::{errors::WhirlpoolErrorCode, Result};
+use crate::util::get_tick_rent_amount;
 use pinocchio::account_info::AccountInfo;
 
 pub fn pino_update_tick_array_accounts(

--- a/programs/whirlpool/src/pinocchio/ported/position.rs
+++ b/programs/whirlpool/src/pinocchio/ported/position.rs
@@ -1,23 +1,18 @@
-use crate::manager::tick_array_manager::get_tick_rent_amount;
 use crate::pinocchio::{cpi::system_transfer::SystemTransfer, errors::WhirlpoolErrorCode, Result};
-use crate::state::Position;
-use pinocchio::{
-    account_info::AccountInfo,
-    sysvars::{rent::Rent, Sysvar},
-};
+use crate::util::{get_position_minimum_rent_amount, get_tick_rent_amount};
+use pinocchio::account_info::AccountInfo;
 
 pub fn pino_ensure_position_has_enough_rent_for_ticks(
     funder_info: &AccountInfo,
     position_info: &AccountInfo,
     system_program_info: &AccountInfo,
 ) -> Result<()> {
-    let rent = Rent::get()?;
-    let position_rent_required = rent.minimum_balance(Position::LEN);
+    let position_rent_with_fallback_margin = get_position_minimum_rent_amount()?;
     let tick_rent_amount = get_tick_rent_amount()?;
     let tick_required_rent = tick_rent_amount
         .checked_mul(2)
         .ok_or(WhirlpoolErrorCode::RentCalculationError)?;
-    let all_required_rent = position_rent_required
+    let all_required_rent = position_rent_with_fallback_margin
         .checked_add(tick_required_rent)
         .ok_or(WhirlpoolErrorCode::RentCalculationError)?;
 

--- a/programs/whirlpool/src/util/mod.rs
+++ b/programs/whirlpool/src/util/mod.rs
@@ -1,4 +1,5 @@
 pub mod account;
+pub mod rent;
 pub mod shared;
 pub mod sparse_swap;
 pub mod swap_tick_sequence;
@@ -8,6 +9,7 @@ pub mod token_2022;
 pub mod v2;
 
 pub use account::*;
+pub use rent::*;
 pub use shared::*;
 pub use sparse_swap::*;
 pub use swap_tick_sequence::*;

--- a/programs/whirlpool/src/util/rent.rs
+++ b/programs/whirlpool/src/util/rent.rs
@@ -1,0 +1,95 @@
+use anchor_lang::prelude::*;
+
+fn assert_expected_rent_config() -> Result<()> {
+    let rent = Rent::get()?;
+    match (
+        rent.exemption_threshold.to_bits(),
+        rent.lamports_per_byte_year,
+    ) {
+        // floating point number operation is high cost, so we hardcode a precalculated value here
+        // see also: https://github.com/anza-xyz/solana-sdk/blob/5390fa973897e969c5adea858079c7de1fa67d07/rent/src/lib.rs#L55-L59
+        //           https://github.com/anza-xyz/agave/pull/7373  (SIMD-0194)
+        //           https://github.com/anza-xyz/agave/pull/10126 (SIMD-0437 Rent reduction)
+        //           https://github.com/anza-xyz/agave/pull/10127 (SIMD-0438 Rent reduction fallback)
+        //
+        // New params (after SIMD-0194 and Rent reduction (Agave 4.2))
+        // - 0x3f_f0_00_00_00_00_00_00u64 = 1.0f64 in u64 bits representation
+        // - 6960u64 = 1_000_000_000 / 100 * 365 / (1024 * 1024) * 2
+        //
+        // Why we use ..=6960u64 here:
+        // To ensure that accounts remain rent-exempt even if the rent reduction fallback to 6960 occurs, any value below 6960 is treated as 6960.
+        // This also keeps the amount of lamports transferred between Position and DynamicTickArray accounts constant,
+        // even if the fallback never occurs.
+        // If the amount is not kept constant, it may become possible to withdraw more/less lamports from a DynamicTickArray
+        // than were transferred to it during increase liquidity, or the Position account may not have enough lamports to cover the required transfer.
+        (0x3f_f0_00_00_00_00_00_00u64, ..=6960u64) |
+        // Old params (before SIMD-0194)
+        // - 0x40_00_00_00_00_00_00_00u64 = 2.0f64 in u64 bits representation
+        // - 3480u64 = 1_000_000_000 / 100 * 365 / (1024 * 1024)
+        (0x40_00_00_00_00_00_00_00u64, 3480u64) => { Ok(()) },
+        _ => {
+            unreachable!(
+                "unexpected Rent configuration on the Solana network: lamports_per_byte_year={}, exemption_threshold_bits={:#018x}",
+                rent.lamports_per_byte_year,
+                rent.exemption_threshold.to_bits(),
+            );
+        }
+    }
+}
+
+pub fn get_tick_rent_amount() -> Result<u64> {
+    assert_expected_rent_config()?;
+    Ok(779_520)
+}
+
+pub fn get_dynamic_tick_array_minimum_rent_amount() -> Result<u64> {
+    assert_expected_rent_config()?;
+    Ok(1_920_960)
+}
+
+pub fn get_position_minimum_rent_amount() -> Result<u64> {
+    assert_expected_rent_config()?;
+    Ok(2_394_240)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ACCOUNT_STORAGE_OVERHEAD: u64 = 128;
+    const FIXED_LAMPORTS_PER_BYTE: u64 = 6960;
+
+    #[test]
+    fn assert_tick_len() {
+        // get_tick_rent_amount depends on this assumption.
+        assert_eq!(
+            crate::manager::tick_array_manager::TICK_INITIALIZATION_SIZE,
+            112
+        );
+        assert_eq!(
+            get_tick_rent_amount().unwrap(),
+            112 * FIXED_LAMPORTS_PER_BYTE
+        );
+    }
+
+    fn assert_dynamic_tick_array_min_len() {
+        // get_dynamic_tick_array_minimum_rent_amount depends on this assumption.
+        assert_eq!(
+            crate::state::dynamic_tick_array::DynamicTickArray::MIN_LEN,
+            148
+        );
+        assert_eq!(
+            get_dynamic_tick_array_minimum_rent_amount().unwrap(),
+            (ACCOUNT_STORAGE_OVERHEAD + 148) * FIXED_LAMPORTS_PER_BYTE
+        );
+    }
+
+    fn assert_position_len() {
+        // get_position_minimum_rent_amount depends on this assumption.
+        assert_eq!(crate::state::position::Position::LEN, 216);
+        assert_eq!(
+            get_position_minimum_rent_amount().unwrap(),
+            (ACCOUNT_STORAGE_OVERHEAD + 216) * FIXED_LAMPORTS_PER_BYTE
+        );
+    }
+}

--- a/programs/whirlpool/src/util/rent.rs
+++ b/programs/whirlpool/src/util/rent.rs
@@ -52,6 +52,11 @@ pub fn get_position_minimum_rent_amount() -> Result<u64> {
     Ok(2_394_240)
 }
 
+pub fn get_native_mint_token_account_minimum_rent_amount() -> Result<u64> {
+    assert_expected_rent_config()?;
+    Ok(2_039_280)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -90,6 +95,16 @@ mod tests {
         assert_eq!(
             get_position_minimum_rent_amount().unwrap(),
             (ACCOUNT_STORAGE_OVERHEAD + 216) * FIXED_LAMPORTS_PER_BYTE
+        );
+    }
+
+    fn assert_token_account_len() {
+        use solana_program::program_pack::Pack;
+        // get_native_mint_token_account_minimum_rent_amount depends on this assumptions.
+        assert_eq!(anchor_spl::token::spl_token::state::Account::LEN, 165);
+        assert_eq!(
+            get_native_mint_token_account_minimum_rent_amount().unwrap(),
+            (ACCOUNT_STORAGE_OVERHEAD + 165) * FIXED_LAMPORTS_PER_BYTE
         );
     }
 }

--- a/programs/whirlpool/src/util/rent.rs
+++ b/programs/whirlpool/src/util/rent.rs
@@ -38,21 +38,25 @@ fn assert_expected_rent_config() -> Result<()> {
 }
 
 pub fn get_tick_rent_amount() -> Result<u64> {
+    #[cfg(target_os = "solana")]
     assert_expected_rent_config()?;
     Ok(779_520)
 }
 
 pub fn get_dynamic_tick_array_minimum_rent_amount() -> Result<u64> {
+    #[cfg(target_os = "solana")]
     assert_expected_rent_config()?;
     Ok(1_920_960)
 }
 
 pub fn get_position_minimum_rent_amount() -> Result<u64> {
+    #[cfg(target_os = "solana")]
     assert_expected_rent_config()?;
     Ok(2_394_240)
 }
 
 pub fn get_native_mint_token_account_minimum_rent_amount() -> Result<u64> {
+    #[cfg(target_os = "solana")]
     assert_expected_rent_config()?;
     Ok(2_039_280)
 }
@@ -77,6 +81,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn assert_dynamic_tick_array_min_len() {
         // get_dynamic_tick_array_minimum_rent_amount depends on this assumption.
         assert_eq!(
@@ -89,6 +94,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn assert_position_len() {
         // get_position_minimum_rent_amount depends on this assumption.
         assert_eq!(crate::state::position::Position::LEN, 216);
@@ -98,6 +104,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn assert_token_account_len() {
         use solana_program::program_pack::Pack;
         // get_native_mint_token_account_minimum_rent_amount depends on this assumptions.

--- a/programs/whirlpool/src/util/token_2022.rs
+++ b/programs/whirlpool/src/util/token_2022.rs
@@ -1,5 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_spl::associated_token::{self, AssociatedToken};
+use anchor_spl::token::spl_token;
 use anchor_spl::token_2022::spl_token_2022::extension::{
     BaseStateWithExtensions, StateWithExtensions,
 };
@@ -8,7 +9,7 @@ use anchor_spl::token_2022::spl_token_2022::{
 };
 use anchor_spl::token_2022::{get_account_data_size, GetAccountDataSize, Token2022};
 use anchor_spl::token_2022_extensions::spl_token_metadata_interface;
-use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
+use anchor_spl::token_interface::{Mint, TokenAccount};
 use solana_program::program::{invoke, invoke_signed};
 use solana_program::system_instruction::transfer;
 
@@ -16,7 +17,7 @@ use crate::constants::{
     WP_2022_METADATA_NAME_PREFIX, WP_2022_METADATA_SYMBOL, WP_2022_METADATA_URI_BASE,
 };
 use crate::state::*;
-use crate::util::safe_create_account;
+use crate::util::{get_native_mint_token_account_minimum_rent_amount, safe_create_account};
 
 pub fn initialize_position_mint_2022<'info>(
     position_mint: &Signer<'info>,
@@ -462,21 +463,21 @@ pub fn close_empty_token_account_2022<'info>(
 pub fn initialize_vault_token_account<'info>(
     whirlpool: &Account<'info, Whirlpool>,
     vault_token_account: &Signer<'info>,
-    vault_mint: &InterfaceAccount<'info, Mint>,
+    vault_mint_account_info: &AccountInfo<'info>,
     funder: &Signer<'info>,
-    token_program: &Interface<'info, TokenInterface>,
+    token_program_account_info: &AccountInfo<'info>,
     system_program: &Program<'info, System>,
 ) -> Result<()> {
-    let is_token_2022 = token_program.key() == spl_token_2022::ID;
+    let is_token_2022 = token_program_account_info.key() == spl_token_2022::ID;
 
     // The size required for extensions that are mandatory on the TokenAccount side — based on the TokenExtensions enabled on the Mint —
     // is automatically accounted for. For non-mandatory extensions, however, they must be explicitly added,
     // so we specify ImmutableOwner explicitly.
     let space = get_account_data_size(
         CpiContext::new(
-            token_program.to_account_info(),
+            token_program_account_info.clone(),
             GetAccountDataSize {
-                mint: vault_mint.to_account_info(),
+                mint: vault_mint_account_info.clone(),
             },
         ),
         // Needless to say, the program will never attempt to change the owner of the vault.
@@ -490,14 +491,20 @@ pub fn initialize_vault_token_account<'info>(
         },
     )?;
 
-    let lamports = Rent::get()?.minimum_balance(space as usize);
+    let lamports = if spl_token::native_mint::check_id(&vault_mint_account_info.key()) {
+        // Enforce the pre-Rent Reduction lamport level to prevent the lamports available as the WSOL balance from decreasing
+        // if rent increases due to the Rent Reduction Fallback.
+        get_native_mint_token_account_minimum_rent_amount()?
+    } else {
+        Rent::get()?.minimum_balance(space as usize)
+    };
 
     // create account
     safe_create_account(
         system_program.to_account_info(),
         funder.to_account_info(),
         vault_token_account.to_account_info(),
-        &token_program.key(),
+        token_program_account_info.key,
         lamports,
         space,
         &[],
@@ -507,11 +514,11 @@ pub fn initialize_vault_token_account<'info>(
         // initialize ImmutableOwner extension
         invoke(
             &spl_token_2022::instruction::initialize_immutable_owner(
-                token_program.key,
+                token_program_account_info.key,
                 vault_token_account.key,
             )?,
             &[
-                token_program.to_account_info(),
+                token_program_account_info.clone(),
                 vault_token_account.to_account_info(),
             ],
         )?;
@@ -520,15 +527,15 @@ pub fn initialize_vault_token_account<'info>(
     // initialize token account
     invoke(
         &spl_token_2022::instruction::initialize_account3(
-            token_program.key,
+            token_program_account_info.key,
             vault_token_account.key,
-            &vault_mint.key(),
+            vault_mint_account_info.key,
             &whirlpool.key(),
         )?,
         &[
-            token_program.to_account_info(),
+            token_program_account_info.clone(),
             vault_token_account.to_account_info(),
-            vault_mint.to_account_info(),
+            vault_mint_account_info.clone(),
             whirlpool.to_account_info(),
         ],
     )?;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4567,7 +4567,7 @@ __metadata:
     "@types/bn.js": "npm:~5.1.6"
     "@types/jest": "npm:^30.0.0"
     decimal.js: "npm:^10.5.0"
-    litesvm: "npm:^0.4.0"
+    litesvm: "npm:^1.3.0"
     tiny-invariant: "npm:^1.3.1"
     typescript: "npm:^5.9.3"
     vitest: "npm:^3.2.4"
@@ -4959,6 +4959,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana-program/system@npm:^0.12.0, @solana-program/system@npm:^0.12.2":
+  version: 0.12.2
+  resolution: "@solana-program/system@npm:0.12.2"
+  peerDependencies:
+    "@solana/kit": ^6.4.0
+  checksum: 10c0/cb57baf73d2b6c56ed5c43cf08839afbd37e1bbeef1df2c7af33d0d6e413db62e5bb825db749ca3ef4486a3f60195b3ae3e9298232774fea4fd5514374bff292
+  languageName: node
+  linkType: hard
+
 "@solana-program/token-2022@npm:^0.6.1":
   version: 0.6.1
   resolution: "@solana-program/token-2022@npm:0.6.1"
@@ -4966,6 +4975,17 @@ __metadata:
     "@solana/kit": ^5.0
     "@solana/sysvars": ^5.0
   checksum: 10c0/bc9af5b18df2e87c256c05dd4f575cb94767ad770753b4c6979aca81c864ba034eb9d591be9933f93e16d5b7dd6f28da4055348a6ffa93a4ab72d4bf6fe14092
+  languageName: node
+  linkType: hard
+
+"@solana-program/token@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "@solana-program/token@npm:0.14.0"
+  dependencies:
+    "@solana-program/system": "npm:^0.12.0"
+  peerDependencies:
+    "@solana/kit": ^6.5.0
+  checksum: 10c0/0b84ac5d9d9e248df928a1f9681494f58f92676d47c7aaed6ac34ba3392c760c005060162aa61c060b5169b1f206b3bb2803fc7d7c104e87d582773408a0b59f
   languageName: node
   linkType: hard
 
@@ -4994,6 +5014,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/accounts@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/accounts@npm:6.10.0"
+  dependencies:
+    "@solana/addresses": "npm:6.10.0"
+    "@solana/codecs-core": "npm:6.10.0"
+    "@solana/codecs-strings": "npm:6.10.0"
+    "@solana/errors": "npm:6.10.0"
+    "@solana/rpc-spec": "npm:6.10.0"
+    "@solana/rpc-types": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/ba28efb46aa8e83723cbe93e7e4f364f0d1b5cbc53e59529a39dcc2f9df0f57f47ce65519341b41ae7798971cd0a28e42f94f0b4b9cc6e2f4163c09865770ab5
+  languageName: node
+  linkType: hard
+
 "@solana/addresses@npm:5.0.0":
   version: 5.0.0
   resolution: "@solana/addresses@npm:5.0.0"
@@ -5009,6 +5048,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/addresses@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/addresses@npm:6.10.0"
+  dependencies:
+    "@solana/assertions": "npm:6.10.0"
+    "@solana/codecs-core": "npm:6.10.0"
+    "@solana/codecs-strings": "npm:6.10.0"
+    "@solana/errors": "npm:6.10.0"
+    "@solana/nominal-types": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/5169bb86b4d04c53c1d7cf531df59e855a5c8353e46686a18697f197ba906053bbf252beee2862f039e6abcf7dfe23345c73d8ff8311af6899125af78dc6692b
+  languageName: node
+  linkType: hard
+
 "@solana/assertions@npm:5.0.0":
   version: 5.0.0
   resolution: "@solana/assertions@npm:5.0.0"
@@ -5017,6 +5074,20 @@ __metadata:
   peerDependencies:
     typescript: ">=5.3.3"
   checksum: 10c0/29edaad9eb34efe99f4f7fad4073dc681cf01e4e7b38292af49e580068bf193a065a0ed73f509327df7c9668222a4f8ab2446c02af59b55783602442f0755d3f
+  languageName: node
+  linkType: hard
+
+"@solana/assertions@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/assertions@npm:6.10.0"
+  dependencies:
+    "@solana/errors": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/a3d27741db5424e0ef54bc788d10eac206a4fd278a19dbe0a3a34fd22c33cd8e08930af04b10cd1faa1d559230f4de2f3705518cf651f0ed568b411a3e6e44f7
   languageName: node
   linkType: hard
 
@@ -5096,6 +5167,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/codecs-core@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/codecs-core@npm:6.10.0"
+  dependencies:
+    "@solana/errors": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/eadf65a0298c3c8b170c5ab02a7963777799463c0134f06af9999c6992c3ba97988be4cbe5efbf0001397efdac960fa59ebbf3e40b721dd40e2bc1a0b9fead2c
+  languageName: node
+  linkType: hard
+
 "@solana/codecs-data-structures@npm:2.0.0-rc.1":
   version: 2.0.0-rc.1
   resolution: "@solana/codecs-data-structures@npm:2.0.0-rc.1"
@@ -5132,6 +5217,22 @@ __metadata:
   peerDependencies:
     typescript: ">=5.3.3"
   checksum: 10c0/5cd4d4843d945f212862857a885ec361b57cc4c7f813f2b6d16ae604a03621a17b90d9d7700069bfce6a121139e0902ccc04ae9771d7a3bdee60968d26642397
+  languageName: node
+  linkType: hard
+
+"@solana/codecs-data-structures@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/codecs-data-structures@npm:6.10.0"
+  dependencies:
+    "@solana/codecs-core": "npm:6.10.0"
+    "@solana/codecs-numbers": "npm:6.10.0"
+    "@solana/errors": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/523984f42fd68ad1f3f0da10ee2a8d417af99fcc804a4adb2ade082766fbfa3a5d4a3d0ef15fd521e8f8f4ca8d825e536d783a4edf5b336e4ec88a3a451c5377
   languageName: node
   linkType: hard
 
@@ -5180,6 +5281,21 @@ __metadata:
   peerDependencies:
     typescript: ">=5.3.3"
   checksum: 10c0/415d6a7df4ccb795f7ae32e794976fa906d28378b03225dcc39c21e5d25548176287fe4378525456a3e397f33e43a03ea38c62853e9ea4ed2e354b03412ac249
+  languageName: node
+  linkType: hard
+
+"@solana/codecs-numbers@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/codecs-numbers@npm:6.10.0"
+  dependencies:
+    "@solana/codecs-core": "npm:6.10.0"
+    "@solana/errors": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/9ff619b50c51d86a8b6ad39f5fe12f336b55ba45f30057b9bade94ef53c03f3b86d8eef8858d7ebb9777c559d28609e9c35fdc4d80ac6ba26614d0fef98f87fa
   languageName: node
   linkType: hard
 
@@ -5237,6 +5353,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/codecs-strings@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/codecs-strings@npm:6.10.0"
+  dependencies:
+    "@solana/codecs-core": "npm:6.10.0"
+    "@solana/codecs-numbers": "npm:6.10.0"
+    "@solana/errors": "npm:6.10.0"
+  peerDependencies:
+    fastestsmallesttextencoderdecoder: ^1.0.22
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    fastestsmallesttextencoderdecoder:
+      optional: true
+    typescript:
+      optional: true
+  checksum: 10c0/b1144f4e180c13fdd9926b085336c82fee145e6a7104d7b68eb95d7ccccbf4650b47fd2cee1f5c823cab67c989251d91c64fcaa107c8ad61f7ed192f07ab4b25
+  languageName: node
+  linkType: hard
+
 "@solana/codecs-strings@npm:^4.0.0":
   version: 4.0.0
   resolution: "@solana/codecs-strings@npm:4.0.0"
@@ -5278,6 +5413,25 @@ __metadata:
   peerDependencies:
     typescript: ">=5.3.3"
   checksum: 10c0/c7704309d715767aa2c420e7fe06949e23dfb19def0d9b7529d3460b8244ccf352d4a84e46ca2c83beb308b35635c53280f2baa46fdb0c56eb71224d7c6e0f4b
+  languageName: node
+  linkType: hard
+
+"@solana/codecs@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/codecs@npm:6.10.0"
+  dependencies:
+    "@solana/codecs-core": "npm:6.10.0"
+    "@solana/codecs-data-structures": "npm:6.10.0"
+    "@solana/codecs-numbers": "npm:6.10.0"
+    "@solana/codecs-strings": "npm:6.10.0"
+    "@solana/fixed-points": "npm:6.10.0"
+    "@solana/options": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/d92b0350dd33da2245aac5795d0ec72a076f9490803ffcdd9c9f98405f746c9ff22d19e17b3cebb21322cc63f356d84436124cfa7a7d6623eb33bd0eba6551c2
   languageName: node
   linkType: hard
 
@@ -5366,6 +5520,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/errors@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/errors@npm:6.10.0"
+  dependencies:
+    chalk: "npm:5.6.2"
+    commander: "npm:15.0.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    errors: bin/cli.mjs
+  checksum: 10c0/fe81aed0b2e026b707d24a742a941bb55d620f3d5b4a673ee1c56b700d8928e26e6ad29d462821a73b9653ca75e2bded1ee384bbfd2f1f845dd5ba52fe0b1323
+  languageName: node
+  linkType: hard
+
 "@solana/fast-stable-stringify@npm:5.0.0":
   version: 5.0.0
   resolution: "@solana/fast-stable-stringify@npm:5.0.0"
@@ -5375,12 +5546,51 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/fast-stable-stringify@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/fast-stable-stringify@npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/1a9d7bf7b6efe946866993e250b900f3a709520deb4c934c2935bc28b09ebce19e30b0a9fdad04b05fbd83f1cb81ad3f1ff03e480bdbc77dd69f01bbd5666744
+  languageName: node
+  linkType: hard
+
+"@solana/fixed-points@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/fixed-points@npm:6.10.0"
+  dependencies:
+    "@solana/codecs-core": "npm:6.10.0"
+    "@solana/errors": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/2bef959422a1bc0a8d2b27a16f76a832b38c60a5b6f8ff92e7e5628c1613b4f1b2150b7e0bb2fd3ba1dd0872ef75366c4539951af1bb5cea8d7fa27f1f5c3285
+  languageName: node
+  linkType: hard
+
 "@solana/functional@npm:5.0.0":
   version: 5.0.0
   resolution: "@solana/functional@npm:5.0.0"
   peerDependencies:
     typescript: ">=5.3.3"
   checksum: 10c0/cd2f968351f6c736629f82609d6a6359f2e69053d2877c217258640229b6178fd361aee436747f2771383952f40ab226723e8d82ea54ef6dc993d613d27b6425
+  languageName: node
+  linkType: hard
+
+"@solana/functional@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/functional@npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/ecd3a49e12a3c4afe985d8f7c37f6e0744159d89d5fba984c44b56e20a7ebdbf0ebe29731ccbb59f8d7edd73c7c8ae29570b8d05eeea9b39172158207d114a37
   languageName: node
   linkType: hard
 
@@ -5399,6 +5609,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/instruction-plans@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/instruction-plans@npm:6.10.0"
+  dependencies:
+    "@solana/errors": "npm:6.10.0"
+    "@solana/instructions": "npm:6.10.0"
+    "@solana/keys": "npm:6.10.0"
+    "@solana/promises": "npm:6.10.0"
+    "@solana/transaction-messages": "npm:6.10.0"
+    "@solana/transactions": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/0c647c018e96761bf0918ce9674c31f8df98b8b90ee56d8a3bb800e183ee5419a467f89a58cd910815fb21924bfc2b94b319fe85bb84350f9a13a5d1062c82c6
+  languageName: node
+  linkType: hard
+
 "@solana/instructions@npm:5.0.0":
   version: 5.0.0
   resolution: "@solana/instructions@npm:5.0.0"
@@ -5408,6 +5637,21 @@ __metadata:
   peerDependencies:
     typescript: ">=5.3.3"
   checksum: 10c0/bd86a47f9b77267d6c45cdfe1be1d8d206a2c39a52ecd99830dc9f4bf9b9e96930cb81acdc715aefac772c80223c0327853a64f9c543882c23d3f3deb67158e0
+  languageName: node
+  linkType: hard
+
+"@solana/instructions@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/instructions@npm:6.10.0"
+  dependencies:
+    "@solana/codecs-core": "npm:6.10.0"
+    "@solana/errors": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/2e87a599778c9e0c96517020192af0e7a3fb291c1c0e07743d2dbe4bd44521de01009af37591dcc3a145859386164f71d3d78ba3d558c685de9eeb97339c4967
   languageName: node
   linkType: hard
 
@@ -5423,6 +5667,25 @@ __metadata:
   peerDependencies:
     typescript: ">=5.3.3"
   checksum: 10c0/71573a7717f42ae140d4be811734f7a134d1699e700354c8283e1ef250dd193b8ef766563a1d87c1d7312df5e9f76244288824fad8e42642b503a04d1ee0134d
+  languageName: node
+  linkType: hard
+
+"@solana/keys@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/keys@npm:6.10.0"
+  dependencies:
+    "@solana/assertions": "npm:6.10.0"
+    "@solana/codecs-core": "npm:6.10.0"
+    "@solana/codecs-strings": "npm:6.10.0"
+    "@solana/errors": "npm:6.10.0"
+    "@solana/nominal-types": "npm:6.10.0"
+    "@solana/promises": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/d8ddd66d5ac6c3b07167c25f8ca204fbe90e51456a78e20942a3ff9321d160e1776f564c663e88bcfb58746a55cac13354c6d7d66cb02acf0ab161eb33f72b0a
   languageName: node
   linkType: hard
 
@@ -5455,12 +5718,83 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/kit@npm:^6.10.0":
+  version: 6.10.0
+  resolution: "@solana/kit@npm:6.10.0"
+  dependencies:
+    "@solana/accounts": "npm:6.10.0"
+    "@solana/addresses": "npm:6.10.0"
+    "@solana/codecs": "npm:6.10.0"
+    "@solana/errors": "npm:6.10.0"
+    "@solana/functional": "npm:6.10.0"
+    "@solana/instruction-plans": "npm:6.10.0"
+    "@solana/instructions": "npm:6.10.0"
+    "@solana/keys": "npm:6.10.0"
+    "@solana/offchain-messages": "npm:6.10.0"
+    "@solana/plugin-core": "npm:6.10.0"
+    "@solana/plugin-interfaces": "npm:6.10.0"
+    "@solana/program-client-core": "npm:6.10.0"
+    "@solana/programs": "npm:6.10.0"
+    "@solana/rpc": "npm:6.10.0"
+    "@solana/rpc-api": "npm:6.10.0"
+    "@solana/rpc-parsed-types": "npm:6.10.0"
+    "@solana/rpc-spec-types": "npm:6.10.0"
+    "@solana/rpc-subscriptions": "npm:6.10.0"
+    "@solana/rpc-types": "npm:6.10.0"
+    "@solana/signers": "npm:6.10.0"
+    "@solana/subscribable": "npm:6.10.0"
+    "@solana/sysvars": "npm:6.10.0"
+    "@solana/transaction-confirmation": "npm:6.10.0"
+    "@solana/transaction-messages": "npm:6.10.0"
+    "@solana/transactions": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/234f81edb07910d56ebf8962e6a8bdff2814be84567b007687794e53df80b61fb21614bf87145abd6223e28eae1a270df1d302bfe4230cae42413cab06b32222
+  languageName: node
+  linkType: hard
+
 "@solana/nominal-types@npm:5.0.0":
   version: 5.0.0
   resolution: "@solana/nominal-types@npm:5.0.0"
   peerDependencies:
     typescript: ">=5.3.3"
   checksum: 10c0/b4207d547f1b9dc39d784dff7336ca04fbb84a9a202da3ab81eab83dcda14e4bc0166d9857f0e75ea94eef6872a5cddd33998e39c18f4b376e8ce0883a1b0f34
+  languageName: node
+  linkType: hard
+
+"@solana/nominal-types@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/nominal-types@npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/b7d50e18278e5b4529778b0d8f350f2cd83fee63e16731b41d1727a9990450656c57628361ccac64d9f091f3ead7070cd886d411d6824494a6899e525a655cc1
+  languageName: node
+  linkType: hard
+
+"@solana/offchain-messages@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/offchain-messages@npm:6.10.0"
+  dependencies:
+    "@solana/addresses": "npm:6.10.0"
+    "@solana/codecs-core": "npm:6.10.0"
+    "@solana/codecs-data-structures": "npm:6.10.0"
+    "@solana/codecs-numbers": "npm:6.10.0"
+    "@solana/codecs-strings": "npm:6.10.0"
+    "@solana/errors": "npm:6.10.0"
+    "@solana/keys": "npm:6.10.0"
+    "@solana/nominal-types": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/ec24fe2e072da23f3ebe4b8bb293a8f6cd4f8e4d51153096723322ce4100d39748c073beca7a0444d0199a4f8989158f9c25ff6c75d9433c9a6f55e4975334fb
   languageName: node
   linkType: hard
 
@@ -5509,6 +5843,78 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/options@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/options@npm:6.10.0"
+  dependencies:
+    "@solana/codecs-core": "npm:6.10.0"
+    "@solana/codecs-data-structures": "npm:6.10.0"
+    "@solana/codecs-numbers": "npm:6.10.0"
+    "@solana/codecs-strings": "npm:6.10.0"
+    "@solana/errors": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/4f750bbabee7e8a073d5c8697dc29d81672f1e08a272c5e8b22b53244de5a2dffb384205777c964fd080caf3be2cc8230f20a5cd8c4ef8587daff7c54033642f
+  languageName: node
+  linkType: hard
+
+"@solana/plugin-core@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/plugin-core@npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/f8295296702146f952ba466d7eadc12440855a33955c2a07b2e54e12de8af1a345b9b46fcbb100554947fb19bad21adfb3f1d2c1271ea19aaf75d47d009f6ec8
+  languageName: node
+  linkType: hard
+
+"@solana/plugin-interfaces@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/plugin-interfaces@npm:6.10.0"
+  dependencies:
+    "@solana/addresses": "npm:6.10.0"
+    "@solana/instruction-plans": "npm:6.10.0"
+    "@solana/keys": "npm:6.10.0"
+    "@solana/rpc-spec": "npm:6.10.0"
+    "@solana/rpc-subscriptions-spec": "npm:6.10.0"
+    "@solana/rpc-types": "npm:6.10.0"
+    "@solana/signers": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/844485f3f65e1297d8813a03e7f3007536f34b88bf2de01fd37ddf51ac0f944a184da00b168ac611a95987e1d9cc895789fc11fc858a7b9e8ed32a832e4cf65b
+  languageName: node
+  linkType: hard
+
+"@solana/program-client-core@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/program-client-core@npm:6.10.0"
+  dependencies:
+    "@solana/accounts": "npm:6.10.0"
+    "@solana/addresses": "npm:6.10.0"
+    "@solana/codecs-core": "npm:6.10.0"
+    "@solana/errors": "npm:6.10.0"
+    "@solana/instruction-plans": "npm:6.10.0"
+    "@solana/instructions": "npm:6.10.0"
+    "@solana/plugin-interfaces": "npm:6.10.0"
+    "@solana/rpc-api": "npm:6.10.0"
+    "@solana/signers": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/839ef123431999e7ed83930bcf22329072bdfe9692a0e1126b36c159a6fbb8f3c3db2e4a3d3867dd3d62ef0e4515c18c64af3b88b9828421866dc5568e525e52
+  languageName: node
+  linkType: hard
+
 "@solana/programs@npm:5.0.0":
   version: 5.0.0
   resolution: "@solana/programs@npm:5.0.0"
@@ -5521,12 +5927,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/programs@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/programs@npm:6.10.0"
+  dependencies:
+    "@solana/addresses": "npm:6.10.0"
+    "@solana/errors": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/2cc2f0df31d908ed338f810a8d5c775566db9a45fc7537574a517518b52665aa61849479344ab0739e27037a4516925b427ab3fbdccf057d516bfcd8e58e99c7
+  languageName: node
+  linkType: hard
+
 "@solana/promises@npm:5.0.0":
   version: 5.0.0
   resolution: "@solana/promises@npm:5.0.0"
   peerDependencies:
     typescript: ">=5.3.3"
   checksum: 10c0/815c7e461ea6b0e12c1496e8bfd4c8be2356447e0dbbf3e2f719ae1ec584dc282d9c3e9a5a9503db18f243e222fb1563485e38025ae8c17cbb4652b1f6c8254e
+  languageName: node
+  linkType: hard
+
+"@solana/promises@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/promises@npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/72448b0cd2b0dbf91a5c01f69e305eb00d99e17c253a6e1cd3b7d4fef4a709a6760a69d3e256c2ae980bbf31b3d4e2e6a1efdb55b96c83d1a2addf7ef3eb9e33
   languageName: node
   linkType: hard
 
@@ -5573,12 +6006,48 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/rpc-api@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/rpc-api@npm:6.10.0"
+  dependencies:
+    "@solana/addresses": "npm:6.10.0"
+    "@solana/codecs-core": "npm:6.10.0"
+    "@solana/codecs-strings": "npm:6.10.0"
+    "@solana/errors": "npm:6.10.0"
+    "@solana/keys": "npm:6.10.0"
+    "@solana/rpc-parsed-types": "npm:6.10.0"
+    "@solana/rpc-spec": "npm:6.10.0"
+    "@solana/rpc-transformers": "npm:6.10.0"
+    "@solana/rpc-types": "npm:6.10.0"
+    "@solana/transaction-messages": "npm:6.10.0"
+    "@solana/transactions": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/b702b518862930e2636ab98dbb1a87627b1f21d99ebdb021e109e7e1a35fb91d510a2ec094ce3d0be9d1950ddbb276fe86596c8f19c35e9d0cb0b28e176ff480
+  languageName: node
+  linkType: hard
+
 "@solana/rpc-parsed-types@npm:5.0.0":
   version: 5.0.0
   resolution: "@solana/rpc-parsed-types@npm:5.0.0"
   peerDependencies:
     typescript: ">=5.3.3"
   checksum: 10c0/308a31a7090e1823a77e21e10af05959890381cbc4cc5361ac2a65394e477b8975f8fa349311dc2f6eb445d1d299b0bdd79763bd9970d9d793b11070c6d5ed9a
+  languageName: node
+  linkType: hard
+
+"@solana/rpc-parsed-types@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/rpc-parsed-types@npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/6754307ab2adcefc4f57941bd85362cdd2411484fdcdf902f4048423b7e38282436da3c7dd4a5786d1d81849420831c841b71c6b8b5cbc0f051d347c9c1bc69e
   languageName: node
   linkType: hard
 
@@ -5591,6 +6060,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/rpc-spec-types@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/rpc-spec-types@npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/5e4c0d0ad8f9d30b48426f11ca12e5321e3bc6643adb5486d3848729af307f2072017430034ee0cf46d57b3732bb0b0e0ceac5bfbb911a83bb0e89badb4ca0e0
+  languageName: node
+  linkType: hard
+
 "@solana/rpc-spec@npm:5.0.0":
   version: 5.0.0
   resolution: "@solana/rpc-spec@npm:5.0.0"
@@ -5600,6 +6081,22 @@ __metadata:
   peerDependencies:
     typescript: ">=5.3.3"
   checksum: 10c0/7a0062b7d150403101a522528dd7b5c27fb2b1e035e9bc8e282e80e730c701a7704bf43356353b6ed58d4e3a9a1af2955e617d3c69f8dac96e306625d7d35e4b
+  languageName: node
+  linkType: hard
+
+"@solana/rpc-spec@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/rpc-spec@npm:6.10.0"
+  dependencies:
+    "@solana/errors": "npm:6.10.0"
+    "@solana/rpc-spec-types": "npm:6.10.0"
+    "@solana/subscribable": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/75d35548b788e3b392f8dca0a641b7ee9341f82c40490023be6567bc6065a44bf536817e6809a262b55d87347b44c6161946289ee35fa3e3894e6bf3f3b57eb8
   languageName: node
   linkType: hard
 
@@ -5620,6 +6117,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/rpc-subscriptions-api@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/rpc-subscriptions-api@npm:6.10.0"
+  dependencies:
+    "@solana/addresses": "npm:6.10.0"
+    "@solana/keys": "npm:6.10.0"
+    "@solana/rpc-subscriptions-spec": "npm:6.10.0"
+    "@solana/rpc-transformers": "npm:6.10.0"
+    "@solana/rpc-types": "npm:6.10.0"
+    "@solana/transaction-messages": "npm:6.10.0"
+    "@solana/transactions": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/ab88865b50fb4fd6545fc7220e7bd91efa4bb71d06e7c279d4540f1e2d52185d018708bb46b8054ba4ef937791e3686de1487dc24d9e194812df9b8b6464c1d1
+  languageName: node
+  linkType: hard
+
 "@solana/rpc-subscriptions-channel-websocket@npm:5.0.0":
   version: 5.0.0
   resolution: "@solana/rpc-subscriptions-channel-websocket@npm:5.0.0"
@@ -5635,6 +6152,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/rpc-subscriptions-channel-websocket@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/rpc-subscriptions-channel-websocket@npm:6.10.0"
+  dependencies:
+    "@solana/errors": "npm:6.10.0"
+    "@solana/functional": "npm:6.10.0"
+    "@solana/rpc-subscriptions-spec": "npm:6.10.0"
+    "@solana/subscribable": "npm:6.10.0"
+    ws: "npm:^8.21.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/e455b432d3b09a07c501eb35d582f5f5cd86761d781581fe2ddff350ca07ff1721e06908fdcfbf63721b62478978d3da465b0049d212ccd33519d496fc66f7c1
+  languageName: node
+  linkType: hard
+
 "@solana/rpc-subscriptions-spec@npm:5.0.0":
   version: 5.0.0
   resolution: "@solana/rpc-subscriptions-spec@npm:5.0.0"
@@ -5646,6 +6181,23 @@ __metadata:
   peerDependencies:
     typescript: ">=5.3.3"
   checksum: 10c0/16a4e867287020ead68c10b0467087fca33233f887c1bf90ab9dce40173d53e52dda33e68df59d99a4b9cde2e84ecc3f4dca6bf4be3073e89488523beff5e4bf
+  languageName: node
+  linkType: hard
+
+"@solana/rpc-subscriptions-spec@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/rpc-subscriptions-spec@npm:6.10.0"
+  dependencies:
+    "@solana/errors": "npm:6.10.0"
+    "@solana/promises": "npm:6.10.0"
+    "@solana/rpc-spec-types": "npm:6.10.0"
+    "@solana/subscribable": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/023d0b9bbc6a74df22a2d931ea9770bd3df941ddb876a947977b4433430ef9796a5999f9856b5f1a4705aa08dfdcc2f11957533de90b54bdbe263d32d49cb5ff
   languageName: node
   linkType: hard
 
@@ -5670,6 +6222,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/rpc-subscriptions@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/rpc-subscriptions@npm:6.10.0"
+  dependencies:
+    "@solana/errors": "npm:6.10.0"
+    "@solana/fast-stable-stringify": "npm:6.10.0"
+    "@solana/functional": "npm:6.10.0"
+    "@solana/promises": "npm:6.10.0"
+    "@solana/rpc-spec-types": "npm:6.10.0"
+    "@solana/rpc-subscriptions-api": "npm:6.10.0"
+    "@solana/rpc-subscriptions-channel-websocket": "npm:6.10.0"
+    "@solana/rpc-subscriptions-spec": "npm:6.10.0"
+    "@solana/rpc-transformers": "npm:6.10.0"
+    "@solana/rpc-types": "npm:6.10.0"
+    "@solana/subscribable": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/bc30ef8e9ae1d60df94a6312a98c3337a136e9638ed08dd865a359e9d3573d565d3c570d0445313dc5d3a541b26230d525cd041e8a03481c1f2360aef289d150
+  languageName: node
+  linkType: hard
+
 "@solana/rpc-transformers@npm:5.0.0":
   version: 5.0.0
   resolution: "@solana/rpc-transformers@npm:5.0.0"
@@ -5682,6 +6258,24 @@ __metadata:
   peerDependencies:
     typescript: ">=5.3.3"
   checksum: 10c0/96bc23db97dbc44283d31c84f1269b0c884745f9018a8823738770584f502933a1cfb50be094b5dd55bf0f391efbeed2ff557397c57976d31ec9ce2e2cf99c22
+  languageName: node
+  linkType: hard
+
+"@solana/rpc-transformers@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/rpc-transformers@npm:6.10.0"
+  dependencies:
+    "@solana/errors": "npm:6.10.0"
+    "@solana/functional": "npm:6.10.0"
+    "@solana/nominal-types": "npm:6.10.0"
+    "@solana/rpc-spec-types": "npm:6.10.0"
+    "@solana/rpc-types": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/c8ca9dd2a77fd9936247070b9cf26b686d06fd6ce5b2351c00e318aae0fdc4d6edf64cab952bf060709dc34aa278587ece7939c2412f3f5da6244bce4398e6fa
   languageName: node
   linkType: hard
 
@@ -5699,6 +6293,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/rpc-transport-http@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/rpc-transport-http@npm:6.10.0"
+  dependencies:
+    "@solana/errors": "npm:6.10.0"
+    "@solana/rpc-spec": "npm:6.10.0"
+    "@solana/rpc-spec-types": "npm:6.10.0"
+    undici-types: "npm:^8.4.1"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/807fb49b90dc2df7fc57899e071bc9b8c34c2acb73bf5f4712597bc0def1be5cbd222495548927b4ad47682883e62f3ff77e4dae9d0937f8b70a543240fce53a
+  languageName: node
+  linkType: hard
+
 "@solana/rpc-types@npm:5.0.0":
   version: 5.0.0
   resolution: "@solana/rpc-types@npm:5.0.0"
@@ -5712,6 +6323,26 @@ __metadata:
   peerDependencies:
     typescript: ">=5.3.3"
   checksum: 10c0/e084989eea4ca2042bd75625447db2d1cd2ee3227fead45a2977c160113c3e2461d38aeff9fa8180a00551f9045d9e9f824fd6a5df325f899c807699a6340f62
+  languageName: node
+  linkType: hard
+
+"@solana/rpc-types@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/rpc-types@npm:6.10.0"
+  dependencies:
+    "@solana/addresses": "npm:6.10.0"
+    "@solana/codecs-core": "npm:6.10.0"
+    "@solana/codecs-numbers": "npm:6.10.0"
+    "@solana/codecs-strings": "npm:6.10.0"
+    "@solana/errors": "npm:6.10.0"
+    "@solana/fixed-points": "npm:6.10.0"
+    "@solana/nominal-types": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/7e9b83ec6b8ff8d026e854bb24892c279969fedacd8254fc2af7bc333ca7733d6ca2eba6bcc3a5b1b1bf81c9bee38c83964f74bbf3a2a70b553d18c0ac396e38
   languageName: node
   linkType: hard
 
@@ -5734,6 +6365,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/rpc@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/rpc@npm:6.10.0"
+  dependencies:
+    "@solana/errors": "npm:6.10.0"
+    "@solana/fast-stable-stringify": "npm:6.10.0"
+    "@solana/functional": "npm:6.10.0"
+    "@solana/rpc-api": "npm:6.10.0"
+    "@solana/rpc-spec": "npm:6.10.0"
+    "@solana/rpc-spec-types": "npm:6.10.0"
+    "@solana/rpc-transformers": "npm:6.10.0"
+    "@solana/rpc-transport-http": "npm:6.10.0"
+    "@solana/rpc-types": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/ace737874897d497a26156aeeeb86c4b146c4f96bb74b81a7bfd1044ef1560e075d7e3b9dbf9cd5d99b6b4805d80bc00f65d043ae15567689db8c44c052f6909
+  languageName: node
+  linkType: hard
+
 "@solana/signers@npm:5.0.0":
   version: 5.0.0
   resolution: "@solana/signers@npm:5.0.0"
@@ -5749,6 +6402,28 @@ __metadata:
   peerDependencies:
     typescript: ">=5.3.3"
   checksum: 10c0/cc399975b9878064f13d98396c0bec7106b115e8abf474c613805e93eeab6c6693cdd9ccb1ef592ef39a41ee3475aad9d0df443a771adbd4e2b7f8012f7287c8
+  languageName: node
+  linkType: hard
+
+"@solana/signers@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/signers@npm:6.10.0"
+  dependencies:
+    "@solana/addresses": "npm:6.10.0"
+    "@solana/codecs-core": "npm:6.10.0"
+    "@solana/errors": "npm:6.10.0"
+    "@solana/instructions": "npm:6.10.0"
+    "@solana/keys": "npm:6.10.0"
+    "@solana/nominal-types": "npm:6.10.0"
+    "@solana/offchain-messages": "npm:6.10.0"
+    "@solana/transaction-messages": "npm:6.10.0"
+    "@solana/transactions": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/50b5b604daeb35999d3d0b498f2800cd1cc39aff219acfb692e7c504734d97200f428b81d625921939a89575343eb851bb84877757bdff7316010252ad7a5d17
   languageName: node
   linkType: hard
 
@@ -5800,6 +6475,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/subscribable@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/subscribable@npm:6.10.0"
+  dependencies:
+    "@solana/errors": "npm:6.10.0"
+    "@solana/promises": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/d5c32559c9877fa546bf976eb6c497fac5df5bcf172472df39087795763a976eebce85ee20de81765095949076a89a4247a3d51d1a366cb444a256bacd123dac
+  languageName: node
+  linkType: hard
+
 "@solana/sysvars@npm:5.0.0, @solana/sysvars@npm:^5.0.0":
   version: 5.0.0
   resolution: "@solana/sysvars@npm:5.0.0"
@@ -5811,6 +6501,25 @@ __metadata:
   peerDependencies:
     typescript: ">=5.3.3"
   checksum: 10c0/259625c59e5caa1d68c032cd8822828fa2d83076874b40406e4242a5fce2663ed196642dbf7f6b7d858dbba3a7dab9106b7993415e9bf56c563e3519baf0dc7f
+  languageName: node
+  linkType: hard
+
+"@solana/sysvars@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/sysvars@npm:6.10.0"
+  dependencies:
+    "@solana/accounts": "npm:6.10.0"
+    "@solana/codecs-core": "npm:6.10.0"
+    "@solana/codecs-data-structures": "npm:6.10.0"
+    "@solana/codecs-numbers": "npm:6.10.0"
+    "@solana/errors": "npm:6.10.0"
+    "@solana/rpc-types": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/100b8bd114645ca5c2ad1c8172014c907362720d096e323bd47afb945905fe648bb1115faea91c0c14f8f44d538e38b26fc185373431659c257ad26f12cc9545
   languageName: node
   linkType: hard
 
@@ -5834,6 +6543,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/transaction-confirmation@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/transaction-confirmation@npm:6.10.0"
+  dependencies:
+    "@solana/addresses": "npm:6.10.0"
+    "@solana/codecs-strings": "npm:6.10.0"
+    "@solana/errors": "npm:6.10.0"
+    "@solana/keys": "npm:6.10.0"
+    "@solana/promises": "npm:6.10.0"
+    "@solana/rpc": "npm:6.10.0"
+    "@solana/rpc-subscriptions": "npm:6.10.0"
+    "@solana/rpc-types": "npm:6.10.0"
+    "@solana/transaction-messages": "npm:6.10.0"
+    "@solana/transactions": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/c0353afe2ca1a25e1e0850cfc5e07356c7b0b70852c46fd2c6f9adf6f6243fff96918e42207b616b57fda805353601d39fd13d2730478fa03b587bd4fc1a5daa
+  languageName: node
+  linkType: hard
+
 "@solana/transaction-messages@npm:5.0.0":
   version: 5.0.0
   resolution: "@solana/transaction-messages@npm:5.0.0"
@@ -5850,6 +6582,28 @@ __metadata:
   peerDependencies:
     typescript: ">=5.3.3"
   checksum: 10c0/68898a59c118fa4660154de50006a93028d0ca8f85864ec43225d556e96db668d0128aa735fc4f2bb1b372e66b7277ed8465cf9840e48e8e113c96d04232bd3b
+  languageName: node
+  linkType: hard
+
+"@solana/transaction-messages@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/transaction-messages@npm:6.10.0"
+  dependencies:
+    "@solana/addresses": "npm:6.10.0"
+    "@solana/codecs-core": "npm:6.10.0"
+    "@solana/codecs-data-structures": "npm:6.10.0"
+    "@solana/codecs-numbers": "npm:6.10.0"
+    "@solana/errors": "npm:6.10.0"
+    "@solana/functional": "npm:6.10.0"
+    "@solana/instructions": "npm:6.10.0"
+    "@solana/nominal-types": "npm:6.10.0"
+    "@solana/rpc-types": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/00937463f1f7681a3e77462f223380d053959362b5c9afa35d9a3ce27934e3e318d349a0594793174db13c9fef6d268826300a438d7a295c2db905791e77e016
   languageName: node
   linkType: hard
 
@@ -5872,6 +6626,31 @@ __metadata:
   peerDependencies:
     typescript: ">=5.3.3"
   checksum: 10c0/c02e89e4fd1657fefb46db6a6678aeed326a182d136a621d1cc9afa2c68161012ce256848133b1b0b4e101829593e25ad9183080e00e362144bde423640016a7
+  languageName: node
+  linkType: hard
+
+"@solana/transactions@npm:6.10.0":
+  version: 6.10.0
+  resolution: "@solana/transactions@npm:6.10.0"
+  dependencies:
+    "@solana/addresses": "npm:6.10.0"
+    "@solana/codecs-core": "npm:6.10.0"
+    "@solana/codecs-data-structures": "npm:6.10.0"
+    "@solana/codecs-numbers": "npm:6.10.0"
+    "@solana/codecs-strings": "npm:6.10.0"
+    "@solana/errors": "npm:6.10.0"
+    "@solana/functional": "npm:6.10.0"
+    "@solana/instructions": "npm:6.10.0"
+    "@solana/keys": "npm:6.10.0"
+    "@solana/nominal-types": "npm:6.10.0"
+    "@solana/rpc-types": "npm:6.10.0"
+    "@solana/transaction-messages": "npm:6.10.0"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/a2e406cb155e491f5c619fe9a7c08851647c29bdcbfde37b828cfeea6b1939dfae1259af0d7a4ec0139d3db1dc30fed94b8d9d18d6ae7a8adc861e2d6796360a
   languageName: node
   linkType: hard
 
@@ -8550,6 +9329,13 @@ __metadata:
   version: 14.0.1
   resolution: "commander@npm:14.0.1"
   checksum: 10c0/64439c0651ddd01c1d0f48c8f08e97c18a0a1fa693879451f1203ad01132af2c2aa85da24cf0d8e098ab9e6dc385a756be670d2999a3c628ec745c3ec124587b
+  languageName: node
+  linkType: hard
+
+"commander@npm:15.0.0":
+  version: 15.0.0
+  resolution: "commander@npm:15.0.0"
+  checksum: 10c0/539229c171914ea1ccd45ee5f10d924289a12a684ea3a7a44147abe54003c35ed6de9ae4ad198d88c29fdf403dca0428451a388234e6dc01b6faa978fb207206
   languageName: node
   linkType: hard
 
@@ -12564,9 +13350,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"litesvm-darwin-arm64@npm:1.3.0":
+  version: 1.3.0
+  resolution: "litesvm-darwin-arm64@npm:1.3.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "litesvm-darwin-x64@npm:0.4.0":
   version: 0.4.0
   resolution: "litesvm-darwin-x64@npm:0.4.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"litesvm-darwin-x64@npm:1.3.0":
+  version: 1.3.0
+  resolution: "litesvm-darwin-x64@npm:1.3.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -12578,9 +13378,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"litesvm-linux-arm64-gnu@npm:1.3.0":
+  version: 1.3.0
+  resolution: "litesvm-linux-arm64-gnu@npm:1.3.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "litesvm-linux-arm64-musl@npm:0.4.0":
   version: 0.4.0
   resolution: "litesvm-linux-arm64-musl@npm:0.4.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"litesvm-linux-arm64-musl@npm:1.3.0":
+  version: 1.3.0
+  resolution: "litesvm-linux-arm64-musl@npm:1.3.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
@@ -12592,9 +13406,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"litesvm-linux-x64-gnu@npm:1.3.0":
+  version: 1.3.0
+  resolution: "litesvm-linux-x64-gnu@npm:1.3.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "litesvm-linux-x64-musl@npm:0.4.0":
   version: 0.4.0
   resolution: "litesvm-linux-x64-musl@npm:0.4.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"litesvm-linux-x64-musl@npm:1.3.0":
+  version: 1.3.0
+  resolution: "litesvm-linux-x64-musl@npm:1.3.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
@@ -12625,6 +13453,36 @@ __metadata:
     litesvm-linux-x64-musl:
       optional: true
   checksum: 10c0/81fd19bf2fb65cd21877717e46139fb0eed70aabbb7779c1da16e5365c02fbef13292197b7680bc8ccb2b90cfcf1c338a517b869ffd7231eb6b75adf8251205b
+  languageName: node
+  linkType: hard
+
+"litesvm@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "litesvm@npm:1.3.0"
+  dependencies:
+    "@solana-program/system": "npm:^0.12.2"
+    "@solana-program/token": "npm:^0.14.0"
+    "@solana/kit": "npm:^6.10.0"
+    litesvm-darwin-arm64: "npm:1.3.0"
+    litesvm-darwin-x64: "npm:1.3.0"
+    litesvm-linux-arm64-gnu: "npm:1.3.0"
+    litesvm-linux-arm64-musl: "npm:1.3.0"
+    litesvm-linux-x64-gnu: "npm:1.3.0"
+    litesvm-linux-x64-musl: "npm:1.3.0"
+  dependenciesMeta:
+    litesvm-darwin-arm64:
+      optional: true
+    litesvm-darwin-x64:
+      optional: true
+    litesvm-linux-arm64-gnu:
+      optional: true
+    litesvm-linux-arm64-musl:
+      optional: true
+    litesvm-linux-x64-gnu:
+      optional: true
+    litesvm-linux-x64-musl:
+      optional: true
+  checksum: 10c0/eef75560eb47b960aa40a14ecb4fde6f23315f8087a275c2636da97e7a6dac0363d9da32b03218074e8770385701e0efe6fcfb70260b8ed3cfe983fafa73a1ae
   languageName: node
   linkType: hard
 
@@ -18597,6 +19455,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:^8.4.1":
+  version: 8.10.0
+  resolution: "undici-types@npm:8.10.0"
+  checksum: 10c0/beed5d37590eb750245e25430400e0bbb30f7fc31bc405e3211826eac6f99c9d2c1b957fe56fd096292ed0253526f7cde2dd4cfb29fa31e8f0dafcb00f5c3091
+  languageName: node
+  linkType: hard
+
 "undici-types@npm:~8.3.0":
   version: 8.3.0
   resolution: "undici-types@npm:8.3.0"
@@ -19488,6 +20353,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10c0/eac918213de265ef7cb3d4ca348b891a51a520d839aa51cdb8ca93d4fa7ff9f6ccb339ccee89e4075324097f0a55157c89fa3f7147bde9d8d7e90335dc087b53
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.21.0":
+  version: 8.21.2
+  resolution: "ws@npm:8.21.2"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/82d687bbfbccce04e91266ff9911b27c67ca622fd8fbacc6a64d467a43fbd7ecaa3ef6d820b315c060682f901463f57cac01a02b00c4379f49c747ec7da83169
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The following behavior can cause issues during the phased Rent reduction or if a fallback to lamports_per_byte = 6960 occurs:

- DynamicTickArray is variable-length.
- Position transfers lamports to and from DynamicTickArray.

To address this, we add the following safeguards:

- Fix the amount of Rent reserved for one tick to the current amount.
- When initializing DynamicTickArray and Position accounts, always reserve Rent based on the current amount.

Note: The size of a Position account does not change, but when it sends lamports to a DynamicTickArray and its balance decreases, its rent-exempt status is re-evaluated using the latest Rent parameters. As long as the Position account itself was funded assuming lamports_per_byte = 6960, it will remain safe even if that re-evaluation occurs.

### References:
- [Agave v4.2 updates](https://www.helius.dev/blog/agave-v4-2)
- [SIMD-0437 Rent reduction](https://github.com/anza-xyz/agave/pull/10126)
- [SIMD-0438 Rent reduction fallback](https://github.com/anza-xyz/agave/pull/10127)
- [SIMD-0392 Rent increase adaptions](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0392-rent-increase-adaptations.md)
- [SIMD-0194 Deprecate Rent exemption threshold](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0194-deprecate-rent-exemption-threshold.md)