### PR TITLE
ts-sdk: attach TransferHook remaining accounts on V2 swap/liquidity/harvest

### DIFF
--- a/.changeset/ts-sdk-transfer-hook-remaining-accounts.md
+++ b/.changeset/ts-sdk-transfer-hook-remaining-accounts.md
@@ -1,0 +1,5 @@
+---
+"@orca-so/whirlpools": patch
+---
+
+Attach Token-2022 TransferHook remaining accounts on V2 swap, liquidity, and harvest instructions.

--- a/ts-sdk/whirlpool/src/decreaseLiquidity.ts
+++ b/ts-sdk/whirlpool/src/decreaseLiquidity.ts
@@ -3,6 +3,7 @@ import type {
   WhirlpoolDeployment,
 } from "@orca-so/whirlpools-client";
 import {
+  AccountsType,
   DEFAULT_WHIRLPOOL_DEPLOYMENT,
   fetchAllTickArray,
   fetchPosition,
@@ -58,8 +59,12 @@ import {
 import { MEMO_PROGRAM_ADDRESS } from "@solana-program/memo";
 import assert from "assert";
 import { executeWithCallback } from "./actionHelpers";
+import {
+  appendExtraAccounts,
+  buildRemainingAccounts,
+} from "./remainingAccounts";
+import { getExtraAccountMetasForTransferHook } from "./transferHook";
 // TODO: allow specify number as well as bigint
-// TODO: transfer hook
 
 /**
  * Represents the parameters for decreasing liquidity.
@@ -260,32 +265,59 @@ export async function decreaseLiquidityInstructions(
 
   instructions.push(...createInstructions);
 
-  instructions.push(
-    getDecreaseLiquidityV2Instruction(
-      {
-        whirlpool: whirlpool.address,
-        positionAuthority: authority,
-        position: position.address,
-        positionTokenAccount,
-        tokenOwnerAccountA: tokenAccountAddresses[whirlpool.data.tokenMintA],
-        tokenOwnerAccountB: tokenAccountAddresses[whirlpool.data.tokenMintB],
-        tokenVaultA: whirlpool.data.tokenVaultA,
-        tokenVaultB: whirlpool.data.tokenVaultB,
-        tokenMintA: whirlpool.data.tokenMintA,
-        tokenMintB: whirlpool.data.tokenMintB,
-        tokenProgramA: mintA.programAddress,
-        tokenProgramB: mintB.programAddress,
-        memoProgram: MEMO_PROGRAM_ADDRESS,
-        tickArrayLower,
-        tickArrayUpper,
-        liquidityAmount: quote.liquidityDelta,
-        tokenMinA: quote.tokenMinA,
-        tokenMinB: quote.tokenMinB,
-        remainingAccountsInfo: null,
-      },
-      { programAddress: whirlpoolDeployment.programId },
+  const [transferHookAccountsA, transferHookAccountsB] = await Promise.all([
+    getExtraAccountMetasForTransferHook(
+      rpc,
+      mintA,
+      whirlpool.data.tokenVaultA,
+      tokenAccountAddresses[whirlpool.data.tokenMintA],
+      whirlpool.address,
     ),
+    getExtraAccountMetasForTransferHook(
+      rpc,
+      mintB,
+      whirlpool.data.tokenVaultB,
+      tokenAccountAddresses[whirlpool.data.tokenMintB],
+      whirlpool.address,
+    ),
+  ]);
+  const decreaseRemaining = buildRemainingAccounts([
+    {
+      accountsType: AccountsType.TransferHookA,
+      accounts: transferHookAccountsA,
+    },
+    {
+      accountsType: AccountsType.TransferHookB,
+      accounts: transferHookAccountsB,
+    },
+  ]);
+
+  const decreaseInstruction = getDecreaseLiquidityV2Instruction(
+    {
+      whirlpool: whirlpool.address,
+      positionAuthority: authority,
+      position: position.address,
+      positionTokenAccount,
+      tokenOwnerAccountA: tokenAccountAddresses[whirlpool.data.tokenMintA],
+      tokenOwnerAccountB: tokenAccountAddresses[whirlpool.data.tokenMintB],
+      tokenVaultA: whirlpool.data.tokenVaultA,
+      tokenVaultB: whirlpool.data.tokenVaultB,
+      tokenMintA: whirlpool.data.tokenMintA,
+      tokenMintB: whirlpool.data.tokenMintB,
+      tokenProgramA: mintA.programAddress,
+      tokenProgramB: mintB.programAddress,
+      memoProgram: MEMO_PROGRAM_ADDRESS,
+      tickArrayLower,
+      tickArrayUpper,
+      liquidityAmount: quote.liquidityDelta,
+      tokenMinA: quote.tokenMinA,
+      tokenMinB: quote.tokenMinB,
+      remainingAccountsInfo: decreaseRemaining.remainingAccountsInfo,
+    },
+    { programAddress: whirlpoolDeployment.programId },
   );
+  appendExtraAccounts(decreaseInstruction, decreaseRemaining.extraAccounts);
+  instructions.push(decreaseInstruction);
 
   instructions.push(...cleanupInstructions);
 
@@ -503,57 +535,89 @@ export async function closePositionInstructions(
   const instructions: Instruction[] = [];
   instructions.push(...createInstructions);
 
-  if (quote.liquidityDelta > 0n) {
-    instructions.push(
-      getDecreaseLiquidityV2Instruction(
-        {
-          whirlpool: whirlpool.address,
-          positionAuthority: authority,
-          position: positionAddress[0],
-          positionTokenAccount,
-          tokenOwnerAccountA: tokenAccountAddresses[whirlpool.data.tokenMintA],
-          tokenOwnerAccountB: tokenAccountAddresses[whirlpool.data.tokenMintB],
-          tokenVaultA: whirlpool.data.tokenVaultA,
-          tokenVaultB: whirlpool.data.tokenVaultB,
-          tickArrayLower: lowerTickArrayAddress,
-          tickArrayUpper: upperTickArrayAddress,
-          liquidityAmount: quote.liquidityDelta,
-          tokenMinA: quote.tokenMinA,
-          tokenMinB: quote.tokenMinB,
-          tokenMintA: whirlpool.data.tokenMintA,
-          tokenMintB: whirlpool.data.tokenMintB,
-          tokenProgramA: mintA.programAddress,
-          tokenProgramB: mintB.programAddress,
-          memoProgram: MEMO_PROGRAM_ADDRESS,
-          remainingAccountsInfo: null,
-        },
-        { programAddress: whirlpoolDeployment.programId },
+  const needsPoolTransfers =
+    quote.liquidityDelta > 0n ||
+    feesQuote.feeOwedA > 0n ||
+    feesQuote.feeOwedB > 0n;
+
+  let closePoolRemaining = buildRemainingAccounts([]);
+  if (needsPoolTransfers) {
+    const [closeHookA, closeHookB] = await Promise.all([
+      getExtraAccountMetasForTransferHook(
+        rpc,
+        mintA,
+        whirlpool.data.tokenVaultA,
+        tokenAccountAddresses[whirlpool.data.tokenMintA],
+        whirlpool.address,
       ),
+      getExtraAccountMetasForTransferHook(
+        rpc,
+        mintB,
+        whirlpool.data.tokenVaultB,
+        tokenAccountAddresses[whirlpool.data.tokenMintB],
+        whirlpool.address,
+      ),
+    ]);
+    closePoolRemaining = buildRemainingAccounts([
+      { accountsType: AccountsType.TransferHookA, accounts: closeHookA },
+      { accountsType: AccountsType.TransferHookB, accounts: closeHookB },
+    ]);
+  }
+
+  if (quote.liquidityDelta > 0n) {
+    const decreaseInstruction = getDecreaseLiquidityV2Instruction(
+      {
+        whirlpool: whirlpool.address,
+        positionAuthority: authority,
+        position: positionAddress[0],
+        positionTokenAccount,
+        tokenOwnerAccountA: tokenAccountAddresses[whirlpool.data.tokenMintA],
+        tokenOwnerAccountB: tokenAccountAddresses[whirlpool.data.tokenMintB],
+        tokenVaultA: whirlpool.data.tokenVaultA,
+        tokenVaultB: whirlpool.data.tokenVaultB,
+        tickArrayLower: lowerTickArrayAddress,
+        tickArrayUpper: upperTickArrayAddress,
+        liquidityAmount: quote.liquidityDelta,
+        tokenMinA: quote.tokenMinA,
+        tokenMinB: quote.tokenMinB,
+        tokenMintA: whirlpool.data.tokenMintA,
+        tokenMintB: whirlpool.data.tokenMintB,
+        tokenProgramA: mintA.programAddress,
+        tokenProgramB: mintB.programAddress,
+        memoProgram: MEMO_PROGRAM_ADDRESS,
+        remainingAccountsInfo: closePoolRemaining.remainingAccountsInfo,
+      },
+      { programAddress: whirlpoolDeployment.programId },
     );
+    appendExtraAccounts(decreaseInstruction, closePoolRemaining.extraAccounts);
+    instructions.push(decreaseInstruction);
   }
 
   if (feesQuote.feeOwedA > 0n || feesQuote.feeOwedB > 0n) {
-    instructions.push(
-      getCollectFeesV2Instruction(
-        {
-          whirlpool: whirlpool.address,
-          positionAuthority: authority,
-          position: positionAddress[0],
-          positionTokenAccount,
-          tokenOwnerAccountA: tokenAccountAddresses[whirlpool.data.tokenMintA],
-          tokenOwnerAccountB: tokenAccountAddresses[whirlpool.data.tokenMintB],
-          tokenVaultA: whirlpool.data.tokenVaultA,
-          tokenVaultB: whirlpool.data.tokenVaultB,
-          tokenMintA: whirlpool.data.tokenMintA,
-          tokenMintB: whirlpool.data.tokenMintB,
-          tokenProgramA: mintA.programAddress,
-          tokenProgramB: mintB.programAddress,
-          memoProgram: MEMO_PROGRAM_ADDRESS,
-          remainingAccountsInfo: null,
-        },
-        { programAddress: whirlpoolDeployment.programId },
-      ),
+    const collectFeesInstruction = getCollectFeesV2Instruction(
+      {
+        whirlpool: whirlpool.address,
+        positionAuthority: authority,
+        position: positionAddress[0],
+        positionTokenAccount,
+        tokenOwnerAccountA: tokenAccountAddresses[whirlpool.data.tokenMintA],
+        tokenOwnerAccountB: tokenAccountAddresses[whirlpool.data.tokenMintB],
+        tokenVaultA: whirlpool.data.tokenVaultA,
+        tokenVaultB: whirlpool.data.tokenVaultB,
+        tokenMintA: whirlpool.data.tokenMintA,
+        tokenMintB: whirlpool.data.tokenMintB,
+        tokenProgramA: mintA.programAddress,
+        tokenProgramB: mintB.programAddress,
+        memoProgram: MEMO_PROGRAM_ADDRESS,
+        remainingAccountsInfo: closePoolRemaining.remainingAccountsInfo,
+      },
+      { programAddress: whirlpoolDeployment.programId },
     );
+    appendExtraAccounts(
+      collectFeesInstruction,
+      closePoolRemaining.extraAccounts,
+    );
+    instructions.push(collectFeesInstruction);
   }
 
   for (let i = 0; i < rewardsQuote.rewards.length; i++) {
@@ -562,24 +626,40 @@ export async function closePositionInstructions(
     }
     const rewardMint = rewardMints[i];
     assert(rewardMint.exists, `Reward mint ${i} not found`);
-    instructions.push(
-      getCollectRewardV2Instruction(
-        {
-          whirlpool: whirlpool.address,
-          positionAuthority: authority,
-          position: positionAddress[0],
-          positionTokenAccount,
-          rewardOwnerAccount: tokenAccountAddresses[rewardMint.address],
-          rewardVault: whirlpool.data.rewardInfos[i].vault,
-          rewardIndex: i,
-          rewardMint: rewardMint.address,
-          rewardTokenProgram: rewardMint.programAddress,
-          memoProgram: MEMO_PROGRAM_ADDRESS,
-          remainingAccountsInfo: null,
-        },
-        { programAddress: whirlpoolDeployment.programId },
-      ),
+    const rewardHook = await getExtraAccountMetasForTransferHook(
+      rpc,
+      rewardMint,
+      whirlpool.data.rewardInfos[i].vault,
+      tokenAccountAddresses[rewardMint.address],
+      whirlpool.address,
     );
+    const rewardRemaining = buildRemainingAccounts([
+      {
+        accountsType: AccountsType.TransferHookReward,
+        accounts: rewardHook,
+      },
+    ]);
+    const collectRewardInstruction = getCollectRewardV2Instruction(
+      {
+        whirlpool: whirlpool.address,
+        positionAuthority: authority,
+        position: positionAddress[0],
+        positionTokenAccount,
+        rewardOwnerAccount: tokenAccountAddresses[rewardMint.address],
+        rewardVault: whirlpool.data.rewardInfos[i].vault,
+        rewardIndex: i,
+        rewardMint: rewardMint.address,
+        rewardTokenProgram: rewardMint.programAddress,
+        memoProgram: MEMO_PROGRAM_ADDRESS,
+        remainingAccountsInfo: rewardRemaining.remainingAccountsInfo,
+      },
+      { programAddress: whirlpoolDeployment.programId },
+    );
+    appendExtraAccounts(
+      collectRewardInstruction,
+      rewardRemaining.extraAccounts,
+    );
+    instructions.push(collectRewardInstruction);
   }
 
   switch (positionMint.programAddress) {

--- a/ts-sdk/whirlpool/src/harvest.ts
+++ b/ts-sdk/whirlpool/src/harvest.ts
@@ -23,6 +23,7 @@ import { DEFAULT_ADDRESS, FUNDER, getPayer, getRpcConfig } from "./config";
 import type { WhirlpoolDeployment } from "@orca-so/whirlpools-client";
 import {
   DEFAULT_WHIRLPOOL_DEPLOYMENT,
+  AccountsType,
   fetchAllTickArray,
   fetchPosition,
   fetchWhirlpool,
@@ -51,8 +52,11 @@ import {
   type HydratedPosition,
   type PositionData,
 } from "./position";
-
-// TODO: Transfer hook
+import {
+  appendExtraAccounts,
+  buildRemainingAccounts,
+} from "./remainingAccounts";
+import { getExtraAccountMetasForTransferHook } from "./transferHook";
 
 /** Represents the instructions and quotes for harvesting a position. */
 export type HarvestPositionInstructions = {
@@ -253,27 +257,47 @@ export async function harvestPositionInstructions(
   }
 
   if (feesQuote.feeOwedA > 0n || feesQuote.feeOwedB > 0n) {
-    instructions.push(
-      getCollectFeesV2Instruction(
-        {
-          whirlpool: whirlpool.address,
-          positionAuthority: authority,
-          position: positionAddress[0],
-          positionTokenAccount,
-          tokenOwnerAccountA: tokenAccountAddresses[whirlpool.data.tokenMintA],
-          tokenOwnerAccountB: tokenAccountAddresses[whirlpool.data.tokenMintB],
-          tokenVaultA: whirlpool.data.tokenVaultA,
-          tokenVaultB: whirlpool.data.tokenVaultB,
-          tokenMintA: whirlpool.data.tokenMintA,
-          tokenMintB: whirlpool.data.tokenMintB,
-          tokenProgramA: mintA.programAddress,
-          tokenProgramB: mintB.programAddress,
-          memoProgram: MEMO_PROGRAM_ADDRESS,
-          remainingAccountsInfo: null,
-        },
-        { programAddress: whirlpoolDeployment.programId },
+    const [hookA, hookB] = await Promise.all([
+      getExtraAccountMetasForTransferHook(
+        rpc,
+        mintA,
+        whirlpool.data.tokenVaultA,
+        tokenAccountAddresses[whirlpool.data.tokenMintA],
+        whirlpool.address,
       ),
+      getExtraAccountMetasForTransferHook(
+        rpc,
+        mintB,
+        whirlpool.data.tokenVaultB,
+        tokenAccountAddresses[whirlpool.data.tokenMintB],
+        whirlpool.address,
+      ),
+    ]);
+    const feesRemaining = buildRemainingAccounts([
+      { accountsType: AccountsType.TransferHookA, accounts: hookA },
+      { accountsType: AccountsType.TransferHookB, accounts: hookB },
+    ]);
+    const collectFeesInstruction = getCollectFeesV2Instruction(
+      {
+        whirlpool: whirlpool.address,
+        positionAuthority: authority,
+        position: positionAddress[0],
+        positionTokenAccount,
+        tokenOwnerAccountA: tokenAccountAddresses[whirlpool.data.tokenMintA],
+        tokenOwnerAccountB: tokenAccountAddresses[whirlpool.data.tokenMintB],
+        tokenVaultA: whirlpool.data.tokenVaultA,
+        tokenVaultB: whirlpool.data.tokenVaultB,
+        tokenMintA: whirlpool.data.tokenMintA,
+        tokenMintB: whirlpool.data.tokenMintB,
+        tokenProgramA: mintA.programAddress,
+        tokenProgramB: mintB.programAddress,
+        memoProgram: MEMO_PROGRAM_ADDRESS,
+        remainingAccountsInfo: feesRemaining.remainingAccountsInfo,
+      },
+      { programAddress: whirlpoolDeployment.programId },
     );
+    appendExtraAccounts(collectFeesInstruction, feesRemaining.extraAccounts);
+    instructions.push(collectFeesInstruction);
   }
 
   for (let i = 0; i < rewardsQuote.rewards.length; i++) {
@@ -282,24 +306,40 @@ export async function harvestPositionInstructions(
     }
     const rewardMint = rewardMints[i];
     assert(rewardMint.exists, `Reward mint ${i} not found`);
-    instructions.push(
-      getCollectRewardV2Instruction(
-        {
-          whirlpool: whirlpool.address,
-          positionAuthority: authority,
-          position: positionAddress[0],
-          positionTokenAccount,
-          rewardOwnerAccount: tokenAccountAddresses[rewardMint.address],
-          rewardVault: whirlpool.data.rewardInfos[i].vault,
-          rewardIndex: i,
-          rewardMint: rewardMint.address,
-          rewardTokenProgram: rewardMint.programAddress,
-          memoProgram: MEMO_PROGRAM_ADDRESS,
-          remainingAccountsInfo: null,
-        },
-        { programAddress: whirlpoolDeployment.programId },
-      ),
+    const rewardHook = await getExtraAccountMetasForTransferHook(
+      rpc,
+      rewardMint,
+      whirlpool.data.rewardInfos[i].vault,
+      tokenAccountAddresses[rewardMint.address],
+      whirlpool.address,
     );
+    const rewardRemaining = buildRemainingAccounts([
+      {
+        accountsType: AccountsType.TransferHookReward,
+        accounts: rewardHook,
+      },
+    ]);
+    const collectRewardInstruction = getCollectRewardV2Instruction(
+      {
+        whirlpool: whirlpool.address,
+        positionAuthority: authority,
+        position: positionAddress[0],
+        positionTokenAccount,
+        rewardOwnerAccount: tokenAccountAddresses[rewardMint.address],
+        rewardVault: whirlpool.data.rewardInfos[i].vault,
+        rewardIndex: i,
+        rewardMint: rewardMint.address,
+        rewardTokenProgram: rewardMint.programAddress,
+        memoProgram: MEMO_PROGRAM_ADDRESS,
+        remainingAccountsInfo: rewardRemaining.remainingAccountsInfo,
+      },
+      { programAddress: whirlpoolDeployment.programId },
+    );
+    appendExtraAccounts(
+      collectRewardInstruction,
+      rewardRemaining.extraAccounts,
+    );
+    instructions.push(collectRewardInstruction);
   }
 
   instructions.push(...cleanupInstructions);

--- a/ts-sdk/whirlpool/src/increaseLiquidity.ts
+++ b/ts-sdk/whirlpool/src/increaseLiquidity.ts
@@ -3,6 +3,7 @@ import type {
   WhirlpoolDeployment,
 } from "@orca-so/whirlpools-client";
 import {
+  AccountsType,
   DEFAULT_WHIRLPOOL_DEPLOYMENT,
   fetchAllMaybeTickArray,
   fetchPosition,
@@ -56,9 +57,13 @@ import assert from "assert";
 import { calculateMinimumBalanceForRentExemption } from "./sysvar";
 import { executeWithCallback } from "./actionHelpers";
 import { getSqrtPriceSlippageBounds } from "@orca-so/whirlpools-core";
+import {
+  appendExtraAccounts,
+  buildRemainingAccounts,
+} from "./remainingAccounts";
+import { getExtraAccountMetasForTransferHook } from "./transferHook";
 
 // TODO: allow specify number as well as bigint
-// TODO: transfer hook
 
 /** RPC client for increase-liquidity operations. Requires: GetAccountInfoApi, GetMultipleAccountsApi, GetMinimumBalanceForRentExemptionApi */
 type IncreaseLiquidityRpc = Rpc<
@@ -125,6 +130,33 @@ async function getIncreaseLiquidityInstructions(
     [tokenMintB]: tokenMaxB,
   });
 
+  const [transferHookAccountsA, transferHookAccountsB] = await Promise.all([
+    getExtraAccountMetasForTransferHook(
+      rpc,
+      mintA,
+      tokenAccountAddresses[tokenMintA],
+      tokenVaults.tokenVaultA,
+      authority.address,
+    ),
+    getExtraAccountMetasForTransferHook(
+      rpc,
+      mintB,
+      tokenAccountAddresses[tokenMintB],
+      tokenVaults.tokenVaultB,
+      authority.address,
+    ),
+  ]);
+  const { remainingAccountsInfo, extraAccounts } = buildRemainingAccounts([
+    {
+      accountsType: AccountsType.TransferHookA,
+      accounts: transferHookAccountsA,
+    },
+    {
+      accountsType: AccountsType.TransferHookB,
+      accounts: transferHookAccountsB,
+    },
+  ]);
+
   const commonInstructionParams = {
     whirlpool: whirlpoolAddress,
     positionAuthority: authority,
@@ -135,7 +167,7 @@ async function getIncreaseLiquidityInstructions(
     tokenProgramA: mintA.programAddress,
     tokenProgramB: mintB.programAddress,
     memoProgram: MEMO_PROGRAM_ADDRESS,
-    remainingAccountsInfo: null,
+    remainingAccountsInfo,
     ...tokenVaults,
     ...rest,
   };
@@ -158,6 +190,8 @@ async function getIncreaseLiquidityInstructions(
       },
       { programAddress },
     );
+
+  appendExtraAccounts(increaseLiquidityInstruction, extraAccounts);
 
   return {
     createTokenAccountInstructions,

--- a/ts-sdk/whirlpool/src/remainingAccounts.ts
+++ b/ts-sdk/whirlpool/src/remainingAccounts.ts
@@ -1,0 +1,58 @@
+import type { AccountsType } from "@orca-so/whirlpools-client";
+import type { Address } from "@solana/kit";
+import type { AccountRole } from "@solana/kit";
+
+export type RemainingAccount = {
+  address: Address;
+  role: AccountRole;
+};
+
+export type RemainingAccountsSliceInput = {
+  accountsType: AccountsType;
+  accounts?: RemainingAccount[];
+};
+
+/**
+ * Builds remaining-account slices for V2 instructions.
+ * Empty slices are omitted (same as the legacy SDK RemainingAccountsBuilder).
+ */
+export function buildRemainingAccounts(slices: RemainingAccountsSliceInput[]): {
+  remainingAccountsInfo: {
+    slices: { accountsType: AccountsType; length: number }[];
+  } | null;
+  extraAccounts: RemainingAccount[];
+} {
+  const infoSlices: { accountsType: AccountsType; length: number }[] = [];
+  const extraAccounts: RemainingAccount[] = [];
+
+  for (const slice of slices) {
+    if (!slice.accounts || slice.accounts.length === 0) {
+      continue;
+    }
+    infoSlices.push({
+      accountsType: slice.accountsType,
+      length: slice.accounts.length,
+    });
+    extraAccounts.push(...slice.accounts);
+  }
+
+  return {
+    remainingAccountsInfo:
+      infoSlices.length === 0 ? null : { slices: infoSlices },
+    extraAccounts,
+  };
+}
+
+export function appendExtraAccounts(
+  instruction: { accounts?: RemainingAccount[] | readonly RemainingAccount[] },
+  extraAccounts: RemainingAccount[],
+): void {
+  if (extraAccounts.length === 0) {
+    return;
+  }
+  const accounts = instruction.accounts;
+  if (!accounts) {
+    throw new Error("instruction has no accounts");
+  }
+  (accounts as RemainingAccount[]).push(...extraAccounts);
+}

--- a/ts-sdk/whirlpool/src/swap.ts
+++ b/ts-sdk/whirlpool/src/swap.ts
@@ -45,9 +45,13 @@ import {
 import { MEMO_PROGRAM_ADDRESS } from "@solana-program/memo";
 import { fetchAllMint } from "@solana-program/token-2022";
 import { executeWithCallback } from "./actionHelpers";
+import {
+  appendExtraAccounts,
+  buildRemainingAccounts,
+} from "./remainingAccounts";
+import { getExtraAccountMetasForTransferHook } from "./transferHook";
 
 // TODO: allow specify number as well as bigint
-// TODO: transfer hook
 
 /**
  * Parameters for an exact input swap.
@@ -346,6 +350,43 @@ export async function swapInstructions<T extends SwapParams>(
   const otherAmountThreshold =
     "tokenMaxIn" in quote ? quote.tokenMaxIn : quote.tokenMinOut;
 
+  const ownerAccountA = tokenAccountAddresses[whirlpool.data.tokenMintA];
+  const ownerAccountB = tokenAccountAddresses[whirlpool.data.tokenMintB];
+  const [transferHookAccountsA, transferHookAccountsB] = await Promise.all([
+    getExtraAccountMetasForTransferHook(
+      rpc,
+      tokenA,
+      aToB ? ownerAccountA : whirlpool.data.tokenVaultA,
+      aToB ? whirlpool.data.tokenVaultA : ownerAccountA,
+      aToB ? signer.address : whirlpool.address,
+    ),
+    getExtraAccountMetasForTransferHook(
+      rpc,
+      tokenB,
+      aToB ? whirlpool.data.tokenVaultB : ownerAccountB,
+      aToB ? ownerAccountB : whirlpool.data.tokenVaultB,
+      aToB ? whirlpool.address : signer.address,
+    ),
+  ]);
+
+  const { remainingAccountsInfo, extraAccounts } = buildRemainingAccounts([
+    {
+      accountsType: AccountsType.TransferHookA,
+      accounts: transferHookAccountsA,
+    },
+    {
+      accountsType: AccountsType.TransferHookB,
+      accounts: transferHookAccountsB,
+    },
+    {
+      accountsType: AccountsType.SupplementalTickArrays,
+      accounts: [
+        { address: tickArrays[3].address, role: AccountRole.WRITABLE },
+        { address: tickArrays[4].address, role: AccountRole.WRITABLE },
+      ],
+    },
+  ]);
+
   const swapInstruction = getSwapV2Instruction(
     {
       tokenProgramA: tokenA.programAddress,
@@ -355,8 +396,8 @@ export async function swapInstructions<T extends SwapParams>(
       whirlpool: whirlpool.address,
       tokenMintA: whirlpool.data.tokenMintA,
       tokenMintB: whirlpool.data.tokenMintB,
-      tokenOwnerAccountA: tokenAccountAddresses[whirlpool.data.tokenMintA],
-      tokenOwnerAccountB: tokenAccountAddresses[whirlpool.data.tokenMintB],
+      tokenOwnerAccountA: ownerAccountA,
+      tokenOwnerAccountB: ownerAccountB,
       tokenVaultA: whirlpool.data.tokenVaultA,
       tokenVaultB: whirlpool.data.tokenVaultB,
       tickArray0: tickArrays[0].address,
@@ -368,19 +409,12 @@ export async function swapInstructions<T extends SwapParams>(
       amountSpecifiedIsInput: specifiedInput,
       aToB,
       oracle: oracleAddress,
-      remainingAccountsInfo: {
-        slices: [
-          { accountsType: AccountsType.SupplementalTickArrays, length: 2 },
-        ],
-      },
+      remainingAccountsInfo,
     },
     { programAddress: whirlpoolDeployment.programId },
   );
 
-  swapInstruction.accounts.push(
-    { address: tickArrays[3].address, role: AccountRole.WRITABLE },
-    { address: tickArrays[4].address, role: AccountRole.WRITABLE },
-  );
+  appendExtraAccounts(swapInstruction, extraAccounts);
 
   instructions.push(swapInstruction);
   instructions.push(...cleanupInstructions);

--- a/ts-sdk/whirlpool/src/transferHook.ts
+++ b/ts-sdk/whirlpool/src/transferHook.ts
@@ -1,0 +1,370 @@
+import type { Mint } from "@solana-program/token-2022";
+import type { Address, GetAccountInfoApi, Rpc } from "@solana/kit";
+import {
+  AccountRole,
+  fetchEncodedAccount,
+  getAddressDecoder,
+  getAddressEncoder,
+  getProgramDerivedAddress,
+} from "@solana/kit";
+import { DEFAULT_ADDRESS } from "./config";
+import type { RemainingAccount } from "./remainingAccounts";
+
+const EXTRA_ACCOUNT_METAS_SEED = "extra-account-metas";
+const EXECUTE_DISCRIMINATOR = new Uint8Array([
+  105, 37, 101, 197, 75, 251, 102, 26,
+]);
+const EXTRA_ACCOUNT_META_SPAN = 35;
+
+function roleFromFlags(isSigner: boolean, isWritable: boolean): AccountRole {
+  if (isSigner && isWritable) {
+    return AccountRole.WRITABLE_SIGNER;
+  }
+  if (isSigner) {
+    return AccountRole.READONLY_SIGNER;
+  }
+  if (isWritable) {
+    return AccountRole.WRITABLE;
+  }
+  return AccountRole.READONLY;
+}
+
+function flagsFromRole(role: AccountRole): {
+  isSigner: boolean;
+  isWritable: boolean;
+} {
+  return {
+    isSigner:
+      role === AccountRole.READONLY_SIGNER ||
+      role === AccountRole.WRITABLE_SIGNER,
+    isWritable:
+      role === AccountRole.WRITABLE || role === AccountRole.WRITABLE_SIGNER,
+  };
+}
+
+function deEscalateAccountMeta(
+  accountMeta: RemainingAccount,
+  accountMetas: RemainingAccount[],
+): RemainingAccount {
+  const maybeHighestPrivileges = accountMetas
+    .filter((x) => x.address === accountMeta.address)
+    .reduce<{ isSigner: boolean; isWritable: boolean } | undefined>(
+      (acc, x) => {
+        const flags = flagsFromRole(x.role);
+        if (!acc) {
+          return flags;
+        }
+        return {
+          isSigner: acc.isSigner || flags.isSigner,
+          isWritable: acc.isWritable || flags.isWritable,
+        };
+      },
+      undefined,
+    );
+  if (!maybeHighestPrivileges) {
+    return accountMeta;
+  }
+  const flags = flagsFromRole(accountMeta.role);
+  if (!maybeHighestPrivileges.isSigner && flags.isSigner) {
+    flags.isSigner = false;
+  }
+  if (!maybeHighestPrivileges.isWritable && flags.isWritable) {
+    flags.isWritable = false;
+  }
+  return {
+    address: accountMeta.address,
+    role: roleFromFlags(flags.isSigner, flags.isWritable),
+  };
+}
+
+export function getTransferHookProgramId(mint: Mint): Address | undefined {
+  if (mint.extensions.__option === "None") {
+    return undefined;
+  }
+  for (const extension of mint.extensions.value) {
+    if (extension.__kind === "TransferHook") {
+      if (extension.programId === DEFAULT_ADDRESS) {
+        return undefined;
+      }
+      return extension.programId;
+    }
+  }
+  return undefined;
+}
+
+export async function getExtraAccountMetaAddress(
+  mint: Address,
+  hookProgram: Address,
+): Promise<Address> {
+  const [pda] = await getProgramDerivedAddress({
+    programAddress: hookProgram,
+    seeds: [EXTRA_ACCOUNT_METAS_SEED, getAddressEncoder().encode(mint)],
+  });
+  return pda;
+}
+
+/**
+ * Resolve transfer-hook extra accounts for a Token-2022 mint.
+ * Matches SPL `addExtraAccountMetasForExecute` (amount 0, same as the legacy SDK).
+ */
+export async function getExtraAccountMetasForTransferHook(
+  rpc: Rpc<GetAccountInfoApi>,
+  mint: { address: Address; data: Mint },
+  source: Address,
+  destination: Address,
+  owner: Address,
+): Promise<RemainingAccount[] | undefined> {
+  const hookProgram = getTransferHookProgramId(mint.data);
+  if (!hookProgram) {
+    return undefined;
+  }
+
+  const extraAccountMetaAddress = await getExtraAccountMetaAddress(
+    mint.address,
+    hookProgram,
+  );
+  const extraAccountMetaList = await fetchEncodedAccount(
+    rpc,
+    extraAccountMetaAddress,
+  );
+  if (!extraAccountMetaList.exists) {
+    return undefined;
+  }
+
+  const executeKeys: RemainingAccount[] = [
+    { address: source, role: AccountRole.READONLY },
+    { address: mint.address, role: AccountRole.READONLY },
+    { address: destination, role: AccountRole.READONLY },
+    { address: owner, role: AccountRole.READONLY },
+    { address: extraAccountMetaAddress, role: AccountRole.READONLY },
+  ];
+
+  const executeData = new Uint8Array(16);
+  executeData.set(EXECUTE_DISCRIMINATOR, 0);
+
+  const extraMetas = unpackExtraAccountMetas(extraAccountMetaList.data);
+  for (const extraMeta of extraMetas) {
+    executeKeys.push(
+      deEscalateAccountMeta(
+        await resolveExtraAccountMeta(
+          rpc,
+          extraMeta,
+          executeKeys,
+          executeData,
+          hookProgram,
+        ),
+        executeKeys,
+      ),
+    );
+  }
+
+  return [
+    ...executeKeys.slice(5),
+    { address: hookProgram, role: AccountRole.READONLY },
+    { address: extraAccountMetaAddress, role: AccountRole.READONLY },
+  ];
+}
+
+function readU32LE(data: Uint8Array, offset: number): number {
+  return (
+    (data[offset]! |
+      (data[offset + 1]! << 8) |
+      (data[offset + 2]! << 16) |
+      (data[offset + 3]! << 24)) >>>
+    0
+  );
+}
+
+type PackedExtraAccountMeta = {
+  discriminator: number;
+  addressConfig: Uint8Array;
+  isSigner: boolean;
+  isWritable: boolean;
+};
+
+function unpackExtraAccountMetas(data: Uint8Array): PackedExtraAccountMeta[] {
+  // u64 discriminator, u32 length, u32 count, then ExtraAccountMeta entries
+  const count = readU32LE(data, 12);
+  const metas: PackedExtraAccountMeta[] = [];
+  let offset = 16;
+  for (let i = 0; i < count; i++) {
+    metas.push({
+      discriminator: data[offset]!,
+      addressConfig: data.slice(offset + 1, offset + 33),
+      isSigner: data[offset + 33] !== 0,
+      isWritable: data[offset + 34] !== 0,
+    });
+    offset += EXTRA_ACCOUNT_META_SPAN;
+  }
+  return metas;
+}
+
+async function resolveExtraAccountMeta(
+  rpc: Rpc<GetAccountInfoApi>,
+  extraMeta: PackedExtraAccountMeta,
+  previousMetas: RemainingAccount[],
+  instructionData: Uint8Array,
+  transferHookProgramId: Address,
+): Promise<RemainingAccount> {
+  if (extraMeta.discriminator === 0) {
+    return {
+      address: getAddressDecoder().decode(extraMeta.addressConfig),
+      role: roleFromFlags(extraMeta.isSigner, extraMeta.isWritable),
+    };
+  }
+
+  if (extraMeta.discriminator === 2) {
+    const pubkey = await unpackPubkeyData(
+      rpc,
+      extraMeta.addressConfig,
+      previousMetas,
+      instructionData,
+    );
+    return {
+      address: pubkey,
+      role: roleFromFlags(extraMeta.isSigner, extraMeta.isWritable),
+    };
+  }
+
+  let programId = transferHookProgramId;
+  if (extraMeta.discriminator !== 1) {
+    const accountIndex = extraMeta.discriminator - (1 << 7);
+    const previous = previousMetas[accountIndex];
+    if (!previous) {
+      throw new Error("Transfer hook extra account meta is missing");
+    }
+    programId = previous.address;
+  }
+
+  const seeds = await unpackSeeds(
+    rpc,
+    extraMeta.addressConfig,
+    previousMetas,
+    instructionData,
+  );
+  const [pda] = await getProgramDerivedAddress({
+    programAddress: programId,
+    seeds,
+  });
+  return {
+    address: pda,
+    role: roleFromFlags(extraMeta.isSigner, extraMeta.isWritable),
+  };
+}
+
+async function unpackPubkeyData(
+  rpc: Rpc<GetAccountInfoApi>,
+  keyDataConfig: Uint8Array,
+  previousMetas: RemainingAccount[],
+  instructionData: Uint8Array,
+): Promise<Address> {
+  const discriminator = keyDataConfig[0];
+  if (discriminator === 1) {
+    const dataIndex = keyDataConfig[1]!;
+    return getAddressDecoder().decode(
+      instructionData.subarray(dataIndex, dataIndex + 32),
+    );
+  }
+  if (discriminator === 2) {
+    const accountIndex = keyDataConfig[1]!;
+    const dataIndex = keyDataConfig[2]!;
+    const previous = previousMetas[accountIndex];
+    if (!previous) {
+      throw new Error("Transfer hook extra account meta is missing");
+    }
+    const account = await fetchEncodedAccount(rpc, previous.address);
+    if (!account.exists) {
+      throw new Error("Transfer hook extra account data not found");
+    }
+    return getAddressDecoder().decode(
+      account.data.subarray(dataIndex, dataIndex + 32),
+    );
+  }
+  throw new Error("Invalid transfer hook pubkey data");
+}
+
+async function unpackSeeds(
+  rpc: Rpc<GetAccountInfoApi>,
+  packed: Uint8Array,
+  previousMetas: RemainingAccount[],
+  instructionData: Uint8Array,
+): Promise<Uint8Array[]> {
+  const seeds: Uint8Array[] = [];
+  let i = 0;
+  while (i < packed.length) {
+    const unpacked = await unpackFirstSeed(
+      rpc,
+      packed.subarray(i),
+      previousMetas,
+      instructionData,
+    );
+    if (unpacked == null) {
+      break;
+    }
+    seeds.push(unpacked.data);
+    i += unpacked.packedLength;
+  }
+  return seeds;
+}
+
+async function unpackFirstSeed(
+  rpc: Rpc<GetAccountInfoApi>,
+  seeds: Uint8Array,
+  previousMetas: RemainingAccount[],
+  instructionData: Uint8Array,
+): Promise<{ data: Uint8Array; packedLength: number } | null> {
+  if (seeds.length === 0) {
+    return null;
+  }
+  const discriminator = seeds[0]!;
+  const remaining = seeds.subarray(1);
+  switch (discriminator) {
+    case 0:
+      return null;
+    case 1: {
+      const length = remaining[0]!;
+      return {
+        data: remaining.subarray(1, 1 + length),
+        packedLength: 2 + length,
+      };
+    }
+    case 2: {
+      const index = remaining[0]!;
+      const length = remaining[1]!;
+      return {
+        data: instructionData.subarray(index, index + length),
+        packedLength: 3,
+      };
+    }
+    case 3: {
+      const index = remaining[0]!;
+      const previous = previousMetas[index];
+      if (!previous) {
+        throw new Error("Transfer hook extra account meta is missing");
+      }
+      return {
+        data: new Uint8Array(getAddressEncoder().encode(previous.address)),
+        packedLength: 2,
+      };
+    }
+    case 4: {
+      const accountIndex = remaining[0]!;
+      const dataIndex = remaining[1]!;
+      const length = remaining[2]!;
+      const previous = previousMetas[accountIndex];
+      if (!previous) {
+        throw new Error("Transfer hook extra account meta is missing");
+      }
+      const account = await fetchEncodedAccount(rpc, previous.address);
+      if (!account.exists) {
+        throw new Error("Transfer hook extra account data not found");
+      }
+      return {
+        data: account.data.subarray(dataIndex, dataIndex + length),
+        packedLength: 4,
+      };
+    }
+    default:
+      throw new Error("Invalid transfer hook seed");
+  }
+}

--- a/ts-sdk/whirlpool/tests/remainingAccounts.test.ts
+++ b/ts-sdk/whirlpool/tests/remainingAccounts.test.ts
@@ -1,0 +1,42 @@
+import { describe, it } from "vitest";
+import assert from "assert";
+import { AccountsType } from "@orca-so/whirlpools-client";
+import { AccountRole, address } from "@solana/kit";
+import { buildRemainingAccounts } from "../src/remainingAccounts";
+
+describe("buildRemainingAccounts", () => {
+  it("omits empty slices and returns null info when nothing is attached", () => {
+    const result = buildRemainingAccounts([
+      { accountsType: AccountsType.TransferHookA, accounts: undefined },
+      { accountsType: AccountsType.TransferHookB, accounts: [] },
+    ]);
+    assert.strictEqual(result.remainingAccountsInfo, null);
+    assert.strictEqual(result.extraAccounts.length, 0);
+  });
+
+  it("preserves slice order TransferHook then SupplementalTickArrays", () => {
+    const tickA = address("So11111111111111111111111111111111111111112");
+    const tickB = address("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+    const hook = address("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
+    const result = buildRemainingAccounts([
+      {
+        accountsType: AccountsType.TransferHookA,
+        accounts: [{ address: hook, role: AccountRole.READONLY }],
+      },
+      { accountsType: AccountsType.TransferHookB },
+      {
+        accountsType: AccountsType.SupplementalTickArrays,
+        accounts: [
+          { address: tickA, role: AccountRole.WRITABLE },
+          { address: tickB, role: AccountRole.WRITABLE },
+        ],
+      },
+    ]);
+    assert.deepStrictEqual(
+      result.remainingAccountsInfo?.slices.map((s) => s.accountsType),
+      [AccountsType.TransferHookA, AccountsType.SupplementalTickArrays],
+    );
+    assert.strictEqual(result.extraAccounts.length, 3);
+    assert.strictEqual(result.extraAccounts[0]?.address, hook);
+  });
+});

--- a/ts-sdk/whirlpool/tests/transferHook.test.ts
+++ b/ts-sdk/whirlpool/tests/transferHook.test.ts
@@ -1,0 +1,55 @@
+import { fetchMint } from "@solana-program/token-2022";
+import assert from "assert";
+import { describe, it } from "vitest";
+import {
+  getExtraAccountMetaAddress,
+  getExtraAccountMetasForTransferHook,
+} from "../src/transferHook";
+import { getTestContext, rpc, setRawAccount } from "./utils/mockRpc";
+import {
+  setupMintTETransferHook,
+  TEST_TRANSFER_HOOK_PROGRAM_ADDRESS,
+} from "./utils/tokenExtensions";
+
+await getTestContext();
+
+describe("getExtraAccountMetasForTransferHook", () => {
+  it("returns undefined when ExtraAccountMetaList is missing", async () => {
+    const mint = await setupMintTETransferHook();
+    const mintAccount = await fetchMint(rpc, mint);
+    const extra = await getExtraAccountMetasForTransferHook(
+      rpc,
+      mintAccount,
+      mint,
+      mint,
+      mint,
+    );
+    assert.strictEqual(extra, undefined);
+  });
+
+  it("returns the hook program and ExtraAccountMetaList when the list exists", async () => {
+    const mint = await setupMintTETransferHook();
+    const extraAccountMetaAddress = await getExtraAccountMetaAddress(
+      mint,
+      TEST_TRANSFER_HOOK_PROGRAM_ADDRESS,
+    );
+    await setRawAccount(extraAccountMetaAddress, {
+      lamports: 1_000_000,
+      data: new Uint8Array(16),
+      owner: TEST_TRANSFER_HOOK_PROGRAM_ADDRESS,
+    });
+
+    const mintAccount = await fetchMint(rpc, mint);
+    const extra = await getExtraAccountMetasForTransferHook(
+      rpc,
+      mintAccount,
+      mint,
+      mint,
+      mint,
+    );
+    assert.ok(extra);
+    assert.strictEqual(extra.length, 2);
+    assert.strictEqual(extra[0]?.address, TEST_TRANSFER_HOOK_PROGRAM_ADDRESS);
+    assert.strictEqual(extra[1]?.address, extraAccountMetaAddress);
+  });
+});

--- a/ts-sdk/whirlpool/tests/utils/mockRpc.ts
+++ b/ts-sdk/whirlpool/tests/utils/mockRpc.ts
@@ -168,6 +168,21 @@ export async function getTestContext(): Promise<LiteSVM> {
   return _testContext;
 }
 
+export async function setRawAccount(
+  accountAddress: Address,
+  account: { lamports: number; data: Uint8Array; owner: Address },
+) {
+  const testContext = await getTestContext();
+  testContext.setAccount(toPublicKey(accountAddress), {
+    lamports: account.lamports,
+    data: account.data,
+    owner: toPublicKey(account.owner),
+    executable: false,
+    rentEpoch: 0,
+  });
+  accountsCache.delete(accountAddress);
+}
+
 export async function deleteAccount(address: Address) {
   const testContext = await getTestContext();
   testContext.setAccount(toPublicKey(address), {

--- a/ts-sdk/whirlpool/tests/utils/tokenExtensions.ts
+++ b/ts-sdk/whirlpool/tests/utils/tokenExtensions.ts
@@ -9,8 +9,10 @@ import {
   getInitializeTransferFeeConfigInstruction,
   getSetTransferFeeInstruction,
   getInitializeScaledUiAmountMintInstruction,
+  getInitializeTransferHookInstruction,
 } from "@solana-program/token-2022";
 import type { Address, Instruction } from "@solana/kit";
+import { address } from "@solana/kit";
 import { sendTransaction, signer } from "./mockRpc";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import { DEFAULT_ADDRESS } from "../../src/config";
@@ -93,6 +95,15 @@ export async function setupMintTE(
           }),
         );
         break;
+      case "TransferHook":
+        instructions.push(
+          getInitializeTransferHookInstruction({
+            mint: keypair.address,
+            authority: signer.address,
+            programId: extension.programId,
+          }),
+        );
+        break;
     }
   }
 
@@ -146,6 +157,26 @@ export async function setupMintTEFee(
           maximumFee: 1e9,
           transferFeeBasisPoints: 150,
         },
+      },
+    ],
+  });
+}
+
+/** Transfer-hook counter program used in legacy SDK LiteSVM tests. */
+export const TEST_TRANSFER_HOOK_PROGRAM_ADDRESS = address(
+  "EBZDYx7599krFc4m2govwBdZcicr4GgepqC78m71nsHS",
+);
+
+export async function setupMintTETransferHook(
+  config: { decimals?: number; hookProgramId?: Address } = {},
+): Promise<Address> {
+  return setupMintTE({
+    ...config,
+    extensions: [
+      {
+        __kind: "TransferHook",
+        authority: signer.address,
+        programId: config.hookProgramId ?? TEST_TRANSFER_HOOK_PROGRAM_ADDRESS,
       },
     ],
   });


### PR DESCRIPTION
## Summary
- High-level `@orca-so/whirlpools` V2 builders now attach `TransferHookA` / `TransferHookB` / `TransferHookReward` remaining accounts (legacy SDK already did this).
- Empty slices are omitted; mints without TransferHook are unchanged.
- Fixes `NoExtraAccountsForTransferHook` (`0x17a2`) for Token-2022 TransferHook mints.

Fixes #1372

## Test plan
- [ ] `npx vitest run tests/remainingAccounts.test.ts tests/transferHook.test.ts tests/swap.test.ts` from `ts-sdk/whirlpool`
- [ ] Existing Token-2022 swaps (no TransferHook) still only attach `SupplementalTickArrays`
- [ ] Swap / increase / decrease / harvest against a TransferHook mint with ExtraAccountMetaList present no longer fail with `0x17a2`


