### PR TITLE
docs: fix calculateMinimumBalanceForRentExemption JSDoc

### DIFF
--- a/ts-sdk/whirlpool/src/sysvar.ts
+++ b/ts-sdk/whirlpool/src/sysvar.ts
@@ -8,7 +8,7 @@ const ACCOUNT_STORAGE_OVERHEAD = 128;
 /**
  * Calculates the minimum balance required for rent exemption for a given account size.
  *
- * @param {Rpc} rpc - The Solana RPC client to fetch sysvar rent data.
+ * @param {SysvarRent} rent - The sysvar rent parameters used to compute the exemption.
  * @param {number} dataSize - The size of the account data in bytes.
  * @returns {bigint} The minimum balance required for rent exemption in lamports.
  */


### PR DESCRIPTION
## Summary
- Corrects JSDoc on `calculateMinimumBalanceForRentExemption`: the first argument is `SysvarRent`, not `Rpc`, and the helper does not fetch rent over RPC.
- Tests in `ts-sdk/whirlpool/tests/sysvar.test.ts` already pass a rent object.

Fixes https://github.com/orca-so/whirlpools/issues/1370

## Test plan
- [x] Existing `ts-sdk/whirlpool/tests/sysvar.test.ts` coverage still matches the function signature
- [ ] Review the JSDoc against `ts-sdk/whirlpool/src/sysvar.ts`


